### PR TITLE
dockerfile: complete deps for slime training (follow-up to PR #9)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,11 @@ SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
 WORKDIR /root
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git rsync dnsutils nvtop && \
+    apt-get install -y --no-install-recommends git rsync dnsutils nvtop \
+      cmake ninja-build build-essential \
+      cuda-nvrtc-dev-13-0 cuda-nvml-dev-13-0 cuda-profiler-api-13-0 cuda-nvtx-13-0 \
+      libcusparse-dev-13-0 libcusolver-dev-13-0 libcufft-dev-13-0 libcurand-dev-13-0 \
+      libcudnn9-dev-cuda-13 && \
     rm -rf /var/lib/apt/lists/*
 
 # If the base image is not already vllm/vllm-openai:<version>, set
@@ -25,17 +29,40 @@ RUN if [ "${INSTALL_VLLM}" = "1" ]; then \
       python3 -m pip install --force-reinstall "vllm==${VLLM_VERSION}" ${VLLM_PIP_INSTALL_ARGS}; \
     fi
 
-# TE does not have wheel on cuda 13 yet, thus need to install from source
+# TE does not have wheel on cuda 13 yet, thus need to install from source.
+# nvidia-mathdx: latest is 25.6.0 on PyPI (26.6.0 doesn't exist).
+# pybind11 + setuptools_scm: required by TE's pyproject.toml build under --no-build-isolation.
 RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
-      pip install --no-deps nvidia-mathdx==26.6.0 && \
+      pip install --no-deps nvidia-mathdx pybind11 setuptools_scm && \
       pip -v install --no-build-isolation --no-deps git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.10; \
     else \
       pip -v install --no-build-isolation --no-deps "transformer_engine[pytorch]==2.10.0"; \
     fi && \
     pip install --no-deps onnxscript onnx_ir onnx ml_dtypes
 
-# Keep sglang installed (with --no-deps) so training-side imports keep working
-RUN pip install --no-deps "sglang==${SGLANG_VERSION}" sglang-router==0.3.2 torch_memory_saver==0.0.9
+# Keep sglang installed (with --no-deps) so training-side imports keep working.
+# IPython: sglang/utils.py unconditionally `from IPython.display import HTML, display`
+#   on module load — without it, `import slime` fails.
+# numpy<2: Megatron-LM rejects numpy 2.x (vllm/vllm-openai base ships 2.x).
+RUN pip install --no-deps "sglang==${SGLANG_VERSION}" sglang-router==0.3.2 torch_memory_saver==0.0.9 && \
+    pip install IPython && \
+    pip install "numpy<2"
+
+# mbridge + Megatron-Bridge + modelopt: required by slime's --megatron-to-hf-mode bridge
+# path which loads HF checkpoints into Megatron actors. Without these, slime's
+# checkpoint.py:_load_checkpoint_hf asserts `--megatron-to-hf-mode == "bridge"`
+# but the bridge code fails to import.
+RUN pip install --no-deps git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c && \
+    pip install --no-deps --no-build-isolation git+https://github.com/radixark/Megatron-Bridge.git@bridge && \
+    pip install --no-build-isolation "nvidia-modelopt[torch]>=0.37.0"
+
+# flash-linear-attention (fla) provides ShortConvolution / FusedRMSNormGated /
+# chunk_gated_delta_rule used by slime_plugins/models/qwen3_5.py and qwen3_next.py
+# (linear-attention model variants). Some fla fused kernels dispatch through
+# tilelang at runtime — install both. Tilelang has no cu13 wheel yet; cu128
+# wheel is what upstream slime uses on CUDA 13 (runtime-compatible).
+RUN pip install tilelang -f https://tile-ai.github.io/whl/nightly/cu128/
+RUN pip install flash-linear-attention==0.4.1
 
 # Install slime runtime requirements while excluding SGLang packages. Future
 # code paths should provide vLLM equivalents instead of importing SGLang.
@@ -75,6 +102,36 @@ RUN cd /root/Megatron-LM && \
     rm megatron.patch && \
     python3 -m pip install -e . --no-deps
 
+# megatron-bridge HEAD (qwen_provider.py) imports
+# `get_transformer_block_with_experimental_attention_variant_spec` from
+# Megatron-LM's experimental_attention_variant_module_specs, but the pinned
+# MEGATRON_COMMIT doesn't define that name. We're not using experimental
+# attention variants for the validated models (Qwen3-0.6B), so append a
+# NotImplementedError stub so the import succeeds.
+RUN python3 - <<'PY'
+import importlib.util
+spec = importlib.util.find_spec("megatron.core.models.gpt.experimental_attention_variant_module_specs")
+path = spec.origin
+with open(path, "r") as f: src = f.read()
+if "get_transformer_block_with_experimental_attention_variant_spec" not in src:
+    with open(path, "a") as f:
+        f.write("""
+
+# Stub: megatron-bridge expects this name. The pinned Megatron-LM commit doesn't
+# provide it. Code paths that actually use experimental attention variants will
+# fail at call time with a clear error.
+def get_transformer_block_with_experimental_attention_variant_spec(*args, **kwargs):
+    raise NotImplementedError(
+        "get_transformer_block_with_experimental_attention_variant_spec is a no-op stub; "
+        "the pinned Megatron-LM commit does not provide it. Bump MEGATRON_COMMIT to a "
+        "release that defines this function if you need experimental attention variants."
+    )
+""")
+    print("appended stub to", path)
+else:
+    print("stub already present at", path)
+PY
+
 ENV PYTHONPATH="/root/Megatron-LM:${PYTHONPATH}"
 
 # Install slime itself without dependency resolution so the vLLM base image
@@ -92,6 +149,12 @@ import vllm
 print("vllm import ok", getattr(vllm, "__version__", metadata.version("vllm")))
 print("sglang version", metadata.version("sglang"))
 print("transformer_engine version", metadata.version("transformer_engine"))
+import sglang  # noqa: F401  (verify deep import works, not just dist version)
+print("sglang import ok", sglang.__version__)
+import sglang_router  # noqa: F401
+print("sglang_router import ok", sglang_router.__version__)
+from megatron.bridge import AutoBridge  # noqa: F401  (verify slime's bridge mode dep)
+print("megatron.bridge import ok")
 PY
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Follow-up to PR #9 (`add-verl-vllm-docker-build`, specifically commit `6274695 add sglang --no-deps and change vllm to 0.20.2`). The prior commit added sglang/sglang_router/torch_memory_saver `--no-deps` and the TE source build, but the image still fails to build (and at runtime, `import slime` and Megatron actor init both fail) because of missing transitive deps. This PR closes those gaps so the image is actually trainable.

## What's missing in PR #9 today

I validated by trying to build PR #9 end-to-end and running a 1-step Qwen3-0.6B vllm rollout train. Hit the following cascade — each fix below corresponds to a real crash I encountered:

### TE source compile (apt + pip deps)

- `cmake`, `ninja-build`, `build-essential` — TE's `pyproject.toml` build needs cmake; without it: `error: Could not find CMake executable`
- `cuda-nvrtc-dev-13-0`, `cuda-nvml-dev-13-0`, `cuda-profiler-api-13-0`, `cuda-nvtx-13-0` — `vllm/vllm-openai` base ships only CUDA runtime libs, not dev headers; TE compile crashes with `fatal error: nvml.h / nvrtc.h / nvtx3/nvToolsExt.h / cuda_profiler_api.h: No such file or directory`
- `libcusparse-dev-13-0`, `libcusolver-dev-13-0`, `libcufft-dev-13-0`, `libcurand-dev-13-0`, `libcudnn9-dev-cuda-13` — torch's `ATen/cuda/CUDAContextLight.h` chain requires these; TE compile crashes with `fatal error: cusparse.h: No such file or directory` after ~30s of progress
- `pybind11`, `setuptools_scm` — TE build under `--no-build-isolation` cannot resolve build deps automatically; without them: `ModuleNotFoundError: No module named 'pybind11'`
- Drop pin `nvidia-mathdx==26.6.0` (PyPI's latest is 25.6.0; the pinned version doesn't exist): `Could not find a version that satisfies the requirement nvidia-mathdx==26.6.0`

### slime runtime imports

- `IPython` — `sglang/utils.py` does `from IPython.display import HTML, display` at module load; without it `import slime` fails with `ModuleNotFoundError: No module named 'IPython'`
- `numpy<2` — Megatron-LM raises `AssertionError: Megatron does not support numpy 2.x`; vllm base image ships numpy 2.2.6

### slime checkpoint loading

slime's `_load_checkpoint_hf` (slime/backends/megatron_utils/checkpoint.py:130) asserts `--megatron-to-hf-mode == "bridge"`, but the bridge implementation requires three packages PR #9 doesn't install:

- `mbridge` (ISEEKYAN/mbridge): provides the `mbridge` namespace
- `Megatron-Bridge` (radixark/Megatron-Bridge@bridge): provides the `megatron.bridge` namespace that slime's `model_provider.py:85` imports as `from megatron.bridge import AutoBridge`
- `nvidia-modelopt[torch]`: `megatron.bridge.models.conversion.auto_bridge` imports `modelopt` at module load

### Linear-attention model kernels

- `tilelang` (from https://tile-ai.github.io/whl/nightly/cu128/) — tilelang ships no cu13 wheel; cu128 is what upstream slime uses on CUDA 13. Required by some fla fused kernels at runtime.
- `flash-linear-attention==0.4.1` — provides `ShortConvolution`, `FusedRMSNormGated`, `chunk_gated_delta_rule` imported by `slime_plugins/models/qwen3_5.py` and `qwen3_next.py`. Without fla installed those imports fall into `except ImportError`, and `pytest -m unit` on `test_qwen3_linear_attention_cu_seqlens.py` fails with `AttributeError: module ... has no attribute 'ShortConvolution'`.

### Megatron-LM ↔ megatron-bridge API drift

`megatron.bridge.models.qwen.qwen_provider:21` imports `get_transformer_block_with_experimental_attention_variant_spec` from Megatron-LM's `experimental_attention_variant_module_specs`, but the pinned `MEGATRON_COMMIT=3714d81d...` doesn't define that name (it lives in a newer Megatron release). Without a shim, the actor crashes at init with `ImportError: cannot import name 'get_transformer_block_with_experimental_attention_variant_spec'`.

Fix: append a `NotImplementedError` stub to that module at install time. Code paths that actually use experimental attention variants (we don't, for Qwen3-0.6B) will fail at call time with a clear error message. A cleaner long-term fix is bumping `MEGATRON_COMMIT` to a release that defines the function.

## What's NOT addressed here (deliberately)

- Megatron `--no-rope-fusion` / `--no-gradient-accumulation-fusion` — these are launcher flags, not Dockerfile concerns. Training scripts targeting this image need to pass them (or wait for apex to be re-added).
- vllm weight-sync `start_weight_update` / `finish_weight_update` wrappers — that's a slime-side concern (slime/backends/vllm_utils/vllm_engine.py), out of scope for this Dockerfile PR.

## Validation

Built locally:
```
docker build -f docker/Dockerfile -t vime:dockerfile-followup .
```

Ran a 1-step Qwen3-0.6B vllm rollout training inside the container (4× H200, gsm8k, --num-rollout 1):
```
[MegatronTrainRayActor] step 0: {'train/loss': 0.0, 'train/pg_loss': 0.0, 'train/entropy_loss': 0.269,
  'train/pg_clipfrac': 0.0, 'train/ppo_kl': 0.0, 'train/grad_norm': 0.0, 'train/lr-pg_0': 1e-06, 'train/step': 0}
Job 'raysubmit_ZVkvL1fgwYbnu2fF' succeeded
```

`pytest -m unit -v tests/test_chunked_gae.py tests/test_megatron_argument_validation.py tests/test_qwen3_linear_attention_cu_seqlens.py tests/test_qwen3_5_mtp_bridge_mapping.py tests/plugin_contracts/` — expected **17/17 PASS** with fla/tilelang installed (was 15/17 without; the 2 failures were `test_linear_attention_forwards_cu_seqlens_to_chunk_kernel` blocked by missing fla).

(Note: my training run was against `vllm/vllm-openai:v0.21.0` since this PR's branch was based on that before `6274695` changed the base to v0.20.2. The cascade of fixes should still apply; please re-validate.)

## Test plan

- [x] `docker build` succeeds
- [x] Final import smoke (slime + sglang deep import + megatron.bridge.AutoBridge) passes
- [x] 1-step Qwen3-0.6B vllm rollout training reaches `step 0` and exits 0
- [ ] (PR author's) re-validation against the v0.20.2 base

🤖 Generated with [Claude Code](https://claude.com/claude-code)
