### PR TITLE
[WIP][Feature]add vLLM-compatible rollout

### DIFF
--- a/slime/rollout/vllm_rollout.py
+++ b/slime/rollout/vllm_rollout.py
@@ -1,0 +1,856 @@
+import asyncio
+import copy
+import inspect
+import logging
+import uuid
+from argparse import Namespace
+from collections.abc import Callable
+from contextlib import contextmanager
+from typing import Any
+
+import numpy as np
+import vllm_router  # noqa: F401 — same side-effect as ``import sglang_router`` in sglang rollout
+from tqdm import tqdm
+
+from slime.rollout.base_types import RolloutFnEvalOutput, RolloutFnTrainOutput
+from slime.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
+from slime.utils.async_utils import run
+from slime.utils.data import Dataset
+from slime.utils.eval_config import EvalDatasetConfig
+from slime.utils.http_utils import get, post
+from slime.utils.misc import SingletonMeta, load_function
+from slime.utils.processing_utils import (
+    build_processor_kwargs,
+    encode_image_for_rollout_engine,
+    load_processor,
+    load_tokenizer,
+)
+from slime.utils.trace_utils import trace_function, trace_span
+from slime.utils.types import Sample
+
+from .rm_hub import async_rm, batched_async_rm
+
+__all__ = ["generate_rollout", "get_model_url"]
+
+logger = logging.getLogger(__name__)
+
+_PROCESSOR_PROMPT_KEYS = {"input_ids", "attention_mask"}
+
+
+def _prepare_prompt_ids(sample: Sample, tokenizer, processor: Any) -> list[int]:
+    raw_multimodal_inputs = sample.multimodal_inputs or {}
+    has_multimodal_inputs = any(value is not None for value in raw_multimodal_inputs.values())
+    reuse_existing_input_ids = bool(sample.tokens) and (
+        sample.multimodal_train_inputs is not None or not has_multimodal_inputs
+    )
+
+    if processor and has_multimodal_inputs and not reuse_existing_input_ids:
+        processor_output = processor(text=sample.prompt, **build_processor_kwargs(raw_multimodal_inputs))
+        prompt_ids = processor_output["input_ids"][0]
+        if sample.multimodal_train_inputs is None:
+            sample.multimodal_train_inputs = {
+                k: v for k, v in processor_output.items() if k not in _PROCESSOR_PROMPT_KEYS
+            } or None
+        return prompt_ids
+
+    if reuse_existing_input_ids:
+        return sample.tokens
+
+    return tokenizer.encode(sample.prompt, add_special_tokens=False)
+
+
+def get_model_url(args: Namespace, model_name: str, endpoint: str = "/v1/completions") -> str:
+    """Return the router URL for a named model.
+
+    Use this in custom rollout functions to route requests to a specific
+    model when multiple models are deployed via ``--sglang-config``::
+
+        url = get_model_url(args, "ref", "/v1/completions")
+        resp = await post(url, json=payload)
+
+    Falls back to the default router if *model_name* is not found or
+    ``sglang_model_routers`` is not set.
+    """
+    routers = getattr(args, "sglang_model_routers", None)
+    if routers and model_name in routers:
+        ip, port = routers[model_name]
+        return f"http://{ip}:{port}{endpoint}"
+    return f"http://{args.sglang_router_ip}:{args.sglang_router_port}{endpoint}"
+
+
+async def _router_worker_urls(args: Namespace) -> list[str]:
+    """Resolve worker base URLs from the vLLM router (same HTTP shape as SGLang router)."""
+    base = f"http://{args.sglang_router_ip}:{args.sglang_router_port}"
+    try:
+        response = await get(f"{base}/workers")
+        return [worker["url"] for worker in response["workers"]]
+    except Exception:
+        response = await get(f"{base}/list_workers")
+        return list(response["urls"])
+
+
+def _openai_meta_from_completion_choice(args: Namespace, choice: dict, usage: dict | None) -> dict[str, Any]:
+    """Build a minimal ``meta_info``-like dict for :meth:`Sample.update_from_meta_info`."""
+    fr = choice.get("finish_reason") or "stop"
+    if isinstance(fr, dict):
+        finish = fr
+    else:
+        if fr == "length":
+            typ = "length"
+        elif fr in ("abort", "cancelled"):
+            typ = "abort"
+        else:
+            typ = "stop"
+        finish = {"type": typ}
+    meta: dict[str, Any] = {"finish_reason": finish}
+    if usage:
+        meta["prompt_tokens"] = usage.get("prompt_tokens", 0)
+        meta["completion_tokens"] = usage.get("completion_tokens", 0)
+    return meta
+
+
+def _apply_vllm_routed_experts(args: Namespace, sample: Sample, output: dict, choice: dict) -> None:
+    """Populate ``sample.rollout_routed_experts`` from vLLM routing-replay JSON (see vLLM docs)."""
+    if not getattr(args, "use_rollout_routing_replay", False):
+        return
+    gen_re = choice.get("routed_experts")
+    prompt_re = output.get("prompt_routed_experts")
+    if gen_re is None and prompt_re is None:
+        return
+    parts: list[np.ndarray] = []
+    if prompt_re is not None:
+        parts.append(np.asarray(prompt_re, dtype=np.int32))
+    if gen_re is not None:
+        parts.append(np.asarray(gen_re, dtype=np.int32))
+    if not parts:
+        return
+    arr = np.concatenate(parts, axis=0) if len(parts) > 1 else parts[0]
+    n_tok = len(sample.tokens)
+    expected_rows = max(0, n_tok - 1)
+    if arr.ndim != 3:
+        logger.warning(f"Unexpected routed_experts ndim={arr.ndim} shape={arr.shape}")
+        return
+    if arr.shape[0] == n_tok:
+        arr = arr[:-1]
+    elif arr.shape[0] != expected_rows:
+        logger.warning(
+            f"routed_experts row count {arr.shape[0]} not in {{{expected_rows}, {n_tok}}}; "
+            "skipping rollout_routed_experts assign",
+        )
+        return
+    nl = getattr(args, "num_layers", None)
+    mtk = getattr(args, "moe_router_topk", None)
+    if nl is not None and mtk is not None and (arr.shape[1] != nl or arr.shape[2] != mtk):
+        logger.warning(
+            f"routed_experts shape {arr.shape} does not match args (num_layers={nl}, moe_router_topk={mtk})",
+        )
+        return
+    sample.rollout_routed_experts = arr
+
+
+def _fallback_tokens_from_text_and_completion_logprobs(
+    tokenizer, choice: dict, completion_text: str
+) -> tuple[list[int], list[float]]:
+    """Fallback when vLLM did not return ``token_ids``: approximate from string logprobs or re-tokenize."""
+    lp = choice.get("logprobs")
+    if not lp or not isinstance(lp, dict):
+        toks = tokenizer.encode(completion_text, add_special_tokens=False)
+        return toks, [0.0] * len(toks)
+
+    token_logprobs = lp.get("token_logprobs")
+    tokens_field = lp.get("tokens")
+    if token_logprobs and tokens_field and len(token_logprobs) == len(tokens_field):
+        new_toks: list[int] = []
+        new_lps: list[float] = []
+        for piece, logp in zip(tokens_field, token_logprobs, strict=False):
+            if logp is None:
+                continue
+            ids = tokenizer.encode(piece, add_special_tokens=False)
+            if not ids:
+                continue
+            per = float(logp) / max(len(ids), 1)
+            new_toks.extend(ids)
+            new_lps.extend([per] * len(ids))
+        if new_toks:
+            return new_toks, new_lps
+
+    toks = tokenizer.encode(completion_text, add_special_tokens=False)
+    return toks, [0.0] * len(toks)
+
+
+def _vllm_engine_tokens_and_logprobs(
+    tokenizer,
+    choice: dict[str, Any],
+    completion_text: str,
+    *,
+    is_chat: bool,
+) -> tuple[list[int], list[float]]:
+    """Parse engine ``token_ids`` and per-token logprobs from an OpenAI choice (requires ``return_token_ids``)."""
+    tids_raw = choice.get("token_ids")
+    if isinstance(tids_raw, list) and tids_raw and all(isinstance(x, int) for x in tids_raw):
+        tids = [int(x) for x in tids_raw]
+        lps: list[float] = []
+        lp = choice.get("logprobs")
+        if not isinstance(lp, dict):
+            return tids, [0.0] * len(tids)
+
+        if is_chat:
+            content = lp.get("content")
+            if isinstance(content, list) and len(content) == len(tids):
+                for item in content:
+                    if isinstance(item, dict):
+                        lps.append(float(item.get("logprob", 0.0)))
+                    else:
+                        lps.append(0.0)
+                return tids, lps
+            if isinstance(content, list) and content:
+                # Partial content: pad / truncate to token_ids length if possible
+                for i in range(len(tids)):
+                    if i < len(content) and isinstance(content[i], dict):
+                        lps.append(float(content[i].get("logprob", 0.0)))
+                    else:
+                        lps.append(0.0)
+                return tids, lps
+            return tids, [0.0] * len(tids)
+
+        token_logprobs = lp.get("token_logprobs")
+        if isinstance(token_logprobs, list) and len(token_logprobs) == len(tids):
+            for p in token_logprobs:
+                lps.append(0.0 if p is None else float(p))
+            return tids, lps
+
+        return tids, [0.0] * len(tids)
+
+    if is_chat:
+        lp = choice.get("logprobs")
+        content = lp.get("content") if isinstance(lp, dict) else None
+        if isinstance(content, list) and content:
+            tids_ch: list[int] = []
+            lps_ch: list[float] = []
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+                tok = item.get("token")
+                if not isinstance(tok, str):
+                    continue
+                ids = tokenizer.encode(tok, add_special_tokens=False)
+                if not ids:
+                    continue
+                lv = float(item.get("logprob", 0.0))
+                per = lv / max(len(ids), 1)
+                tids_ch.extend(ids)
+                lps_ch.extend([per] * len(ids))
+            if tids_ch:
+                return tids_ch, lps_ch
+
+    return _fallback_tokens_from_text_and_completion_logprobs(tokenizer, choice, completion_text)
+
+
+def _align_engine_tokens_and_logprobs(
+    new_response_tokens: list[int], new_response_log_probs: list[float]
+) -> tuple[list[int], list[float]]:
+    """Pad or truncate logprobs so ``len(.) == len(new_response_tokens)`` (SGLang always has matched OTL pairs)."""
+    n = len(new_response_tokens)
+    if n == 0:
+        return [], []
+    m = len(new_response_log_probs)
+    if m == n:
+        return new_response_tokens, [float(x) for x in new_response_log_probs]
+    if m > n:
+        return new_response_tokens, [float(x) for x in new_response_log_probs[:n]]
+    return new_response_tokens, [float(x) for x in new_response_log_probs] + [0.0] * (n - m)
+
+
+class GenerateState(metaclass=SingletonMeta):
+    """
+    The global state for the generation process.
+    """
+
+    def __init__(self, args: Namespace) -> None:
+        # persistent state for the generation process
+        self.args = args
+        self.tokenizer = load_tokenizer(args.hf_checkpoint, trust_remote_code=True)
+        self.processor = load_processor(args.hf_checkpoint, trust_remote_code=True)
+
+        self.semaphore = asyncio.Semaphore(
+            args.sglang_server_concurrency * args.rollout_num_gpus // args.rollout_num_gpus_per_engine
+        )
+        self.sampling_params: dict[str, Any] = dict(
+            temperature=args.rollout_temperature,
+            top_p=args.rollout_top_p,
+            top_k=args.rollout_top_k,
+            max_new_tokens=args.rollout_max_response_len,
+            stop=args.rollout_stop,
+            stop_token_ids=args.rollout_stop_token_ids,
+            skip_special_tokens=args.rollout_skip_special_tokens,
+            no_stop_trim=True,
+            spaces_between_special_tokens=False,
+        )
+
+        if getattr(args, "sglang_enable_deterministic_inference", False):
+            sampling_seed_base = args.rollout_seed
+            self.group_sampling_seeds = [sampling_seed_base + i for i in range(args.n_samples_per_prompt)]
+
+        # dp rank balancing
+        self.dp_counts = [0] * (args.sglang_dp_size or 1)
+        self.dp_rank = 0
+
+        self.reset()
+
+    @contextmanager
+    def dp_rank_context(self):
+        candidates = [i for i, count in enumerate(self.dp_counts) if count == min(self.dp_counts)]
+        dp_rank = int(np.random.choice(candidates))
+        self.dp_counts[dp_rank] += 1
+        self.dp_rank = dp_rank
+        try:
+            yield dp_rank
+        finally:
+            self.dp_counts[dp_rank] -= 1
+            assert self.dp_counts[dp_rank] >= 0
+
+    def reset(self) -> None:
+        self.remaining_batch_size = 0
+        self.pendings = set()
+        self.aborted = False
+
+    def submit_generate_tasks(self, samples: list[list[Sample]]) -> None:
+        for group in samples:
+            self.pendings.add(
+                asyncio.create_task(
+                    # submit a group of samples as a single task.
+                    generate_and_rm_group(
+                        self.args,
+                        group,
+                        sampling_params=self.sampling_params.copy(),
+                        evaluation=False,
+                    )
+                )
+            )
+        self.remaining_batch_size += len(samples)
+
+
+def _build_completion_payload(
+    args: Namespace, sampling_params: dict[str, Any], prompt_field: str | list[int]
+) -> dict[str, Any]:
+    """Map shared ``sampling_params`` to vLLM OpenAI ``/v1/completions`` body."""
+    body: dict[str, Any] = {
+        "model": args.hf_checkpoint,
+        "prompt": prompt_field,
+        "max_tokens": sampling_params["max_new_tokens"],
+        "temperature": sampling_params["temperature"],
+        "top_p": sampling_params["top_p"],
+        "logprobs": 1,
+        "return_token_ids": True,
+    }
+    tk = sampling_params.get("top_k")
+    if tk is not None and tk > 0:
+        body["top_k"] = tk
+    if sampling_params.get("stop"):
+        body["stop"] = sampling_params["stop"]
+    if sampling_params.get("stop_token_ids"):
+        body["stop_token_ids"] = sampling_params["stop_token_ids"]
+    if sampling_params.get("skip_special_tokens"):
+        body["skip_special_tokens"] = True
+    if sampling_params.get("seed") is not None:
+        body["seed"] = sampling_params["seed"]
+    return body
+
+
+async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, Any]) -> Sample:
+    """Generate using vLLM OpenAI-compatible HTTP API on the router host/port."""
+    if args.ci_test:
+        assert isinstance(sample.prompt, str)
+
+    state = GenerateState(args)
+    base = f"http://{args.sglang_router_ip}:{args.sglang_router_port}"
+
+    assert (
+        sample.status == Sample.Status.PENDING or sample.status == Sample.Status.ABORTED
+    ), f"Sample status is {sample.status}"
+
+    prompt_ids = _prepare_prompt_ids(sample, state.tokenizer, state.processor)
+
+    assert (
+        sampling_params["max_new_tokens"] >= 0
+    ), f"max_new_tokens: {sampling_params['max_new_tokens']} should not be less than 0"
+    if sampling_params["max_new_tokens"] == 0:
+        sample.status = Sample.Status.TRUNCATED
+        return sample
+
+    images = sample.multimodal_inputs.get("images") if sample.multimodal_inputs else None
+
+    if not sample.tokens:
+        sample.tokens = prompt_ids
+
+    # Use session_id for consistent hashing routing (SGLang Model Gateway)
+    headers = None
+    if sample.session_id:
+        if getattr(args, "router_policy", None) == "consistent_hashing":
+            headers = {"X-SMG-Routing-Key": sample.session_id}
+
+    if images:
+        url = f"{base}/v1/chat/completions"
+        content: list[dict[str, Any]] = [{"type": "text", "text": sample.prompt}]
+        for image in images:
+            data_url = encode_image_for_rollout_engine(image)
+            content.append({"type": "image_url", "image_url": {"url": data_url}})
+        payload = {
+            "model": args.hf_checkpoint,
+            "messages": [{"role": "user", "content": content}],
+            "max_tokens": sampling_params["max_new_tokens"],
+            "temperature": sampling_params["temperature"],
+            "top_p": sampling_params["top_p"],
+            "logprobs": True,
+            "top_logprobs": 1,
+            "return_token_ids": True,
+        }
+        tk = sampling_params.get("top_k")
+        if tk is not None and tk > 0:
+            payload["top_k"] = tk
+        if sampling_params.get("stop"):
+            payload["stop"] = sampling_params["stop"]
+        if sampling_params.get("seed") is not None:
+            payload["seed"] = sampling_params["seed"]
+        with trace_span(sample, "vllm_chat", attrs={"max_tokens": sampling_params["max_new_tokens"]}):
+            output = await post(url, payload, headers=headers)
+        choice = output["choices"][0]
+        msg = choice["message"]
+        raw_content = msg.get("content")
+        if isinstance(raw_content, list):
+            text = "".join(
+                part.get("text", "") for part in raw_content if isinstance(part, dict) and part.get("type") == "text"
+            )
+        else:
+            text = (raw_content or "") if isinstance(raw_content, str) else ""
+        usage = output.get("usage")
+        meta = _openai_meta_from_completion_choice(args, choice, usage)
+        new_response_tokens, new_response_log_probs = _vllm_engine_tokens_and_logprobs(
+            state.tokenizer, choice, text, is_chat=True
+        )
+        new_response_tokens, new_response_log_probs = _align_engine_tokens_and_logprobs(
+            new_response_tokens, new_response_log_probs
+        )
+    else:
+        url = f"{base}/v1/completions"
+        prompt_field: str | list[int] = prompt_ids
+        payload = _build_completion_payload(args, sampling_params, prompt_field)
+        with trace_span(sample, "vllm_completions", attrs={"max_new_tokens": sampling_params["max_new_tokens"]}):
+            output = await post(url, payload, headers=headers)
+        choice = output["choices"][0]
+        text = choice.get("text") or ""
+        usage = output.get("usage")
+        meta = _openai_meta_from_completion_choice(args, choice, usage)
+        new_response_tokens, new_response_log_probs = _vllm_engine_tokens_and_logprobs(
+            state.tokenizer, choice, text, is_chat=False
+        )
+        new_response_tokens, new_response_log_probs = _align_engine_tokens_and_logprobs(
+            new_response_tokens, new_response_log_probs
+        )
+
+    if new_response_tokens:
+        meta["output_token_logprobs"] = [
+            [float(lp), int(tid)] for lp, tid in zip(new_response_log_probs, new_response_tokens, strict=True)
+        ]
+
+    # Update sample with tokens directly - avoiding re-tokenization
+    sample.tokens = sample.tokens + new_response_tokens
+    sample.response_length += len(new_response_tokens)
+    sample.response += text
+
+    # When partial rollout and masking off policy is enabled, update the loss mask
+    if sample.loss_mask is not None:
+        assert args.partial_rollout and args.mask_offpolicy_in_partial_rollout
+        sample.loss_mask += [1] * len(new_response_tokens)
+
+    if sample.rollout_log_probs is None:
+        sample.rollout_log_probs = []
+    sample.rollout_log_probs += new_response_log_probs
+
+    _apply_vllm_routed_experts(args, sample, output, choice)
+
+    sample.update_from_meta_info(args, meta)
+    return sample
+
+
+@trace_function("generate_and_rm", target="sample")
+async def generate_and_rm(
+    args: Namespace,
+    sample: Sample | list[Sample],
+    sampling_params: dict[str, Any],
+    evaluation: bool = False,
+) -> Sample | list[Sample]:
+    # mask previous off-policy generation for partial rollout
+    if args.partial_rollout and args.mask_offpolicy_in_partial_rollout and sample.response_length > 0:
+        sample.loss_mask = [0] * sample.response_length
+
+    # For samples with existing response, check if they're complete
+    if sample.status == Sample.Status.COMPLETED or sample.status == Sample.Status.TRUNCATED:
+        assert sample.response is not None
+        if not args.group_rm:
+            assert sample.reward is not None
+        return sample
+
+    state = GenerateState(args)
+
+    # generate
+    async with state.semaphore:
+        if state.aborted:
+            sample.status = Sample.Status.ABORTED
+            return sample
+
+        with state.dp_rank_context() as _:
+            # Check sample.generate_function_path for per-sample custom_generate_function_path (e.g., from eval dataset config)
+            custom_func_path = getattr(sample, "generate_function_path", None) or args.custom_generate_function_path
+
+            if custom_func_path is not None:
+                custom_generate_func = load_function(custom_func_path)
+                # if signature has evaluation, pass evaluation
+                if "evaluation" in inspect.signature(custom_generate_func).parameters:
+                    sample = await custom_generate_func(args, sample, sampling_params, evaluation=evaluation)
+                else:
+                    sample = await custom_generate_func(args, sample, sampling_params)
+            else:
+                sample = await generate(args, sample, sampling_params)
+
+    # for the rm that need the whole group, we will not do the rm here
+    if args.group_rm:
+        return sample
+
+    if isinstance(sample, list):
+        samples = sample
+        if any(sample.status == Sample.Status.ABORTED for sample in samples):
+            return samples
+
+        samples_need_reward = [sample for sample in samples if sample.reward is None]
+        with trace_span(samples_need_reward, "reward_model"):
+            rewards = await batched_async_rm(args, samples_need_reward)
+        for sample, reward in zip(samples_need_reward, rewards, strict=False):
+            sample.reward = reward
+        return samples
+    else:
+        if sample.status == Sample.Status.ABORTED:
+            return sample
+        # Some custom generate paths may have already filled the reward.
+        if sample.reward is None:
+            with trace_span(sample, "reward_model"):
+                sample.reward = await async_rm(args, sample)
+
+    return sample
+
+
+@trace_function(
+    "generate_and_rm_group",
+    target="group",
+    attrs_getter=lambda args, group, sampling_params, evaluation=False: {"group_size": len(group)},
+)
+async def generate_and_rm_group(
+    args: Namespace, group: list[Sample], sampling_params: dict[str, Any], evaluation: bool = False
+) -> list[Sample]:
+    state = GenerateState(args)
+
+    if state.aborted:
+        return group
+
+    # Generate a unique session_id for each sample in the group
+    for sample in group:
+        if sample.session_id is None:
+            sample.session_id = str(uuid.uuid4())
+
+    tasks = []
+    for idx, sample in enumerate(group):
+        current_sampling_params = sampling_params.copy()
+        if getattr(args, "sglang_enable_deterministic_inference", False):
+            seed = state.group_sampling_seeds[idx]
+            current_sampling_params["seed"] = seed
+        tasks.append(
+            asyncio.create_task(generate_and_rm(args, sample, current_sampling_params, evaluation=evaluation))
+        )
+
+    group = await asyncio.gather(*tasks)
+
+    # for the rm that need the whole group, we will do the rm here
+    if not state.aborted and args.group_rm:
+        with trace_span(group, "group_reward_model"):
+            rewards = await batched_async_rm(args, group)
+        for sample, reward in zip(group, rewards, strict=False):
+            sample.reward = reward
+
+    return group
+
+
+async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
+    aborted_samples: list[list[Sample]] = []
+
+    state = GenerateState(args)
+    assert not state.aborted
+    state.aborted = True
+
+    urls = await _router_worker_urls(args)
+    logger.info(f"vLLM rollout abort (pause) for workers: {urls}")
+    pause_tasks = [post(f"{url.rstrip('/')}/pause?mode=abort", {}, max_retries=3) for url in urls]
+    pause_results = await asyncio.gather(*pause_tasks, return_exceptions=True)
+    for url, result in zip(urls, pause_results, strict=False):
+        if isinstance(result, Exception):
+            logger.warning(f"Failed to pause/abort worker at {url}: {result}")
+
+    # make sure all the pending tasks are finished
+    count = 0
+    while state.pendings:
+        done, state.pendings = await asyncio.wait(state.pendings, return_when=asyncio.FIRST_COMPLETED)
+
+        if not args.partial_rollout:
+            continue
+
+        # for partial rollout, collect the partial samples into the data buffer
+        for task in done:
+            group = task.result()
+            for sample in group:
+                if sample.response and "start_rollout_id" not in sample.metadata:
+                    sample.metadata["start_rollout_id"] = rollout_id
+            aborted_samples.append(group)
+            count += len(group)
+
+    if args.partial_rollout:
+        logger.info(f"Collected {count} partial samples into the data buffer")
+
+    state.pendings = set()
+    return aborted_samples
+
+
+async def generate_rollout_async(
+    args: Namespace, rollout_id: int, data_source: Callable[[int], list[list[Sample]]]
+) -> tuple[RolloutFnTrainOutput, list[list[Sample]]]:
+    """An example to implement the generate_rollout function for an rule based rm rollout generation.
+
+    Args:
+        args: the whole args
+        rollout_id: int, the id of the rollout, used for deterministic data generation
+        data_source: the data source to fetch
+
+    Returns:
+        tuple[RolloutFnTrainOutput, list[list[Sample]]]:
+            - data: a list of groups of samples generated by the rollout, length equals `rollout_batch_size`
+            - aborted_samples: any partial groups collected during abort when partial_rollout is enabled
+    """
+    assert args.rollout_global_dataset
+
+    state = GenerateState(args)
+
+    # instantiate data filters
+    dynamic_filter = (
+        load_function(args.dynamic_sampling_filter_path) if args.dynamic_sampling_filter_path is not None else None
+    )
+
+    metric_gatherer = MetricGatherer()
+
+    # target_data_size is the total number of valid samples to get
+    target_data_size = args.rollout_batch_size
+
+    data = []
+    all_data = []
+    do_print = True
+    pbar = tqdm(total=target_data_size * args.n_samples_per_prompt, desc="Rollout generation")
+    while len(data) < target_data_size:
+        while state.remaining_batch_size < target_data_size:
+            # get samples from the buffer and submit the generation requests.
+            samples = data_source(args.over_sampling_batch_size)
+            state.submit_generate_tasks(samples)
+
+        # wait for the generation to finish
+        done, state.pendings = await asyncio.wait(state.pendings, return_when=asyncio.FIRST_COMPLETED)
+        for task in done:
+            group: list[Sample] = task.result()
+
+            if do_print:
+                sample = group[0][0] if isinstance(group[0], list) else group[0]
+                logger.info(
+                    f"First rollout sample: {[str(sample.prompt) + sample.response]}, label: {str(sample.label)[:100]}, reward: {sample.reward}",
+                )
+                do_print = False
+
+            assert len(group) == args.n_samples_per_prompt
+            all_data.append(group)
+            dynamic_filter_output = call_dynamic_filter(dynamic_filter, args, group)
+            if not dynamic_filter_output.keep:
+                metric_gatherer.on_dynamic_filter_drop(reason=dynamic_filter_output.reason)
+                state.remaining_batch_size -= 1
+                continue
+
+            # add the samples to the data
+            # NOTE: here we have not stored all the unused samples back to the data buffer.
+            if len(data) < target_data_size:
+                data.append(group)
+                pbar.update(args.n_samples_per_prompt)
+
+    pbar.close()
+    sample = data[-1][0][0] if isinstance(data[-1][0], list) else data[-1][0]
+    logger.info(
+        f"Finish rollout: {[str(sample.prompt) + sample.response]}, label: {str(sample.label)[:100]}, reward: {sample.reward}",
+    )
+
+    # there are still some unfinished requests, abort them
+    aborted_samples = await abort(args, rollout_id)
+
+    assert len(data) == args.rollout_batch_size, f"Got {len(data)} samples, expected {args.rollout_batch_size}"
+    data = sorted(data, key=lambda group: group[0][0].index if isinstance(group[0], list) else group[0].index)
+    all_samples = sorted(
+        all_data, key=lambda group: group[0][0].index if isinstance(group[0], list) else group[0].index
+    )
+
+    # reset the global state to prevent effects on the next rollout or eval.
+    state.reset()
+    if args.rollout_sample_filter_path is not None:
+        filter_func = load_function(args.rollout_sample_filter_path)
+        filter_func(args, data)
+
+    # There can be circumstances where users want to process all samples including filtered ones.
+    if args.rollout_all_samples_process_path is not None:
+        process_func = load_function(args.rollout_all_samples_process_path)
+        process_func(args, all_samples, data_source)
+
+    return RolloutFnTrainOutput(samples=data, metrics=metric_gatherer.collect()), aborted_samples
+
+
+EVAL_PROMPT_DATASET = {}
+
+
+async def eval_rollout(args: Namespace, rollout_id: int) -> tuple[dict[str, dict[str, list[Any]]], list[list[Sample]]]:
+    assert not args.group_rm, "Group RM is not supported for eval rollout"
+
+    coros = []
+    for dataset_cfg in getattr(args, "eval_datasets", []) or []:
+        coros.append(eval_rollout_single_dataset(args, rollout_id, dataset_cfg))
+    results_list = await asyncio.gather(*coros)
+    results = {}
+    for r in results_list:
+        results.update(r)
+    return RolloutFnEvalOutput(data=results), []
+
+
+async def eval_rollout_single_dataset(
+    args: Namespace, rollout_id: int, dataset_cfg: EvalDatasetConfig
+) -> dict[str, dict[str, list[Any]]]:
+    """An example to implement the eval_rollout function for an rule based rm rollout generation.
+
+    Args:
+        args: the whole args
+        rollout_id: int, the id of the rollout, used for deterministic data generation
+        dataset_cfg: configuration of the dataset
+    """
+    assert not args.group_rm, "Group RM is not supported for eval rollout"
+
+    global EVAL_PROMPT_DATASET
+
+    cache_key = dataset_cfg.cache_key + (args.hf_checkpoint, args.apply_chat_template)
+    if cache_key not in EVAL_PROMPT_DATASET:
+        tokenizer = load_tokenizer(args.hf_checkpoint, trust_remote_code=True)
+        processor = load_processor(args.hf_checkpoint, trust_remote_code=True)
+        EVAL_PROMPT_DATASET[cache_key] = Dataset(
+            path=dataset_cfg.path,
+            tokenizer=tokenizer,
+            processor=processor,
+            max_length=args.eval_max_prompt_len,
+            prompt_key=dataset_cfg.input_key,
+            label_key=dataset_cfg.label_key,
+            multimodal_keys=args.multimodal_keys,
+            metadata_key=dataset_cfg.metadata_key,
+            tool_key=dataset_cfg.tool_key,
+            apply_chat_template=args.apply_chat_template,
+            apply_chat_template_kwargs=args.apply_chat_template_kwargs,
+        )
+    dataset = EVAL_PROMPT_DATASET[cache_key]
+
+    base_sampling_params = dict(
+        temperature=dataset_cfg.temperature,
+        top_p=dataset_cfg.top_p,
+        top_k=dataset_cfg.top_k,
+        max_new_tokens=dataset_cfg.max_response_len,
+        stop=args.rollout_stop,
+        stop_token_ids=args.rollout_stop_token_ids,
+        skip_special_tokens=args.rollout_skip_special_tokens,
+        no_stop_trim=True,
+        spaces_between_special_tokens=False,
+    )
+
+    tasks = []
+    # do multiple samples for eval prompts
+    sample_index = 0
+    for _i, prompt_sample in enumerate(dataset.samples):
+        for j in range(dataset_cfg.n_samples_per_eval_prompt):
+            # use the same prompt for multiple samples
+            sample = copy.deepcopy(prompt_sample)
+            sample.index = sample_index
+            sample_index += 1
+            sample.metadata = dataset_cfg.inject_metadata(getattr(sample, "metadata", None))
+            sample.generate_function_path = getattr(dataset_cfg, "custom_generate_function_path", None)
+            sampling_params = base_sampling_params
+            if getattr(args, "sglang_enable_deterministic_inference", False):
+                sampling_params = base_sampling_params.copy()
+                sampling_params["seed"] = args.rollout_seed + j
+            tasks.append(
+                asyncio.create_task(
+                    generate_and_rm(
+                        args,
+                        sample,
+                        sampling_params=sampling_params,
+                        evaluation=True,
+                    )
+                )
+            )
+
+    data = []
+    do_print = True
+    pbar = tqdm(total=len(tasks), desc=f"Eval {dataset_cfg.name}", disable=not do_print)
+    for coro in asyncio.as_completed(tasks):
+        sample = await coro
+        if do_print:
+            logged_sample = sample[0] if isinstance(sample, list) else sample
+            logger.info(
+                "eval_rollout_single_dataset example data: "
+                f"{[str(logged_sample.prompt) + logged_sample.response]} "
+                f"reward={logged_sample.reward}"
+            )
+            do_print = False
+        if isinstance(sample, list):
+            data.extend(sample)
+        else:
+            data.append(sample)
+        pbar.update(1)
+    pbar.close()
+
+    data.sort(key=lambda sample: sample.index)
+
+    reward_key = args.eval_reward_key or args.reward_key
+    return {
+        dataset_cfg.name: {
+            "rewards": [sample.reward if not reward_key else sample.reward[reward_key] for sample in data],
+            "truncated": [sample.status == Sample.Status.TRUNCATED for sample in data],
+            "samples": data,
+        }
+    }
+
+
+def generate_rollout(
+    args: Namespace, rollout_id: int, data_source: Any, evaluation: bool = False
+) -> RolloutFnTrainOutput | RolloutFnEvalOutput:
+    """An example to implement the generate_rollout function for an rule based rm rollout generation.
+
+    Args:
+        args: the whole args
+        rollout_id: int, the id of the rollout, used for deterministic data generation
+        data_source: the data source to get and store samples
+        evaluation: bool, whether the rollout is for evaluation or not
+
+    Returns:
+        RolloutFnTrainOutput | RolloutFnEvalOutput: the output of the rollout
+    """
+    assert args.rollout_global_dataset
+    if evaluation:
+        output, _ = run(eval_rollout(args, rollout_id))
+        return output
+
+    output, aborted_samples = run(generate_rollout_async(args, rollout_id, data_source.get_samples))
+    if aborted_samples:
+        data_source.add_samples(aborted_samples)
+    return output


