### PR TITLE
Merge samithuang/slime rebase branch into vime

### DIFF
--- a/slime/backends/megatron_utils/actor.py
+++ b/slime/backends/megatron_utils/actor.py
@@ -9,8 +9,12 @@ import ray
 import torch
 import torch.distributed as dist
 from megatron.core import mpu
-from torch_memory_saver import torch_memory_saver
 from transformers import AutoConfig, AutoTokenizer
+
+try:  # pragma: no cover - depends on the runtime preload environment.
+    from torch_memory_saver import torch_memory_saver  # type: ignore
+except Exception:  # noqa: BLE001 - the native hook may be absent in vLLM runs.
+    torch_memory_saver = None  # type: ignore[assignment]
 
 from slime.ray.train_actor import TrainRayActor
 from slime.utils import train_dump_utils
@@ -77,9 +81,12 @@ class MegatronTrainRayActor(TrainRayActor):
         dist.barrier(group=get_gloo_group())
 
         if args.offload_train:
-            if (x := args.train_memory_margin_bytes) > 0:
-                logger.info(f"Set torch_memory_saver.memory_margin_bytes to {x}")
-                torch_memory_saver.memory_margin_bytes = x
+            if self._uses_torch_memory_saver():
+                if (x := args.train_memory_margin_bytes) > 0:
+                    logger.info(f"Set torch_memory_saver.memory_margin_bytes to {x}")
+                    torch_memory_saver.memory_margin_bytes = x
+            else:
+                logger.info("offload_train enabled without active torch_memory_saver; using CPU tensor offload.")
 
         self.model, self.optimizer, self.opt_param_scheduler, loaded_rollout_id = initialize_model_and_optimizer(
             args, role
@@ -156,6 +163,80 @@ class MegatronTrainRayActor(TrainRayActor):
 
         return start_rollout_id
 
+    def _uses_torch_memory_saver(self) -> bool:
+        if not self.args.offload_train:
+            return False
+        if torch_memory_saver is None:
+            return False
+        return getattr(torch_memory_saver, "_impl", None) is not None
+
+    @torch.no_grad()
+    def _move_optimizer_state_to_device(self, device: str | torch.device) -> None:
+        if self.optimizer is None:
+            return
+
+        def _walk(opt) -> None:
+            inner = getattr(opt, "chained_optimizers", None)
+            if inner:
+                for sub in inner:
+                    _walk(sub)
+                return
+
+            state = getattr(opt, "state", None)
+            if not state:
+                return
+            for key, value in list(state.items()):
+                if isinstance(value, torch.Tensor):
+                    state[key] = value.to(device, non_blocking=True)
+                elif isinstance(value, dict):
+                    for sub_key, sub_value in value.items():
+                        if isinstance(sub_value, torch.Tensor):
+                            value[sub_key] = sub_value.to(device, non_blocking=True)
+
+        _walk(self.optimizer)
+        torch.cuda.synchronize()
+
+    @torch.no_grad()
+    def _move_module_tensors_to_device(self, device: str | torch.device) -> None:
+        if self.model is None:
+            return
+
+        def _move_tensor_attr(owner, attr: str) -> None:
+            t = getattr(owner, attr, None)
+            if isinstance(t, torch.Tensor):
+                t.data = t.data.to(device, non_blocking=True)
+
+        for module in self.model:
+            for bucket_attr in ("buffers", "expert_parallel_buffers"):
+                bucket_list = getattr(module, bucket_attr, None)
+                if isinstance(bucket_list, (list, tuple)):
+                    for buf in bucket_list:
+                        for tensor_attr in ("param_data", "grad_data"):
+                            _move_tensor_attr(buf, tensor_attr)
+
+            for p in module.parameters(recurse=True):
+                p.data = p.data.to(device, non_blocking=True)
+                if p.grad is not None:
+                    p.grad.data = p.grad.data.to(device, non_blocking=True)
+                _move_tensor_attr(p, "main_grad")
+
+            # Megatron DDP can shadow module.buffers with ParamAndGradBuffer lists.
+            for b in torch.nn.Module.buffers(module, recurse=True):
+                b.data = b.data.to(device, non_blocking=True)
+
+    def _cpu_offload_sleep(self) -> None:
+        self._move_module_tensors_to_device("cpu")
+        if getattr(self, "optimizer", None) is not None:
+            self._move_optimizer_state_to_device("cpu")
+        torch.cuda.synchronize()
+
+    def _cpu_offload_wake_up(self) -> None:
+        device = torch.device("cuda", torch.cuda.current_device())
+        self._move_module_tensors_to_device(device)
+        if getattr(self, "optimizer", None) is not None:
+            self._move_optimizer_state_to_device(device)
+        torch.cuda.synchronize()
+
     @timer
     def sleep(self) -> None:
         assert self.args.offload_train
@@ -171,7 +252,11 @@ class MegatronTrainRayActor(TrainRayActor):
             self.weight_updater.disconnect_rollout_engines()
         destroy_process_groups()
 
-        torch_memory_saver.pause()
+        if self._uses_torch_memory_saver():
+            torch_memory_saver.pause()
+        else:
+            self._cpu_offload_sleep()
+            clear_memory()
 
         print_memory("after offload model")
 
@@ -180,7 +265,10 @@ class MegatronTrainRayActor(TrainRayActor):
         assert self.args.offload_train
         print_memory("before wake_up model")
 
-        torch_memory_saver.resume()
+        if self._uses_torch_memory_saver():
+            torch_memory_saver.resume()
+        else:
+            self._cpu_offload_wake_up()
 
         clear_memory()
         reload_process_groups()
@@ -591,7 +679,9 @@ class MegatronTrainRayActor(TrainRayActor):
             if dist.get_rank() == 0:
                 ray.get(self.rollout_manager.clear_updatable_num_new_engines.remote())
 
-        with torch_memory_saver.disable() if self.args.offload_train else nullcontext():
+        weight_update_ctx = torch_memory_saver.disable() if self._uses_torch_memory_saver() else nullcontext()
+
+        with weight_update_ctx:
             print_memory("before update_weights")
             self.weight_updater.update_weights()
             print_memory("after update_weights")

--- a/slime/backends/megatron_utils/update_weight/common.py
+++ b/slime/backends/megatron_utils/update_weight/common.py
@@ -133,7 +133,10 @@ def named_params_and_buffers(
 
 
 def _maybe_get_cpu_backup(x: torch.Tensor):
-    from torch_memory_saver import torch_memory_saver
+    try:
+        from torch_memory_saver import torch_memory_saver
+    except Exception:  # noqa: BLE001 - vLLM runs may not preload the native hook.
+        return x
 
     if (cpu_tensor := torch_memory_saver.get_cpu_backup(x)) is not None:
         return cpu_tensor

--- a/tests/test_update_weight_common.py
+++ b/tests/test_update_weight_common.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def load_common_module(monkeypatch):
+    megatron_mod = types.ModuleType("megatron")
+    megatron_mod.__path__ = []
+
+    core_mod = types.ModuleType("megatron.core")
+    core_mod.__path__ = []
+    core_mod.mpu = types.SimpleNamespace(
+        get_expert_tensor_parallel_world_size=lambda: 2,
+        get_expert_tensor_parallel_group=lambda: "expert_tp",
+        get_tensor_model_parallel_world_size=lambda: 2,
+        get_tensor_model_parallel_group=lambda: "tp",
+        get_expert_model_parallel_world_size=lambda: 1,
+        get_expert_model_parallel_rank=lambda: 0,
+    )
+
+    transformer_mod = types.ModuleType("megatron.core.transformer")
+    transformer_mod.__path__ = []
+    transformer_layer_mod = types.ModuleType("megatron.core.transformer.transformer_layer")
+    transformer_layer_mod.get_transformer_layer_offset = lambda *args, **kwargs: 0
+    transformer_mod.transformer_layer = transformer_layer_mod
+    core_mod.transformer = transformer_mod
+    megatron_mod.core = core_mod
+
+    monkeypatch.setitem(sys.modules, "megatron", megatron_mod)
+    monkeypatch.setitem(sys.modules, "megatron.core", core_mod)
+    monkeypatch.setitem(sys.modules, "megatron.core.transformer", transformer_mod)
+    monkeypatch.setitem(sys.modules, "megatron.core.transformer.transformer_layer", transformer_layer_mod)
+
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "slime"
+        / "backends"
+        / "megatron_utils"
+        / "update_weight"
+        / "common.py"
+    )
+    module_name = "test_update_weight_common_module"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.unit
+def test_maybe_get_cpu_backup_returns_original_tensor_when_hook_missing(monkeypatch):
+    common = load_common_module(monkeypatch)
+
+    monkeypatch.setitem(sys.modules, "torch_memory_saver", types.ModuleType("torch_memory_saver"))
+
+    tensor = torch.tensor([1, 2, 3])
+    assert common._maybe_get_cpu_backup(tensor) is tensor


### PR DESCRIPTION
## Summary

Merges samithuang/slime [PR #12](https://github.com/SamitHuang/slime/pull/12) (rebase branch, commit `9146f9f`) into vime. Both branches forked from upstream slime `8ef1fb4` and independently added vLLM support; this PR reconciles them so vime retains its vLLM design (kaiyuan) while picking up samithuang's broader infrastructure (Jason & Long): non-colocate Megatron+vLLM weight sync, slime router, Megatron grad-coalesce patch, retool fix, e2e scripts

## Per-file precedence

**Kept verbatim from vime (kaiyuan vLLM core)**
- `slime/backends/vllm_utils/vllm_engine.py` (707-line monolithic engine)
- `slime/backends/vllm_utils/__init__.py` (empty)
- `slime/rollout/vllm_rollout.py` (992-line standalone rollout)
- `slime/backends/sglang_utils/sglang_engine.py`
- `slime/rollout/sglang_rollout.py` (kept upstream; samithuang's backend-abstraction refactor dropped)

**Dropped from samithuang (incompatible with vime's design)**
- `slime/backends/vllm_utils/vllm_translation_sidecar.py`
- `slime/rollout/backends/{__init__,base_client,sglang_client,vllm_client}.py`

**Taken from samithuang (Jason & Long infrastructure)**
- `slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py` (colocate + non-colocate weight sync)
- `slime/backends/megatron_utils/update_weight/update_weight_from_tensor_vllm.py`
- `slime/backends/megatron_utils/weight_sync_utils.py`
- `slime/backends/megatron_utils/megatron_patch/*` (chunked grad coalesce)
- `slime/backends/megatron_utils/{__init__,actor,arguments,sglang}.py`, `update_weight/common.py`
- `slime/ray/actor_group.py`, `slime/rollout/base_types.py`, `slime/backends/sglang_utils/arguments.py`
- `slime/router/router.py` (SlimeRouter, gated by `--use-slime-router`)
- e2e scripts: `run-qwen2.5-0.5B-vllm.sh`, `run-qwen2.5-0.5B-reproducibility-noncolocate.sh`, `convert_qwen2.5_ckpt.sh`, `setup_for_vllm.md`
- RFC/docs and `examples/retool` + `tests/plugin_contracts` updates

**Manual splices**
- `slime/ray/rollout.py`: based on samithuang. Vime's `_sanitize_vllm_router_args`, `_vllm_router_args_from_cli`, the `model_path` kwarg passed to engine actors, and the engine-shutdown loop in `RolloutManager.dispose()` are preserved. `_start_router` was rewritten to support three modes: `--use-slime-router` (SlimeRouter), `--rollout-backend vllm` (vllm-router via http_utils), and sglang-router fallback. Samithuang's `_start_vllm_rollout_servers` helper and its early-exit in `start_rollout_servers` were removed because they target a different `VLLMEngine` signature; vime's `ServerGroup.start_engines` already dispatches to `VLLMEngine` when `rollout_backend == "vllm"`.
- `slime/utils/arguments.py`: union of both arg sets with duplicates removed (`--rollout-backend`, `--vllm-gpu-memory-utilization`, `--vllm-weight-sync-packed`). Kept samithuang's `--rollout-backend` default of `sglang` for backwards compat and vime's mutually-exclusive `--vllm-weight-sync-packed` / `--no-vllm-weight-sync-packed` group. Vime's auto-switch of `rollout_function_path` to `vllm_rollout` when `--rollout-backend vllm` is preserved.
- `slime/utils/http_utils.py`: vime's `run_router((impl, router_args))` payload contract kept; samithuang's `sglang_server_concurrency` -> `rollout_server_concurrency` rename applied.
- `slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py`: vime's 3-line addition (import `_is_vllm_backend`, pass `use_vllm=...` and `packed=False`) kept; it correctly wires the existing tensor-update path through samithuang's new vllm-aware signature.

## Test plan

- [ ] `python -m py_compile` over all touched `.py` files (already green locally).
- [ ] Smoke run of `run-qwen2.5-0.5B-vllm.sh` (`--rollout-backend vllm --use-slime-router`, dense Qwen2.5-0.5B on GSM8K).
- [ ] Smoke run of `run-qwen2.5-0.5B-reproducibility-noncolocate.sh` (non-colocate Megatron+vLLM weight sync).
- [ ] Smoke run of an existing sglang e2e script (e.g. `scripts/run-deepseek-r1.sh`) to confirm no regression on the default backend.
- [ ] Compare reward curve between sglang and vllm backends on the same config.

## Known follow-ups (deferred)

- `docs/en/vllm/ROUTER_DESIGN.md` and `rfc-rollout-backend-separation-plan.md` still mention the dropped `vllm_translation_sidecar.py`; update once the design has settled.
- vime's inline vllm-router path and samithuang's standalone `slime/router/router.py` coexist (selected by `--rollout-backend vllm` vs `--use-slime-router`); a future cleanup could unify them.