### PR TITLE
[WIP][Feature] Optional vLLM router for internal rollout gateway

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ qwen_vl_utils # for VLM
 ray[default]
 ring_flash_attn
 sglang-router>=0.2.3
+vllm-router>=0.1.14
 tensorboard
 transformers
 wandb

--- a/slime/backends/sglang_utils/sglang_engine.py
+++ b/slime/backends/sglang_utils/sglang_engine.py
@@ -7,14 +7,13 @@ import time
 from urllib.parse import quote
 
 import requests
-import sglang_router
-from packaging.version import parse
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import kill_process_tree
 from urllib3.exceptions import NewConnectionError
 
 from slime.ray.ray_actor import RayActor
 from slime.utils.http_utils import get_host_info
+from slime.utils.router import router_http_api_tier
 
 logger = logging.getLogger(__name__)
 
@@ -198,7 +197,8 @@ class SGLangEngine(RayActor):
             return
 
         if self.node_rank == 0 and self.router_ip and self.router_port:
-            if parse(sglang_router.__version__) <= parse("0.2.1"):
+            tier = router_http_api_tier(self.args)
+            if tier == "legacy":
                 assert self.worker_type == "regular", "pd disaggregation is not supported in old router."
                 response = requests.post(
                     f"http://{self.router_ip}:{self.router_port}/add_worker?url=http://{self.server_host}:{self.server_port}",
@@ -317,11 +317,12 @@ class SGLangEngine(RayActor):
         if self.worker_type != "encoder" and self.node_rank == 0:
             worker_url = f"http://{self.server_host}:{self.server_port}"
             response = None
-            if parse(sglang_router.__version__) <= parse("0.2.1"):
+            tier = router_http_api_tier(self.args)
+            if tier == "legacy":
                 response = requests.post(
                     f"http://{self.router_ip}:{self.router_port}/remove_worker?url=http://{self.server_host}:{self.server_port}"
                 )
-            elif parse(sglang_router.__version__) < parse("0.3.0"):
+            elif tier == "mid":
                 worker_url = quote(worker_url, safe="")
                 response = requests.delete(f"http://{self.router_ip}:{self.router_port}/workers/{worker_url}")
             else:

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -909,11 +909,13 @@ def _allocate_rollout_engine_addr_and_ports_normal(
 
 
 def _start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool = False) -> tuple[str, int]:
-    """Start sglang_router and return (router_ip, router_port).
+    """Start the HTTP router gateway (sglang-router or vllm-router) and return ``(router_ip, router_port)``.
 
     If ``args.sglang_router_ip`` is already set (e.g. by the user) and
     ``force_new`` is False, skip launching and return the existing values.
     When ``force_new`` is True (multi-model), always allocate a fresh port.
+
+    The implementation is selected by ``--router-impl`` (default: ``sglang``).
     """
     if not force_new and args.sglang_router_ip is not None:
         return args.sglang_router_ip, args.sglang_router_port
@@ -926,15 +928,15 @@ def _start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool 
         if router_port is None:
             router_port = find_available_port(random.randint(3000, 4000))
 
-    from sglang_router.launch_router import RouterArgs
-
     from slime.utils.http_utils import run_router
+    from slime.utils.router import router_args_from_cli
 
-    router_args = RouterArgs.from_cli_args(args, use_router_prefix=True)
+    impl = getattr(args, "router_impl", "sglang")
+    router_args = router_args_from_cli(impl, args)
     router_args.host = router_ip
     router_args.port = router_port
     router_args.prometheus_port = find_available_port(random.randint(4000, 5000))
-    router_args.log_level = "warn"
+    router_args.log_level = "warning" if impl == "vllm" else "warn"  # vllm log choices omit "warn"
     router_args.request_timeout_secs = args.sglang_router_request_timeout_secs
 
     if has_pd_disaggregation:
@@ -944,14 +946,14 @@ def _start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool 
         # contention under high load) and do not indicate a dead server.
         router_args.disable_circuit_breaker = True
 
-    # We will not use the health check from router.
-    router_args.disable_health_check = True
+    if any(f.name == "disable_health_check" for f in dataclasses.fields(type(router_args))):
+        router_args.disable_health_check = True  # vllm-router may omit this field
 
-    logger.info(f"Launch router with args: {router_args}")
+    logger.info(f"Launch HTTP router (impl={impl}) with args: {router_args}")
 
     process = multiprocessing.Process(
         target=run_router,
-        args=(router_args,),
+        args=((impl, router_args),),
     )
     process.daemon = True  # Set the process as a daemon
     process.start()

--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -10,8 +10,6 @@ from typing import Any
 
 import numpy as np
 import pybase64
-import sglang_router
-from packaging.version import parse
 from tqdm import tqdm
 
 from slime.rollout.base_types import RolloutFnEvalOutput, RolloutFnTrainOutput
@@ -20,6 +18,7 @@ from slime.utils.async_utils import run
 from slime.utils.data import Dataset
 from slime.utils.eval_config import EvalDatasetConfig
 from slime.utils.http_utils import get, post
+from slime.utils.router import router_http_api_tier
 from slime.utils.misc import SingletonMeta, load_function
 from slime.utils.processing_utils import (
     build_processor_kwargs,
@@ -349,7 +348,8 @@ async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
     assert not state.aborted
     state.aborted = True
 
-    if parse(sglang_router.__version__) <= parse("0.2.1"):
+    tier = router_http_api_tier(args)
+    if tier == "legacy":
         response = await get(f"http://{args.sglang_router_ip}:{args.sglang_router_port}/list_workers")
         urls = response["urls"]
     else:

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -6,11 +6,11 @@ import os
 from typing import Any
 
 import yaml
-from sglang_router.launch_router import RouterArgs
 
 from slime.backends.sglang_utils.arguments import sglang_parse_args
 from slime.backends.sglang_utils.arguments import validate_args as sglang_validate_args
 from slime.utils.eval_config import EvalDatasetConfig, build_eval_dataset_configs, ensure_dataset_list
+from slime.utils.router import assert_router_backend_available
 from slime.utils.logging_utils import configure_logger
 
 logger = logging.getLogger(__name__)
@@ -1020,7 +1020,23 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 default=False,
                 help="Whether to use SlimeRouter for text-based routing instead of SGLang token-based routing",
             )
-            RouterArgs.add_cli_args(parser, use_router_prefix=True, exclude_host_port=True)
+            parser.add_argument(
+                "--router-impl",
+                type=str,
+                choices=["sglang", "vllm"],
+                default="sglang",
+                dest="router_impl",
+                help=(
+                    "Which HTTP gateway to spawn when slime starts an internal router: "
+                    "sglang-router (sgl-model-gateway) or vllm-router "
+                    "(https://github.com/sgl-project/sglang/tree/main/sgl-model-gateway vs "
+                    "https://github.com/vllm-project/router ). "
+                    "External routers via --sglang-router-ip/--sglang-router-port are unchanged."
+                ),
+            )
+            from slime.utils.router import register_router_cli_args
+
+            register_router_cli_args(parser)
             return parser
 
         # wandb
@@ -1597,6 +1613,8 @@ def slime_validate_args(args):
             "built from https://github.com/zhuzilin/sgl-router."
         )
         args.use_slime_router = False
+
+    assert_router_backend_available(getattr(args, "router_impl", "sglang"))
 
     if args.kl_coef != 0 or args.use_kl_loss:
         if not os.path.exists(args.ref_load):

--- a/slime/utils/http_utils.py
+++ b/slime/utils/http_utils.py
@@ -114,11 +114,24 @@ def _wrap_ipv6(host):
         return host
 
 
-def run_router(args):
-    try:
-        from sglang_router.launch_router import launch_router
+def run_router(payload):
+    """Start the HTTP router gateway in a child process.
 
-        router = launch_router(args)
+    ``payload`` is either ``(impl, router_args)`` with ``impl`` in ``{"sglang","vllm"}``,
+    or a legacy single ``router_args`` object (treated as ``sglang``).
+    """
+    try:
+        if isinstance(payload, tuple) and len(payload) == 2:
+            impl, router_args = payload
+        else:
+            impl, router_args = "sglang", payload
+
+        if impl == "vllm":
+            from vllm_router.launch_router import launch_router
+        else:
+            from sglang_router.launch_router import launch_router
+
+        router = launch_router(router_args)
         if router is None:
             return 1
         return 0

--- a/slime/utils/router.py
+++ b/slime/utils/router.py
@@ -1,0 +1,115 @@
+"""Rollout HTTP gateway helpers (sglang-router vs vllm-router): CLI registration, RouterArgs, control-plane tier."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import logging
+from typing import Any, Literal
+
+from packaging.version import parse
+
+logger = logging.getLogger(__name__)
+
+RouterBackend = Literal["sglang", "vllm"]
+
+
+def register_router_cli_args(parser: argparse.ArgumentParser) -> None:
+    """Register gateway CLI: first importable of ``sglang_router`` / ``vllm_router`` wins.
+
+    ``--worker-urls`` stays unprefixed; other flags use ``--router-*`` when ``use_router_prefix=True``.
+    """
+    last_err: Exception | None = None
+    for name, loader in (
+        ("sglang_router", _load_sglang_router_args_cls),
+        ("vllm_router", _load_vllm_router_args_cls),
+    ):
+        try:
+            router_args_cls = loader()
+        except ImportError as e:
+            last_err = e
+            logger.debug("Router CLI registration: %s not available (%s)", name, e)
+            continue
+        router_args_cls.add_cli_args(parser, use_router_prefix=True, exclude_host_port=True)
+        logger.debug("Router CLI registration: using %s", name)
+        return
+    raise ImportError(
+        "Neither sglang-router nor vllm-router is installed; "
+        "install one of them to use rollout router flags."
+    ) from last_err
+
+
+def _load_sglang_router_args_cls():
+    from sglang_router.launch_router import RouterArgs
+
+    return RouterArgs
+
+
+def _load_vllm_router_args_cls():
+    from vllm_router.router_args import RouterArgs
+
+    return RouterArgs
+
+
+def _sanitize_vllm_router_args(ra: Any) -> Any:
+    """Reset negative ints that are valid in sglang CLI but invalid for vllm-router Rust (e.g. u32).
+
+    Slime registers sglang's ``RouterArgs`` first when both wheels are installed; sglang defaults
+    ``max_concurrent_requests`` to ``-1`` (unlimited), which must not be forwarded to vllm.
+    """
+    from vllm_router.router_args import RouterArgs as VR
+
+    fixes: dict[str, Any] = {}
+    for f in dataclasses.fields(VR):
+        val = getattr(ra, f.name, None)
+        if not isinstance(val, int) or val >= 0:
+            continue
+        if f.default is not dataclasses.MISSING:
+            fixes[f.name] = f.default
+        elif f.default_factory is not dataclasses.MISSING:  # type: ignore[attr-defined]
+            fixes[f.name] = f.default_factory()  # type: ignore[misc]
+        else:
+            logger.warning(
+                "vllm-router: field %r is negative (%s) but has no dataclass default; leaving as-is",
+                f.name,
+                val,
+            )
+    return dataclasses.replace(ra, **fixes) if fixes else ra
+
+
+def router_args_from_cli(impl: RouterBackend, args: argparse.Namespace) -> Any:
+    """Build a RouterArgs dataclass from the global argparse namespace."""
+    if impl == "vllm":
+        from vllm_router.router_args import RouterArgs
+
+        ra = RouterArgs.from_cli_args(args, use_router_prefix=True)
+        return _sanitize_vllm_router_args(ra)
+    from sglang_router.launch_router import RouterArgs
+
+    return RouterArgs.from_cli_args(args, use_router_prefix=True)
+
+
+def assert_router_backend_available(impl: RouterBackend) -> None:
+    """Raise ``ImportError`` if the chosen gateway package is not installed."""
+    if impl == "vllm":
+        import vllm_router  # noqa: F401
+        from vllm_router.launch_router import launch_router  # noqa: F401
+
+        return
+    import sglang_router  # noqa: F401
+    from sglang_router.launch_router import launch_router  # noqa: F401
+
+
+def router_http_api_tier(args: argparse.Namespace) -> Literal["legacy", "mid", "modern"]:
+    """Control-plane style for worker register/list/abort: vllm is always ``/workers`` (modern)."""
+    impl = getattr(args, "router_impl", "sglang")
+    if impl == "vllm":
+        return "modern"
+    import sglang_router
+
+    ver = parse(sglang_router.__version__)
+    if ver <= parse("0.2.1"):
+        return "legacy"
+    if ver < parse("0.3.0"):
+        return "mid"
+    return "modern"


### PR DESCRIPTION
## Purpose
Add support for spawning **[vllm-router](https://github.com/vllm-project/router)** as the HTTP rollout gateway in addition to the existing **sglang-router** (sgl-model-gateway) path.
- New flag **`--router-impl {sglang,vllm}`** (`args.router_impl`): choose which gateway binary Slime starts when no external router is configured (`--sglang-router-ip` unset).
- New module **`slime.utils.router`**: register shared `--router-*` / `--worker-urls` CLI, build `RouterArgs`, assert the selected package is installed, map **worker control-plane** to the modern **`/workers`** API when `router_impl=vllm`, and **sanitize** `RouterArgs` for vLLM when both wheels are installed (e.g. sglang’s `max_concurrent_requests=-1` is invalid for vLLM’s unsigned Rust fields).
- **`slime/utils/http_utils.py`**: `run_router` dispatches to `vllm_router.launch_router` or `sglang_router.launch_router` based on `impl`.
- **`requirements.txt`**: add `vllm-router>=0.1.14` alongside `sglang-router`.
Default behavior remains **sglang**; external routers are unchanged.

## Test Plan
- Install deps: `pip install -r requirements.txt`
- Train / rollout with **`--router-impl vllm`** (internal router) and confirm log line: `Launch HTTP router (impl=vllm) ...`
- Smoke with **`--router-impl sglang`** (or omit flag) to confirm no regression

running:
```
export PYTHONPATH=/root/Megatron-LM
SCRIPT_DIR="/data/nfs/kaiyuan/RL/vime/scripts"
source "${SCRIPT_DIR}/models/qwen3-0.6B.sh"

python train.py \
  ${MODEL_ARGS[@]} \
  \
  --hf-checkpoint /data/nfs/kaiyuan/models/Qwen3-0.6B \
  --ref-load /data/nfs/kaiyuan/models/Qwen3-0.6B_torch_dist \
  --load /work/Qwen3-0.6B_slime_ckpt \
  --save /work/Qwen3-0.6B_slime_ckpt \
  --save-interval 10 \
  --train-memory-margin-bytes 2147483648 \
  \
  --prompt-data /data/nfs/kaiyuan/datasets/dapo-math-17k/dapo-math-17k.jsonl \
  --input-key prompt \
  --label-key label \
  --apply-chat-template \
  --rollout-shuffle \
  \
  --rm-type deepscaler \
  --num-rollout 100 \
  --rollout-batch-size 4 \
  --n-samples-per-prompt 2 \
  --num-steps-per-rollout 1 \
  --global-batch-size 8 \
  \
  --actor-num-nodes 1 \
  --actor-num-gpus-per-node 8 \
  --rollout-num-gpus 8 \
  --rollout-num-gpus-per-engine 2 \
  --rollout-max-response-len 1024 \
  --sglang-mem-fraction-static 0.8 \
  \
  --attention-dropout 0.0 \
  --hidden-dropout 0.0 \
  --accumulate-allreduce-grads-in-fp32 \
  --attention-softmax-in-fp32 \
  --attention-backend flash \
  --optimizer adam \
  --lr 1e-6 \
  --lr-decay-style constant \
  --weight-decay 0.1 \
  --adam-beta1 0.9 \
  --adam-beta2 0.98 \
  --router-impl vllm \
  \
  --colocate
```

## Test Result

<img width="2246" height="263" alt="image" src="https://github.com/user-attachments/assets/1d081cbe-ab27-4cb7-868c-4409eee045ff" />