### PR DESCRIPTION
## Purpose

Prepare vime for an upcoming **vLLM backend** by implementing and documenting **`slime/rollout/vllm_rollout`**: generation goes through the **same router host/port** as today’s rollout args, but uses **vLLM-style OpenAI HTTP** (`/v1/completions`, `/v1/chat/completions` when multimodal) with fields such as **`return_token_ids`** and logprob payloads, then maps results onto the existing **`Sample`** contract (`tokens`, `response`, `rollout_log_probs`, `update_from_meta_info`, etc.) so training and tooling stay aligned with the SGLang rollout surface where it matters, without forcing callers to fork rollout logic per engine.

## Test Plan
### 1. Start vLLM API server only (do **not** use the verify script for this step)

```bash
python -m vllm.entrypoints.openai.api_server \
  --model /data/nfs_87/xky/models/Qwen3-0.6B \
  --host 127.0.0.1 \
  --port 8000
```

### 2. In a second terminal, confirm the worker is actually up

```bash
curl -sS http://127.0.0.1:8000/health
curl -sS http://127.0.0.1:8000/v1/models
```

### 3. Start `vllm-router` separately (another process)

```bash
vllm-router \
  --host 127.0.0.1 \
  --port 30000 \
  --worker-urls http://127.0.0.1:8000 \
  --model-path /data/nfs_87/xky/models/Qwen3-0.6B
```

