### PR TITLE
Switch vllm_rollout endpoint /v1/completions to /inference/v1/generate

### DIFF
--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -127,6 +127,8 @@ def launch_server_process(
         cmd += ["--kv-cache-memory-bytes", str(args.vllm_kv_cache_memory_bytes)]
     if args.rollout_max_context_len is not None:
         cmd += ["--max-model-len", str(args.rollout_max_context_len)]
+    if getattr(args, "use_rollout_routing_replay", False):
+        cmd += ["--enable-return-routed-experts"]
 
     logger.info("Launching vLLM server: %s", " ".join(cmd))
 

--- a/slime/rollout/vllm_rollout.py
+++ b/slime/rollout/vllm_rollout.py
@@ -39,10 +39,10 @@ _PROCESSOR_PROMPT_KEYS = {"input_ids", "attention_mask"}
 
 
 def _coerce_flat_int_token_ids(ids: Any) -> list[int]:
-    """Turn tokenizer / processor output into a flat ``list[int]`` for vLLM ``/v1/completions`` JSON.
+    """Turn tokenizer / processor output into a flat ``list[int]`` for vLLM token-only JSON.
 
-    vLLM deserializes ``prompt`` as ``StringOrArray`` (Rust): a JSON string or a JSON array of integers.
-    Nested lists, numpy/torch scalars, or non-int elements cause ``422`` deserialization errors.
+    ``/inference/v1/generate`` requires ``token_ids: list[int]``. Nested lists, numpy/torch scalars,
+    or non-int elements cause ``422`` validation errors.
     """
     if ids is None:
         return []
@@ -96,13 +96,13 @@ def _base_dataset_prompt_ids(sample: Sample, tokenizer, processor: Any) -> list[
     return _coerce_flat_int_token_ids(tokenizer.encode(sample.prompt, add_special_tokens=False))
 
 
-def get_model_url(args: Namespace, model_name: str, endpoint: str = "/v1/completions") -> str:
+def get_model_url(args: Namespace, model_name: str, endpoint: str = "/inference/v1/generate") -> str:
     """Return the router URL for a named model.
 
     Use this in custom rollout functions to route requests to a specific
     model when multiple models are deployed via ``--sglang-config``::
 
-        url = get_model_url(args, "ref", "/v1/completions")
+        url = get_model_url(args, "ref", "/inference/v1/generate")
         resp = await post(url, json=payload)
 
     Falls back to the default router if *model_name* is not found or
@@ -138,7 +138,7 @@ async def _resume_vllm_workers(urls: list[str]) -> None:
             logger.warning("Failed to resume vLLM worker at %s: %s", url, result)
 
 
-def _openai_meta_from_completion_choice(args: Namespace, choice: dict, usage: dict | None) -> dict[str, Any]:
+def _vllm_meta_from_generate_choice(args: Namespace, choice: dict, usage: dict | None) -> dict[str, Any]:
     """Build a minimal ``meta_info``-like dict for :meth:`Sample.update_from_meta_info`."""
     fr = choice.get("finish_reason") or "stop"
     if isinstance(fr, dict):
@@ -166,14 +166,11 @@ def _apply_vllm_routed_experts(
 ) -> None:
     """Populate ``sample.rollout_routed_experts`` from vLLM ``choices[].routed_experts`` when enabled.
 
-    vLLM exposes MoE routing replay on the **per-completion** ``CompletionOutput`` as a single
-    ``routed_experts`` ndarray (shape ``[num_positions, num_layers, topk]``); the V1 scheduler
-    builds it once per finished request from KV slot indices for ``request.num_tokens - 1``
-    positions — there is **no** separate ``prompt_routed_experts`` key on the HTTP completion
-    payload (confirmed absent in upstream ``vllm``; see ``CompletionOutput`` in
-    ``vllm/outputs.py`` and ``_get_routed_experts`` in ``vllm/v1/core/sched/scheduler.py``).
-    When the OpenAI layer forwards it, it appears as an extra field on the choice object
-    (Pydantic ``extra="allow"`` on ``CompletionResponseChoice``).
+    TODO: cherry-pick https://github.com/vllm-project/vllm/pull/39568 for routed experts over
+    ``/inference/v1/generate``. With that support, vLLM exposes MoE routing replay on each
+    response choice. The routing tensor covers generated positions as
+    ``[num_positions, num_layers, topk]``; there is no separate ``prompt_routed_experts`` key in
+    this rollout path.
     """
     if not getattr(args, "use_rollout_routing_replay", False):
         return
@@ -204,44 +201,8 @@ def _apply_vllm_routed_experts(
     sample.rollout_routed_experts = arr
 
 
-def _fallback_tokens_from_text_and_completion_logprobs(
-    tokenizer, choice: dict, completion_text: str
-) -> tuple[list[int], list[float]]:
-    """Fallback when vLLM did not return ``token_ids``: approximate from string logprobs or re-tokenize."""
-    lp = choice.get("logprobs")
-    if not lp or not isinstance(lp, dict):
-        toks = tokenizer.encode(completion_text, add_special_tokens=False)
-        return toks, [0.0] * len(toks)
-
-    token_logprobs = lp.get("token_logprobs")
-    tokens_field = lp.get("tokens")
-    if token_logprobs and tokens_field and len(token_logprobs) == len(tokens_field):
-        new_toks: list[int] = []
-        new_lps: list[float] = []
-        for piece, logp in zip(tokens_field, token_logprobs, strict=False):
-            if logp is None:
-                continue
-            ids = tokenizer.encode(piece, add_special_tokens=False)
-            if not ids:
-                continue
-            per = float(logp) / max(len(ids), 1)
-            new_toks.extend(ids)
-            new_lps.extend([per] * len(ids))
-        if new_toks:
-            return new_toks, new_lps
-
-    toks = tokenizer.encode(completion_text, add_special_tokens=False)
-    return toks, [0.0] * len(toks)
-
-
-def _vllm_engine_tokens_and_logprobs(
-    tokenizer,
-    choice: dict[str, Any],
-    completion_text: str,
-    *,
-    is_chat: bool,
-) -> tuple[list[int], list[float]]:
-    """Parse engine ``token_ids`` and per-token logprobs from an OpenAI choice (requires ``return_token_ids``)."""
+def _inference_generate_tokens_and_logprobs(choice: dict[str, Any]) -> tuple[list[int], list[float]]:
+    """Parse ``token_ids`` and ``logprobs.content`` from a vLLM ``/inference/v1/generate`` choice."""
     tids_raw = choice.get("token_ids")
     if isinstance(tids_raw, list) and tids_raw and all(isinstance(x, int) for x in tids_raw):
         tids = [int(x) for x in tids_raw]
@@ -250,56 +211,26 @@ def _vllm_engine_tokens_and_logprobs(
         if not isinstance(lp, dict):
             return tids, [0.0] * len(tids)
 
-        if is_chat:
-            content = lp.get("content")
-            if isinstance(content, list) and len(content) == len(tids):
-                for item in content:
-                    if isinstance(item, dict):
-                        lps.append(float(item.get("logprob", 0.0)))
-                    else:
-                        lps.append(0.0)
-                return tids, lps
-            if isinstance(content, list) and content:
-                # Partial content: pad / truncate to token_ids length if possible
-                for i in range(len(tids)):
-                    if i < len(content) and isinstance(content[i], dict):
-                        lps.append(float(content[i].get("logprob", 0.0)))
-                    else:
-                        lps.append(0.0)
-                return tids, lps
-            return tids, [0.0] * len(tids)
-
-        token_logprobs = lp.get("token_logprobs")
-        if isinstance(token_logprobs, list) and len(token_logprobs) == len(tids):
-            for p in token_logprobs:
-                lps.append(0.0 if p is None else float(p))
+        content = lp.get("content")
+        if isinstance(content, list) and len(content) == len(tids):
+            for item in content:
+                if isinstance(item, dict):
+                    lps.append(float(item.get("logprob", 0.0)))
+                else:
+                    lps.append(0.0)
+            return tids, lps
+        if isinstance(content, list) and content:
+            # Partial content: pad / truncate to token_ids length if possible.
+            for i in range(len(tids)):
+                if i < len(content) and isinstance(content[i], dict):
+                    lps.append(float(content[i].get("logprob", 0.0)))
+                else:
+                    lps.append(0.0)
             return tids, lps
 
         return tids, [0.0] * len(tids)
 
-    if is_chat:
-        lp = choice.get("logprobs")
-        content = lp.get("content") if isinstance(lp, dict) else None
-        if isinstance(content, list) and content:
-            tids_ch: list[int] = []
-            lps_ch: list[float] = []
-            for item in content:
-                if not isinstance(item, dict):
-                    continue
-                tok = item.get("token")
-                if not isinstance(tok, str):
-                    continue
-                ids = tokenizer.encode(tok, add_special_tokens=False)
-                if not ids:
-                    continue
-                lv = float(item.get("logprob", 0.0))
-                per = lv / max(len(ids), 1)
-                tids_ch.extend(ids)
-                lps_ch.extend([per] * len(ids))
-            if tids_ch:
-                return tids_ch, lps_ch
-
-    return _fallback_tokens_from_text_and_completion_logprobs(tokenizer, choice, completion_text)
+    return [], []
 
 
 def _align_engine_tokens_and_logprobs(
@@ -408,6 +339,15 @@ def _build_inference_sampling_params(sampling_params: dict[str, Any]) -> dict[st
     return sp
 
 
+def build_inference_payload(args: Namespace, sampling_params: dict[str, Any], token_ids: list[int]) -> dict[str, Any]:
+    """Build a vLLM ``/inference/v1/generate`` request body for token-only rollout."""
+    return {
+        "model": args.hf_checkpoint,
+        "token_ids": token_ids,
+        "sampling_params": _build_inference_sampling_params(sampling_params),
+    }
+
+
 def _mm_render_response_to_generate_body(render_data: Any, model: str) -> dict[str, Any]:
     """Turn ``/v1/chat/completions/render`` JSON into a ``/inference/v1/generate`` request body (minus ``sampling_params``).
 
@@ -447,35 +387,8 @@ def _mm_render_response_to_generate_body(render_data: Any, model: str) -> dict[s
     )
 
 
-def _build_completion_payload(
-    args: Namespace, sampling_params: dict[str, Any], prompt_field: str | list[int]
-) -> dict[str, Any]:
-    """Map shared ``sampling_params`` to vLLM OpenAI ``/v1/completions`` body."""
-    body: dict[str, Any] = {
-        "model": args.hf_checkpoint,
-        "prompt": prompt_field,
-        "max_tokens": sampling_params["max_new_tokens"],
-        "temperature": sampling_params["temperature"],
-        "top_p": sampling_params["top_p"],
-        "logprobs": 1,
-        "return_token_ids": True,
-    }
-    tk = sampling_params.get("top_k")
-    if tk is not None and tk > 0:
-        body["top_k"] = tk
-    if sampling_params.get("stop"):
-        body["stop"] = sampling_params["stop"]
-    if sampling_params.get("stop_token_ids"):
-        body["stop_token_ids"] = sampling_params["stop_token_ids"]
-    if sampling_params.get("skip_special_tokens"):
-        body["skip_special_tokens"] = True
-    if sampling_params.get("seed") is not None:
-        body["seed"] = sampling_params["seed"]
-    return body
-
-
 async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, Any]) -> Sample:
-    """Generate using vLLM OpenAI-compatible HTTP API on the router host/port."""
+    """Generate using vLLM ``/inference/v1/generate`` on the router host/port."""
     if args.ci_test:
         assert isinstance(sample.prompt, str)
 
@@ -532,46 +445,32 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         gen_url = f"{base}/inference/v1/generate"
         with trace_span(sample, "vllm_mm_generate", attrs={"max_tokens": params["max_new_tokens"]}):
             output = await post(gen_url, generate_body, headers=headers)
-        choice = output["choices"][0]
-        skip_sp = params.get("skip_special_tokens")
-        skip_decode = True if skip_sp is None else bool(skip_sp)
-        out_ids = choice.get("token_ids") or []
-        text = (
-            state.tokenizer.decode(out_ids, skip_special_tokens=skip_decode)
-            if isinstance(out_ids, list) and out_ids
-            else ""
-        )
-        usage = output.get("usage")
-        meta = _openai_meta_from_completion_choice(args, choice, usage)
-        new_response_tokens, new_response_log_probs = _vllm_engine_tokens_and_logprobs(
-            state.tokenizer, choice, text, is_chat=True
-        )
-        new_response_tokens, new_response_log_probs = _align_engine_tokens_and_logprobs(
-            new_response_tokens, new_response_log_probs
-        )
     else:
-        url = f"{base}/v1/completions"
-        # vLLM OpenAI ``prompt``: JSON string or flat array of integers. On partial continuation, send full
-        # ``sample.tokens`` as integer ids (aligned with dev_vllm ``sglang_rollout`` + vLLM backend).
+        url = f"{base}/inference/v1/generate"
+        # vLLM disaggregated ``/inference/v1/generate`` is token-only. On partial continuation, send the
+        # full prompt+response prefix so vLLM continues from the current sample state.
         if len(sample.response) > 0:
-            prompt_field = _coerce_flat_int_token_ids(sample.tokens)
-        elif isinstance(sample.prompt, str):
-            prompt_field = sample.prompt
+            token_ids = _coerce_flat_int_token_ids(sample.tokens)
         else:
-            prompt_field = prompt_ids
-        payload = _build_completion_payload(args, params, prompt_field)
-        with trace_span(sample, "vllm_completions", attrs={"max_new_tokens": params["max_new_tokens"]}):
+            token_ids = prompt_ids
+        payload = build_inference_payload(args, params, token_ids)
+        with trace_span(sample, "vllm_inference_generate", attrs={"max_new_tokens": params["max_new_tokens"]}):
             output = await post(url, payload, headers=headers)
-        choice = output["choices"][0]
-        text = choice.get("text") or ""
-        usage = output.get("usage")
-        meta = _openai_meta_from_completion_choice(args, choice, usage)
-        new_response_tokens, new_response_log_probs = _vllm_engine_tokens_and_logprobs(
-            state.tokenizer, choice, text, is_chat=False
-        )
-        new_response_tokens, new_response_log_probs = _align_engine_tokens_and_logprobs(
-            new_response_tokens, new_response_log_probs
-        )
+
+    choice = output["choices"][0]
+    skip_sp = params.get("skip_special_tokens")
+    skip_decode = True if skip_sp is None else bool(skip_sp)
+    out_ids = choice.get("token_ids") or []
+    text = (
+        state.tokenizer.decode(out_ids, skip_special_tokens=skip_decode)
+        if isinstance(out_ids, list) and out_ids
+        else ""
+    )
+    meta = _vllm_meta_from_generate_choice(args, choice, output.get("usage"))
+    new_response_tokens, new_response_log_probs = _inference_generate_tokens_and_logprobs(choice)
+    new_response_tokens, new_response_log_probs = _align_engine_tokens_and_logprobs(
+        new_response_tokens, new_response_log_probs
+    )
 
     if new_response_tokens:
         meta["output_token_logprobs"] = [

--- a/slime/rollout/vllm_rollout.py
+++ b/slime/rollout/vllm_rollout.py
@@ -1,6 +1,8 @@
 import asyncio
+import base64
 import copy
 import inspect
+import io
 import json
 import logging
 import uuid
@@ -158,6 +160,11 @@ def _vllm_meta_from_generate_choice(args: Namespace, choice: dict, usage: dict |
     return meta
 
 
+def _decode_vllm_routed_experts(value: str) -> np.ndarray:
+    raw = base64.b64decode(value.encode("ascii"), validate=True)
+    return np.load(io.BytesIO(raw), allow_pickle=False)
+
+
 def _apply_vllm_routed_experts(
     args: Namespace,
     sample: Sample,
@@ -166,18 +173,16 @@ def _apply_vllm_routed_experts(
 ) -> None:
     """Populate ``sample.rollout_routed_experts`` from vLLM ``choices[].routed_experts`` when enabled.
 
-    TODO: cherry-pick https://github.com/vllm-project/vllm/pull/39568 for routed experts over
-    ``/inference/v1/generate``. With that support, vLLM exposes MoE routing replay on each
-    response choice. The routing tensor covers generated positions as
-    ``[num_positions, num_layers, topk]``; there is no separate ``prompt_routed_experts`` key in
-    this rollout path.
+    vLLM ``/inference/v1/generate`` returns routed experts as a base64 encoded
+    ``.npy`` payload on each response choice when the server is launched with
+    ``--enable-return-routed-experts``.
     """
     if not getattr(args, "use_rollout_routing_replay", False):
         return
     gen_re = choice.get("routed_experts")
     if gen_re is None:
         return
-    arr = np.asarray(gen_re, dtype=np.int32)
+    arr = _decode_vllm_routed_experts(gen_re)
     n_tok = len(sample.tokens)
     expected_rows = max(0, n_tok - 1)
     if arr.ndim != 3:

--- a/slime/rollout/vllm_rollout.py
+++ b/slime/rollout/vllm_rollout.py
@@ -344,15 +344,6 @@ def _build_inference_sampling_params(sampling_params: dict[str, Any]) -> dict[st
     return sp
 
 
-def build_inference_payload(args: Namespace, sampling_params: dict[str, Any], token_ids: list[int]) -> dict[str, Any]:
-    """Build a vLLM ``/inference/v1/generate`` request body for token-only rollout."""
-    return {
-        "model": args.hf_checkpoint,
-        "token_ids": token_ids,
-        "sampling_params": _build_inference_sampling_params(sampling_params),
-    }
-
-
 def _mm_render_response_to_generate_body(render_data: Any, model: str) -> dict[str, Any]:
     """Turn ``/v1/chat/completions/render`` JSON into a ``/inference/v1/generate`` request body (minus ``sampling_params``).
 
@@ -418,6 +409,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
     if params["max_new_tokens"] == 0:
         sample.status = Sample.Status.TRUNCATED
         return sample
+    inference_sampling_params = _build_inference_sampling_params(params)
 
     images = sample.multimodal_inputs.get("images") if sample.multimodal_inputs else None
 
@@ -446,7 +438,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         with trace_span(sample, "vllm_mm_render", attrs={"model": args.hf_checkpoint}):
             render_data = await post(render_url, render_payload, headers=headers)
         generate_body = _mm_render_response_to_generate_body(render_data, args.hf_checkpoint)
-        generate_body["sampling_params"] = _build_inference_sampling_params(params)
+        generate_body["sampling_params"] = inference_sampling_params
         gen_url = f"{base}/inference/v1/generate"
         with trace_span(sample, "vllm_mm_generate", attrs={"max_tokens": params["max_new_tokens"]}):
             output = await post(gen_url, generate_body, headers=headers)
@@ -458,7 +450,11 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
             token_ids = _coerce_flat_int_token_ids(sample.tokens)
         else:
             token_ids = prompt_ids
-        payload = build_inference_payload(args, params, token_ids)
+        payload = {
+            "model": args.hf_checkpoint,
+            "token_ids": token_ids,
+            "sampling_params": inference_sampling_params,
+        }
         with trace_span(sample, "vllm_inference_generate", attrs={"max_new_tokens": params["max_new_tokens"]}):
             output = await post(url, payload, headers=headers)
 

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1821,10 +1821,6 @@ def slime_validate_args(args):
             args.rollout_function_path = "slime.rollout.vllm_rollout.generate_rollout"
         if args.eval_function_path == "slime.rollout.sglang_rollout.generate_rollout":
             args.eval_function_path = "slime.rollout.vllm_rollout.generate_rollout"
-        if args.use_rollout_routing_replay:
-            raise ValueError(
-                "TODO: add https://github.com/vllm-project/vllm/pull/39568 to support rollout routing replay in /inference/v1/generate. "
-            )
 
     if args.num_steps_per_rollout is not None:
         global_batch_size = args.rollout_batch_size * args.n_samples_per_prompt // args.num_steps_per_rollout

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1821,6 +1821,10 @@ def slime_validate_args(args):
             args.rollout_function_path = "slime.rollout.vllm_rollout.generate_rollout"
         if args.eval_function_path == "slime.rollout.sglang_rollout.generate_rollout":
             args.eval_function_path = "slime.rollout.vllm_rollout.generate_rollout"
+        if args.use_rollout_routing_replay:
+            raise ValueError(
+                "TODO: add https://github.com/vllm-project/vllm/pull/39568 to support rollout routing replay in /inference/v1/generate. "
+            )
 
     if args.num_steps_per_rollout is not None:
         global_batch_size = args.rollout_batch_size * args.n_samples_per_prompt // args.num_steps_per_rollout

--- a/tests/test_vllm_generate_endpoint.py
+++ b/tests/test_vllm_generate_endpoint.py
@@ -117,6 +117,7 @@ def _execute_case(case: VLLMGenerateCase):
         rollout_num_gpus_per_engine=case.num_gpus,
         seed=1234,
         vllm_gpu_memory_utilization=0.9,
+        vllm_async_scheduling=False,
         vllm_enforce_eager=False,
         rollout_max_context_len=case.max_model_len,
         use_rollout_routing_replay=case.use_rollout_routing_replay,
@@ -137,9 +138,9 @@ def _execute_case(case: VLLMGenerateCase):
         rollout_args = Namespace(
             ci_test=False,
             hf_checkpoint=case.model_path,
-            sglang_router_ip="127.0.0.1",
-            sglang_router_port=server_port,
-            sglang_server_concurrency=512,
+            router_ip="127.0.0.1",
+            router_port=server_port,
+            vllm_server_concurrency=512,
             rollout_num_gpus=case.num_gpus,
             rollout_num_gpus_per_engine=case.num_gpus,
             rollout_temperature=0.0,
@@ -149,9 +150,9 @@ def _execute_case(case: VLLMGenerateCase):
             rollout_stop=None,
             rollout_stop_token_ids=None,
             rollout_skip_special_tokens=True,
-            sglang_dp_size=1,
+            vllm_dp_size=1,
             use_rollout_routing_replay=case.use_rollout_routing_replay,
-            sglang_speculative_algorithm=None,
+            vllm_speculative_config=None,
             use_distributed_post=False,
         )
         sampling_params = {

--- a/tests/test_vllm_generate_endpoint.py
+++ b/tests/test_vllm_generate_endpoint.py
@@ -1,0 +1,209 @@
+"""
+Runtime check for the vLLM rollout data path.
+
+This test launches a real vLLM server through ``vllm_engine.launch_server_process``
+and then calls ``vllm_rollout.generate``. It specifically verifies that the
+rollout client can use vLLM's token-only ``/inference/v1/generate`` endpoint.
+"""
+
+import asyncio
+import os
+import socket
+from argparse import Namespace
+from dataclasses import dataclass
+
+import slime.utils.external_utils.command_utils as U
+from slime.backends.vllm_utils.vllm_engine import _wait_server_healthy, launch_server_process
+from slime.rollout import vllm_rollout
+from slime.utils import http_utils
+from slime.utils.types import Sample
+
+
+@dataclass(frozen=True)
+class VLLMGenerateCase:
+    name: str
+    hf_repo: str
+    model_path: str
+    num_gpus: int
+    prompt: str
+    use_rollout_routing_replay: bool = False
+    max_model_len: int = 1024
+    max_new_tokens: int = 8
+    timeout_s: float = 600.0
+
+
+CASES = [
+    VLLMGenerateCase(
+        name="qwen3-0.6b",
+        hf_repo="Qwen/Qwen3-0.6B",
+        model_path="/root/models/Qwen3-0.6B",
+        num_gpus=1,
+        prompt="The capital of France is",
+    ),
+    VLLMGenerateCase(
+        name="qwen3-30b-a3b",
+        hf_repo="Qwen/Qwen3-30B-A3B",
+        model_path="/root/models/Qwen3-30B-A3B",
+        num_gpus=1,
+        prompt="Solve: 1 + 1 =",
+    ),
+    VLLMGenerateCase(
+        name="qwen3-30b-a3b-r3",
+        hf_repo="Qwen/Qwen3-30B-A3B",
+        model_path="/root/models/Qwen3-30B-A3B",
+        num_gpus=1,
+        prompt="Solve: 2 + 3 =",
+        use_rollout_routing_replay=True,
+    ),
+]
+CASES_BY_NAME = {case.name: case for case in CASES}
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _visible_devices(num_gpus: int) -> str:
+    visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if visible_devices:
+        return ",".join(visible_devices.split(",")[:num_gpus])
+    return ",".join(str(i) for i in range(num_gpus))
+
+
+def _stop_process_tree(process) -> None:
+    if not process.is_alive():
+        return
+    try:
+        from vllm.utils.system_utils import kill_process_tree
+
+        kill_process_tree(process.pid)
+    except Exception:
+        process.terminate()
+    process.join(timeout=30)
+    if process.is_alive():
+        process.kill()
+        process.join(timeout=10)
+
+
+async def _generate_with_http_client(rollout_args, sample: Sample, sampling_params: dict):
+    http_utils.init_http_client(rollout_args)
+    try:
+        return await vllm_rollout.generate(rollout_args, sample, sampling_params)
+    finally:
+        if http_utils._http_client is not None:
+            await http_utils._http_client.aclose()
+            http_utils._http_client = None
+
+
+def prepare():
+    U.exec_command("mkdir -p /root/models")
+    seen_model_paths = set()
+    for case in CASES:
+        if case.model_path in seen_model_paths:
+            continue
+        seen_model_paths.add(case.model_path)
+        if not os.path.exists(case.model_path):
+            U.exec_command(f"hf download {case.hf_repo} --local-dir {case.model_path}")
+
+
+def _execute_case(case: VLLMGenerateCase):
+    if not os.path.exists(case.model_path):
+        U.exec_command(f"hf download {case.hf_repo} --local-dir {case.model_path}")
+
+    server_port = _free_port()
+    server_args = Namespace(
+        rollout_num_gpus_per_engine=case.num_gpus,
+        seed=1234,
+        vllm_gpu_memory_utilization=0.9,
+        vllm_enforce_eager=False,
+        rollout_max_context_len=case.max_model_len,
+        use_rollout_routing_replay=case.use_rollout_routing_replay,
+    )
+
+    process = launch_server_process(
+        bind_host="127.0.0.1",
+        server_port=server_port,
+        args=server_args,
+        rank=0,
+        visible_devices=_visible_devices(case.num_gpus),
+        model_path=case.model_path,
+    )
+
+    try:
+        _wait_server_healthy(f"http://127.0.0.1:{server_port}", process, timeout_s=case.timeout_s)
+
+        rollout_args = Namespace(
+            ci_test=False,
+            hf_checkpoint=case.model_path,
+            sglang_router_ip="127.0.0.1",
+            sglang_router_port=server_port,
+            sglang_server_concurrency=512,
+            rollout_num_gpus=case.num_gpus,
+            rollout_num_gpus_per_engine=case.num_gpus,
+            rollout_temperature=0.0,
+            rollout_top_p=1.0,
+            rollout_top_k=-1,
+            rollout_max_response_len=case.max_new_tokens,
+            rollout_stop=None,
+            rollout_stop_token_ids=None,
+            rollout_skip_special_tokens=True,
+            sglang_dp_size=1,
+            use_rollout_routing_replay=case.use_rollout_routing_replay,
+            sglang_speculative_algorithm=None,
+            use_distributed_post=False,
+        )
+        sampling_params = {
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "top_k": -1,
+            "max_new_tokens": case.max_new_tokens,
+            "stop": None,
+            "stop_token_ids": None,
+            "skip_special_tokens": True,
+        }
+
+        # Ensure a previous GenerateState singleton from an in-process runner
+        # cannot keep stale tokenizer/router args.
+        vllm_rollout.GenerateState.clear_instances()
+        sample = asyncio.run(
+            _generate_with_http_client(
+                rollout_args,
+                Sample(index=0, prompt=case.prompt),
+                sampling_params,
+            )
+        )
+
+        assert sample.response_length > 0
+        assert sample.rollout_log_probs is not None
+        assert len(sample.rollout_log_probs) == sample.response_length
+        assert sample.status in (Sample.Status.COMPLETED, Sample.Status.TRUNCATED)
+        if case.use_rollout_routing_replay:
+            assert sample.rollout_routed_experts is not None
+    finally:
+        _stop_process_tree(process)
+
+
+def test_qwen3_0_6b_vllm_inference_generate_endpoint():
+    _execute_case(CASES_BY_NAME["qwen3-0.6b"])
+
+
+def test_qwen3_30b_a3b_vllm_inference_generate_endpoint():
+    _execute_case(CASES_BY_NAME["qwen3-30b-a3b"])
+
+
+def test_qwen3_30b_a3b_r3_vllm_inference_generate_endpoint():
+    _execute_case(CASES_BY_NAME["qwen3-30b-a3b-r3"])
+
+
+def execute():
+    for case in CASES:
+        _execute_case(case)
+
+
+if __name__ == "__main__":
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    prepare()
+    execute()


### PR DESCRIPTION
## Description

This PR switches the vLLM text-only rollout path from the OpenAI-compatible /v1/completions endpoint to the SkyRL style token-only /inference/v1/generate endpoint.

The new path tokenizes prompts on the rollout client side, sends token_ids to vLLM, and parses generated token ids and per-token logprobs directly from the `/inference/v1/generate` response. This also aligns the vLLM rollout behavior with the existing SGLang text-only rollout style, where the rollout client owns tokenization and the server receives token ids.

More reasons about why use `inference/v1/generate` instead of `/v1/completions`:
- RL is sensitive to tokens. A word may be tokenized into different tokens. Better follow "Token in Token out" paradim. `/inference/v1/generate` is designed for this, see https://github.com/vllm-project/vllm/issues/22817 .
- It reduces dependency on OpenAI-compatible completion schema for RL training data construction.
- For multimodal rollout, /v1/completions is not a natural fit because it has no native multimodal request schema. See SkyRL's practice here: https://www.anyscale.com/blog/vision-language-model-reinforcement-learning-skyrl .
- Follow slime/sglang and SkyRL design.

## Changes

- Replace text-only vLLM rollout request URL from /v1/completions to /inference/v1/generate.
- Delete all related to `/v1/completions`.

**Note:**

This PR only targets the text-only vLLM rollout path. **Multimodal rollout is not part of this change.** The existing multimodal flow still uses: /v1/chat/completions/render -> /inference/v1/generate in SkyRL.

**Routed experts support is currently not supported in `/inference/v1/generate` in v0.20.2. So please don't merge this pr currently. It is in https://github.com/vllm-project/vllm/pull/39568.** Once it is released in next version. I will keep doing this pr.