### 4. Confirm the router

```bash
curl -sS http://127.0.0.1:30000/workers
```

### 5. Run slime rollout E2E against the router

With the API server and router already running as above, run:

```bash
python vime/scripts/verify_vllm_rollout_e2e.py <your usual flags, e.g. --router-url http://127.0.0.1:30000 ...>
```
verify_vllm_rollout_e2e.py 
```
#!/usr/bin/env python
"""Verify vLLM router + ``slime.rollout.vllm_rollout`` against **already running** vLLM + router.

Start the stack in another terminal with ``start_vllm_router_for_rollout.py``.

Example::

    python vime/scripts/verify_vllm_rollout_e2e.py \\
      --router-url "http://127.0.0.1:30000" \\
      --model "/path/to/Qwen3-0.6B"

Rollout E2E then validates **token / logprob / text** consistency (disable with ``--skip-rollout-output-check``).
"""
from __future__ import annotations

import argparse
import json
import math
import sys
import threading
import time
import urllib.error
import urllib.request
from argparse import Namespace
from pathlib import Path
from urllib.parse import urlparse

_VIME_ROOT = Path(__file__).resolve().parents[1]
if str(_VIME_ROOT) not in sys.path:
    sys.path.insert(0, str(_VIME_ROOT))


def _http_get_json(url: str, timeout: float = 10.0) -> dict:
    req = urllib.request.Request(url=url, method="GET")
    with urllib.request.urlopen(req, timeout=timeout) as resp:
        return json.loads(resp.read().decode("utf-8"))


def _http_post_json(url: str, payload: dict, timeout: float = 30.0) -> dict:
    req = urllib.request.Request(
        url=url,
        method="POST",
        data=json.dumps(payload).encode("utf-8"),
        headers={"Content-Type": "application/json"},
    )
    with urllib.request.urlopen(req, timeout=timeout) as resp:
        return json.loads(resp.read().decode("utf-8"))


def _http_post_empty(url: str, timeout: float = 30.0) -> tuple[int, bytes]:
    req = urllib.request.Request(url=url, method="POST", data=b"")
    with urllib.request.urlopen(req, timeout=timeout) as resp:
        return resp.status, resp.read()


def _wait_router_reachable(router_url: str, timeout_s: int) -> None:
    candidates = ["/workers", "/list_workers", "/health", "/v1/models"]
    deadline = time.time() + timeout_s
    last_error: Exception | None = None
    while time.time() < deadline:
        for endpoint in candidates:
            try:
                _http_get_json(f"{router_url}{endpoint}", timeout=3.0)
                print(f"[ready] router {router_url} endpoint {endpoint}")
                return
            except Exception as exc:  # noqa: BLE001
                last_error = exc
        time.sleep(1)
    raise TimeoutError(f"Router not reachable within {timeout_s}s: {last_error}")


def _router_host_port(router_url: str) -> tuple[str, int]:
    p = urlparse(router_url)
    if not p.hostname:
        raise ValueError(f"Invalid router URL: {router_url}")
    if p.port is None:
        raise ValueError(f"Router URL must include an explicit port: {router_url}")
    return p.hostname, int(p.port)


class _RolloutVerifyDataSource:
    """Minimal data source for ``generate_rollout`` (no global HF dataset)."""

    def __init__(self, prompt: str, n_samples_per_prompt: int, pool_groups: int = 32):
        self.prompt = prompt
        self.n_samples_per_prompt = n_samples_per_prompt
        self.pool_groups = pool_groups
        self._next_group = 0
        self.added: list = []

    def get_samples(self, num_samples: int) -> list:
        from slime.utils.types import Sample

        out = []
        for _ in range(num_samples):
            group = []
            for j in range(self.n_samples_per_prompt):
                s = Sample(prompt=self.prompt, label="", reward=None, metadata={})
                s.index = self._next_group * self.n_samples_per_prompt + j
                s.group_index = self._next_group
                group.append(s)
            self._next_group += 1
            if self._next_group >= self.pool_groups:
                self._next_group = 0
            out.append(group)
        return out

    def add_samples(self, samples) -> None:
        self.added.extend(samples)


def _build_rollout_namespace(
    *,
    router_url: str,
    hf_checkpoint: str,
    rollout_batch_size: int,
    n_samples_per_prompt: int,
    rollout_max_response_len: int,
    over_sampling_batch_size: int | None,
    prompt: str,
    rm_type: str,
) -> Namespace:
    host, port = _router_host_port(router_url)
    obs = over_sampling_batch_size if over_sampling_batch_size is not None else rollout_batch_size
    return Namespace(
        hf_checkpoint=hf_checkpoint,
        sglang_router_ip=host,
        sglang_router_port=port,
        rollout_global_dataset=True,
        rollout_batch_size=rollout_batch_size,
        n_samples_per_prompt=n_samples_per_prompt,
        over_sampling_batch_size=obs,
        rollout_max_response_len=rollout_max_response_len,
        rollout_temperature=0.7,
        rollout_top_p=0.95,
        rollout_top_k=-1,
        rollout_stop=None,
        rollout_stop_token_ids=None,
        rollout_skip_special_tokens=False,
        rollout_seed=42,
        sglang_enable_deterministic_inference=False,
        sglang_server_concurrency=8,
        rollout_num_gpus=1,
        rollout_num_gpus_per_engine=1,
        sglang_dp_size=1,
        group_rm=False,
        partial_rollout=False,
        mask_offpolicy_in_partial_rollout=False,
        dynamic_sampling_filter_path=None,
        rollout_sample_filter_path=None,
        rollout_all_samples_process_path=None,
        custom_generate_function_path=None,
        custom_rm_path=None,
        rm_type=rm_type,
        reward_key=None,
        eval_reward_key=None,
        eval_datasets=[],
        apply_chat_template=False,
        apply_chat_template_kwargs=None,
        multimodal_keys=None,
        ci_test=False,
        router_policy=None,
        use_rollout_routing_replay=False,
        num_layers=1,
        moe_router_topk=1,
        sglang_speculative_algorithm=False,
        use_distributed_post=False,
    )


def _run_http_smoke(router_url: str, model: str, prompt: str) -> None:
    completion_payload = {
        "model": model,
        "prompt": prompt,
        "max_tokens": 32,
        "temperature": 0.7,
        "top_p": 0.95,
        "logprobs": 1,
    }
    out = _http_post_json(f"{router_url}/v1/completions", completion_payload, timeout=120.0)
    print(f"[check] /v1/completions ok, keys={list(out.keys())}")

    base = router_url.rstrip("/")
    try:
        try:
            workers = _http_get_json(f"{base}/workers", timeout=10.0)["workers"]
            worker_urls = [w["url"] for w in workers]
        except Exception:
            worker_urls = list(_http_get_json(f"{base}/list_workers", timeout=10.0)["urls"])
    except Exception as exc:
        raise RuntimeError(f"Could not list router workers: {exc}") from exc

    # vLLM only mounts /pause and /is_paused when VLLM_SERVER_DEV_MODE=1 (see rlhf api_router.attach_router).
    probe = f"{worker_urls[0].rstrip('/')}/is_paused"
    try:
        _http_get_json(probe, timeout=5.0)
    except urllib.error.HTTPError as exc:
        if exc.code == 404:
            print(
                "[check] worker has no /is_paused (404); skipping long-request + POST /pause abort smoke. "
                "To enable it, restart the vLLM api_server with: export VLLM_SERVER_DEV_MODE=1"
            )
            return
        raise

    long_req_error: list[Exception] = []

    def _long_generate() -> None:
        try:
            _http_post_json(
                f"{router_url}/v1/completions",
                {
                    "model": model,
                    "prompt": prompt,
                    "max_tokens": 4096,
                    "temperature": 0.7,
                    "top_p": 0.95,
                    "logprobs": 1,
                },
                timeout=300.0,
            )
        except Exception as exc:  # noqa: BLE001
            long_req_error.append(exc)

    t = threading.Thread(target=_long_generate, daemon=True)
    t.start()
    time.sleep(2.0)
    try:
        try:
            for wu in worker_urls:
                pause_url = f"{wu.rstrip('/')}/pause?mode=abort"
                status, body = _http_post_empty(pause_url, timeout=30.0)
                print(f"[check] POST {pause_url} ok, status={status}, body_len={len(body)}")
        except urllib.error.HTTPError as exc:
            raise RuntimeError(f"Abort request failed: HTTP {exc.code}") from exc

        t.join(timeout=20.0)
        if t.is_alive():
            raise RuntimeError("Long completion request still running after abort; abort may be ineffective.")
        if long_req_error:
            print(f"[check] long request ended with exception after abort (acceptable): {long_req_error[0]}")
        else:
            print("[check] long request returned after abort.")
    finally:
        failures: list[str] = []
        for wu in worker_urls:
            resume_url = f"{wu.rstrip('/')}/resume"
            try:
                st, bod = _http_post_empty(resume_url, timeout=30.0)
                print(f"[check] POST {resume_url} ok, status={st}, body_len={len(bod)}")
            except Exception as res_exc:  # noqa: BLE001
                failures.append(f"{resume_url}: {res_exc}")
        if failures:
            raise RuntimeError(
                "POST /resume failed (vLLM workers stay paused; rollout would hang): " + "; ".join(failures)
            ) from None


def _run_rollout_e2e(
    router_url: str,
    *,
    hf_checkpoint: str,
    rollout_batch_size: int,
    n_samples_per_prompt: int,
    rollout_max_response_len: int,
    over_sampling_batch_size: int | None,
    prompt: str,
    rm_type: str,
    validate_output: bool,
) -> None:
    from slime.rollout.base_types import RolloutFnTrainOutput
    from slime.rollout.vllm_rollout import generate_rollout
    from slime.utils.http_utils import init_http_client

    args = _build_rollout_namespace(
        router_url=router_url,
        hf_checkpoint=hf_checkpoint,
        rollout_batch_size=rollout_batch_size,
        n_samples_per_prompt=n_samples_per_prompt,
        rollout_max_response_len=rollout_max_response_len,
        over_sampling_batch_size=over_sampling_batch_size,
        prompt=prompt,
        rm_type=rm_type,
    )
    init_http_client(args)
    ds = _RolloutVerifyDataSource(prompt, n_samples_per_prompt=n_samples_per_prompt)
    print("[rollout] calling slime.rollout.vllm_rollout.generate_rollout ...")
    out = generate_rollout(args, rollout_id=0, data_source=ds, evaluation=False)
    assert isinstance(out, RolloutFnTrainOutput), type(out)
    assert len(out.samples) == rollout_batch_size, f"expected {rollout_batch_size} groups, got {len(out.samples)}"
    for gi, group in enumerate(out.samples):
        assert len(group) == n_samples_per_prompt, (gi, len(group), n_samples_per_prompt)
        for si, sample in enumerate(group):
            assert sample.response, f"group {gi} sample {si}: empty response"
            assert sample.reward is not None, f"group {gi} sample {si}: missing reward"
            assert sample.response_length > 0, f"group {gi} sample {si}: zero response_length"
    print(f"[rollout] ok: {rollout_batch_size} group(s), {n_samples_per_prompt} sample(s)/group, rewards set.")
    if validate_output:
        _validate_rollout_output(args, out, prompt)


def _validate_rollout_output(args: Namespace, out, prompt: str) -> None:
    """Assert token / logprob / text consistency (same checks as SGLang-style engine fields)."""
    from slime.rollout.base_types import RolloutFnTrainOutput
    from slime.utils.processing_utils import load_tokenizer
    from slime.utils.types import Sample

    assert isinstance(out, RolloutFnTrainOutput)
    tok = load_tokenizer(args.hf_checkpoint, trust_remote_code=True)
    prompt_ids = tok.encode(prompt, add_special_tokens=False)

    for gi, group in enumerate(out.samples):
        for si, sample in enumerate(group):
            if sample.status not in (Sample.Status.COMPLETED, Sample.Status.TRUNCATED):
                raise AssertionError(f"group {gi} sample {si}: unexpected status {sample.status!r}")
            if sample.rollout_log_probs is None:
                raise AssertionError(f"group {gi} sample {si}: rollout_log_probs is None")
            n_lp = len(sample.rollout_log_probs)
            if n_lp != sample.response_length:
                raise AssertionError(
                    f"group {gi} sample {si}: len(rollout_log_probs)={n_lp} != response_length={sample.response_length}"
                )
            for j, p in enumerate(sample.rollout_log_probs):
                if not math.isfinite(p):
                    raise AssertionError(f"group {gi} sample {si}: non-finite logprob at {j}: {p!r}")
            n_tok = len(sample.tokens)
            expected_total = len(prompt_ids) + sample.response_length
            if n_tok != expected_total:
                raise AssertionError(
                    f"group {gi} sample {si}: len(tokens)={n_tok} != "
                    f"len(prompt_ids)+response_length={expected_total}"
                )
            if sample.tokens[: len(prompt_ids)] != prompt_ids:
                raise AssertionError(
                    f"group {gi} sample {si}: leading token ids do not match tokenizer.encode(prompt)"
                )
            resp_ids = sample.tokens[len(prompt_ids) : expected_total]
            decoded = tok.decode(resp_ids, skip_special_tokens=args.rollout_skip_special_tokens)
            if decoded != sample.response:
                # vLLM / BPE occasionally differs only by boundary whitespace from strict decode
                if decoded.rstrip("\n") != sample.response.rstrip("\n"):
                    raise AssertionError(
                        f"group {gi} sample {si}: decode(response_token_ids) != sample.response\n"
                        f"  decode (len={len(decoded)!r}): {decoded[:200]!r}\n"
                        f"  response (len={len(sample.response)!r}): {sample.response[:200]!r}"
                    )
    print(
        "[rollout] output check: status, len(rollout_log_probs)==response_length, "
        "tokens==prompt_ids+response_ids, decode(response_ids)==response — ok"
    )


def main() -> int:
    parser = argparse.ArgumentParser(
        description="Wait for router, optionally run HTTP smoke, then vllm_rollout.generate_rollout E2E."
    )
    parser.add_argument("--router-url", default="http://127.0.0.1:30000", help="Running vllm-router base URL.")
    parser.add_argument("--router-ready-timeout-s", type=int, default=120, help="Poll until router answers.")
    parser.add_argument("--model", required=True, help="Model id for HTTP smoke / must match vLLM server.")
    parser.add_argument(
        "--hf-checkpoint",
        default=None,
        help="HF path for tokenizer and rollout request ``model``. Defaults to --model.",
    )
    parser.add_argument("--prompt", default="Hello. Reply in one short English sentence.")
    parser.add_argument("--skip-http-smoke", action="store_true", help="Skip /v1/completions + pause/abort checks.")
    parser.add_argument("--skip-rollout-e2e", action="store_true", help="Skip generate_rollout E2E.")
    parser.add_argument(
        "--skip-rollout-output-check",
        action="store_true",
        help="Skip token/logprob/text consistency checks after rollout.",
    )
    parser.add_argument("--rollout-batch-size", type=int, default=1)
    parser.add_argument("--n-samples-per-prompt", type=int, default=2)
    parser.add_argument("--rollout-max-response-len", type=int, default=64)
    parser.add_argument("--over-sampling-batch-size", type=int, default=None)
    parser.add_argument("--rm-type", type=str, default="random")
    cli = parser.parse_args()

    hf_ckpt = cli.hf_checkpoint or cli.model

    _wait_router_reachable(cli.router_url, timeout_s=cli.router_ready_timeout_s)

    if not cli.skip_http_smoke:
        _run_http_smoke(cli.router_url, cli.model, cli.prompt)

    if not cli.skip_rollout_e2e:
        _run_rollout_e2e(
            cli.router_url,
            hf_checkpoint=hf_ckpt,
            rollout_batch_size=cli.rollout_batch_size,
            n_samples_per_prompt=cli.n_samples_per_prompt,
            rollout_max_response_len=cli.rollout_max_response_len,
            over_sampling_batch_size=cli.over_sampling_batch_size,
            prompt=cli.prompt,
            rm_type=cli.rm_type,
            validate_output=not cli.skip_rollout_output_check,
        )

    print("\n[done] verify_vllm_rollout_e2e passed.")
    return 0


if __name__ == "__main__":
    try:
        raise SystemExit(main())
    except KeyboardInterrupt:
        raise SystemExit(130)

```

## Test Result
<img width="1609" height="264" alt="image" src="https://github.com/user-attachments/assets/75256bb3-561c-45ce-8d2f-48efb348bec4" />

