### PR TITLE
dockerfile: cu12 base for vllm rollout (vllm/vllm-openai:v0.21.0-cu129)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -117,8 +117,10 @@ RUN cd Megatron-LM && \
 
 # ====================================== Install main package ============================================
 
-COPY . /root/slime
-RUN cd /root/slime && \
+ARG VIME_COMMIT=main
+RUN git clone https://github.com/vllm-project/vime.git /root/slime && \
+    cd /root/slime && \
+    git checkout ${VIME_COMMIT} && \
     pip install -e . --no-deps
 
 RUN cd /root/slime/slime/backends/megatron_utils/kernels/int4_qat && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,122 +1,179 @@
-ARG SGLANG_IMAGE_TAG=v0.5.10.post1
-FROM slimerl/sglang:${SGLANG_IMAGE_TAG} AS sglang
+ARG BASE_IMAGE=vllm/vllm-openai:v0.21.0-cu129-ubuntu2404
+FROM ${BASE_IMAGE}
 
 # ======================================== Arguments =============================================
 
-ARG PATCH_VERSION=latest
+# MEGATRON_COMMIT + PATCH_VERSION track slime upstream's docker/Dockerfile
+# (slime 1dcf0da / patch latest as of 2026-02-14). vllm 0.21 cu129 base gives
+# us torch 2.11.0+cu129, libcudart.so.12 natively, vllm + vllm-router pre-installed.
 ARG MEGATRON_COMMIT=1dcf0dafa884ad52ffb243625717a3471643e087
+ARG PATCH_VERSION=latest
 
-ARG ENABLE_CUDA_13=0
+# Pinned to match slime upstream Dockerfile for parity (sglang here is install-on-top
+# via --no-deps; the cu129 base ships vllm, not sglang).
+ARG SGLANG_VERSION=0.5.10.post1
+ARG SLIME_TORCH_MEMORY_SAVER_COMMIT=d64a639
 
-# ======================================== Setup =============================================
+SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
 
 WORKDIR /root/
 
 # ======================================== Apt dependencies =============================================
 
-RUN apt update
-RUN apt install -y nvtop rsync dnsutils
+# TE 2.10 has no prebuilt wheel — always builds from source.  vllm/vllm-openai
+# base is an inference image, so the cu12 dev-header collection needed by the TE
+# source build (cusparse / cusolver / cufft / curand / cudnn / nvrtc / nvml /
+# profiler-api / nvtx) has to be installed explicitly.  cuda-cudart-12-9 is
+# already present in the base.  cmake / ninja / build-essential drive apex +
+# flash-attn 2/3 source builds.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      git rsync dnsutils nvtop \
+      cmake ninja-build build-essential \
+      cuda-nvrtc-dev-12-9 cuda-nvml-dev-12-9 cuda-profiler-api-12-9 cuda-nvtx-12-9 \
+      libcusparse-dev-12-9 libcusolver-dev-12-9 libcufft-dev-12-9 libcurand-dev-12-9 \
+      libcudnn9-dev-cuda-12 && \
+    rm -rf /var/lib/apt/lists/*
+
+# python → python3 symlink early so subsequent source builds (flash-attn hopper,
+# apex) that invoke `python` succeed. slime upstream's base (slimerl/sglang) has
+# this symlink already; vllm/vllm-openai base only ships python3.
+RUN ln -sf /usr/bin/python3 /usr/local/bin/python
 
 # ====================================== Python dependencies ============================================
 
-# The compilation is slow, thus should be put at top
-# TransformerEngines does not support too high FA2
+# flash-attn 2.7.4.post1 — slime upstream parity. TE 2.10 doesn't support newer
+# FA2 majors, so this version is the ceiling. Source compile (~3-5 min with MAX_JOBS).
 RUN MAX_JOBS=64 pip -v install flash-attn==2.7.4.post1 --no-build-isolation
 
-# The compilation is slow, thus should be put at top
+# flash-attn 3 hopper kernels — slime upstream parity. Source compile from the
+# dao-AILab/flash-attention `hopper/` subdir at the pinned commit. Installed under
+# `flash_attn_3/` so callers explicitly opt in (slime does, vllm has its own FA3 path).
 RUN git clone https://github.com/Dao-AILab/flash-attention.git && \
-    cd flash-attention/ && git checkout fbf24f67cf7f6442c5cfb2c1057f4bfc57e72d89 && git submodule update --init && cd hopper/ && \
+    cd flash-attention/ && \
+    git checkout fbf24f67cf7f6442c5cfb2c1057f4bfc57e72d89 && \
+    git submodule update --init && \
+    cd hopper/ && \
     MAX_JOBS=96 python setup.py install && \
-    export python_path=`python -c "import site; print(site.getsitepackages()[0])"` && \
+    python_path=$(python -c "import site; print(site.getsitepackages()[0])") && \
     mkdir -p $python_path/flash_attn_3 && \
     cp flash_attn_interface.py $python_path/flash_attn_3/flash_attn_interface.py && \
-    rm -rf flash-attention/
+    rm -rf /root/flash-attention/
 
-RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
+# TransformerEngine 2.10 — cu12 wheel is available, no source compile.
+RUN pip -v install --no-build-isolation "transformer_engine[pytorch]==2.10.0"
 
-RUN pip install flash-linear-attention==0.4.1
-RUN pip install tilelang -f https://tile-ai.github.io/whl/nightly/cu128/
-
-# TE does not have wheel on cuda 13 yet, thus need to install from source
-RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
-      pip install nvidia-mathdx==26.6.0 && \
-      pip -v install --no-build-isolation git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.10; \
-    else \
-      pip -v install --no-build-isolation "transformer_engine[pytorch]==2.10.0"; \
-    fi
-
+# apex from source — slime upstream parity. Enables rope/grad fusion in Megatron;
+# without this, launcher must pass --no-rope-fusion --no-gradient-accumulation-fusion.
+# Slow (~10 min) but cached on rebuild.
 RUN NVCC_APPEND_FLAGS="--threads 4" \
-  pip -v install --disable-pip-version-check --no-cache-dir \
-  --no-build-isolation \
-  --config-settings "--build-option=--cpp_ext --cuda_ext --parallel 8" git+https://github.com/NVIDIA/apex.git@10417aceddd7d5d05d7cbf7b0fc2daad1105f8b4
+    pip -v install --disable-pip-version-check --no-cache-dir --no-build-isolation \
+    --config-settings "--build-option=--cpp_ext --cuda_ext --parallel 8" \
+    git+https://github.com/NVIDIA/apex.git@10417aceddd7d5d05d7cbf7b0fc2daad1105f8b4
 
-RUN git clone https://github.com/NVIDIA/Megatron-LM.git --recursive && \
-    cd Megatron-LM && git checkout ${MEGATRON_COMMIT} && \
-    pip install -e .
+# Megatron-LM (clone now, patch + install after the patch COPY layer below).
+RUN git clone https://github.com/NVIDIA/Megatron-LM.git --recursive /root/Megatron-LM && \
+    cd /root/Megatron-LM && \
+    git checkout "${MEGATRON_COMMIT}"
 
-RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@d64a639 --no-cache-dir --force-reinstall
-RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@bridge --no-deps --no-build-isolation
-RUN pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation
-
-# This patch from masahi will be included in later Triton releases
-RUN if [ "$ENABLE_CUDA_13" = "1" ]; then \
-    (cd /root && git clone -b feat/v350_plus_8045 https://github.com/fzyzcjy/triton.git && cd triton && pip install -r python/requirements.txt && pip install --verbose -e .); \
-  fi
-
-COPY requirements.txt /tmp/requirements.txt
-RUN pip install --ignore-installed PyJWT && \
-    pip install -r /tmp/requirements.txt
-
-# Temporarily install another sgl-kernel version for GB300 without rebuilding the whole image
-RUN if [ "$ENABLE_CUDA_13" = "1" ]; then \
-    SGL_KERNEL_VERSION=0.3.17.post2 && \
-    python3 -m pip install https://github.com/sgl-project/whl/releases/download/v${SGL_KERNEL_VERSION}/sgl_kernel-${SGL_KERNEL_VERSION}+cu130-cp310-abi3-manylinux2014_$(uname -m).whl --force-reinstall --no-deps; \
-  fi
-
-# https://github.com/pytorch/pytorch/issues/168167
-RUN pip install nvidia-cudnn-cu12==9.16.0.29
-
-# reinstall numpy 1.x for megatron
-RUN pip install "numpy<2"
-
-RUN pip install https://github.com/zhuzilin/sgl-router/releases/download/v0.3.2-5f8d397/sglang_router-0.3.2-cp38-abi3-manylinux_2_28_x86_64.whl --force-reinstall
-RUN python -c "import sglang_router; assert 'slime' in sglang_router.__version__"
-
-RUN rm -rf /root/.cache/pip /root/flash-attention
-
-# ====================================== Patches ============================================
-
-COPY docker/patch/${PATCH_VERSION}/megatron.patch /root/Megatron-LM/
-RUN cd Megatron-LM && \
+# Apply slime's Megatron patch.
+COPY docker/patch/${PATCH_VERSION}/megatron.patch /root/Megatron-LM/megatron.patch
+RUN cd /root/Megatron-LM && \
     git update-index --refresh && \
     git apply megatron.patch --3way && \
     if grep -R -n '^<<<<<<< ' .; then \
-      echo "Patch failed to apply cleanly. Please resolve conflicts." && \
+      echo "Megatron patch failed to apply cleanly. Please resolve conflicts." && \
       exit 1; \
     fi && \
-    rm megatron.patch
-
-# TODO temporarily skip patching for GB200/GB300 (and require users to bring their own sglang version). should add back later.
-ARG ENABLE_SGLANG_PATCH=1
-COPY docker/patch/${PATCH_VERSION}/sglang.patch /sgl-workspace/sglang/
-RUN if [ "$ENABLE_SGLANG_PATCH" = "1" ]; then \
-  cd /sgl-workspace/sglang && \
-  git update-index --refresh && \
-  git apply sglang.patch --3way && \
-  if grep -R -n '^<<<<<<< ' .; then \
-    echo "Patch failed to apply cleanly. Please resolve conflicts." && \
-    exit 1; \
-  fi && \
-  rm sglang.patch; \
-fi
-
-# ====================================== Install main package ============================================
-
-ARG SLIME_COMMIT=main
-RUN git clone https://github.com/THUDM/slime.git /root/slime && \
-    cd /root/slime && \
-    git checkout ${SLIME_COMMIT} && \
+    rm megatron.patch && \
     pip install -e . --no-deps
 
-RUN cd /root/slime/slime/backends/megatron_utils/kernels/int4_qat && \
-    pip install . --no-build-isolation
+# torch_memory_saver from source (slime parity) — pypi wheel ships cu12 binary so
+# would work too, but slime uses the source build for newer features.
+RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@${SLIME_TORCH_MEMORY_SAVER_COMMIT} --no-cache-dir --force-reinstall
+
+# mbridge + Megatron-Bridge + modelopt — needed by slime's --megatron-to-hf-mode bridge
+# checkpoint load path.
+RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps && \
+    pip install git+https://github.com/radixark/Megatron-Bridge.git@bridge --no-deps --no-build-isolation && \
+    pip install "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
+
+# fla + tilelang — linear-attention model variants (slime_plugins/models/qwen3_5.py,
+# qwen3_next.py). cu12 native wheels here, no version skew vs base.
+RUN pip install flash-linear-attention==0.4.1 && \
+    pip install tilelang -f https://tile-ai.github.io/whl/nightly/cu128/
+
+# sglang stubs — vime's slime/utils/arguments.py + slime/ray/rollout.py still import
+# sglang_router at module load. Install --no-deps so it doesn't drag a full sglang
+# stack into the cu12 environment. vllm rollout doesn't actually exercise sglang code.
+RUN pip install --no-deps "sglang==${SGLANG_VERSION}" sglang-router==0.3.2 && \
+    pip install IPython
+
+# pytorch issue #168167 workaround (slime upstream's pin).
+RUN pip install nvidia-cudnn-cu12==9.16.0.29
+
+# Megatron requires numpy 1.x.
+RUN pip install "numpy<2"
+
+# Install slime runtime requirements while excluding the sglang lines (we ship the
+# stub via --no-deps above; the requirements file pulls sglang's full transitive set
+# which conflicts with the vllm-base environment).
+COPY requirements.txt /tmp/slime-requirements.txt
+RUN python3 - <<'PY' && \
+    python3 -m pip install -r /tmp/slime-requirements-vllm.txt
+from pathlib import Path
+
+source = Path("/tmp/slime-requirements.txt")
+target = Path("/tmp/slime-requirements-vllm.txt")
+skip_prefixes = ("sglang", "sglang-router")
+
+lines = []
+for raw_line in source.read_text().splitlines():
+    normalized = raw_line.split("#", 1)[0].strip().lower()
+    if normalized.startswith(skip_prefixes):
+        continue
+    lines.append(raw_line)
+
+target.write_text("\n".join(lines) + "\n")
+PY
+
+ENV PYTHONPATH="/root/Megatron-LM:${PYTHONPATH}"
+
+# pytest for in-container test runs. (python symlink is set early, above.)
+RUN python3 -m pip install pytest
+
+# Install slime itself last so changes to the source don't bust earlier layers.
+COPY . /root/slime
+RUN cd /root/slime && \
+    pip install -e . --no-deps
+
+WORKDIR /root/slime
+
+# Build-time smoke: catch missing imports here instead of at first `docker run`.
+RUN python3 - <<'PY'
+import importlib.metadata as metadata
+import vllm
+print("vllm import ok", getattr(vllm, "__version__", metadata.version("vllm")))
+print("sglang version", metadata.version("sglang"))
+print("sglang_router version", metadata.version("sglang-router"))
+print("transformer_engine version", metadata.version("transformer_engine"))
+print("torch", __import__("torch").__version__)
+import flash_attn  # noqa: F401
+print("flash_attn import ok", flash_attn.__version__)
+import apex  # noqa: F401
+print("apex import ok")
+import sglang  # noqa: F401
+print("sglang import ok", sglang.__version__)
+import sglang_router  # noqa: F401
+print("sglang_router import ok", sglang_router.__version__)
+from megatron.bridge import AutoBridge  # noqa: F401
+print("megatron.bridge import ok")
+import slime  # noqa: F401
+print("slime import ok")
+PY
+
+# Reset ENTRYPOINT inherited from vllm/vllm-openai base (which sets
+# `["vllm serve"]`). Without this, every `docker run <image> <cmd>` invocation
+# gets `<cmd>` interpreted as an argument to `vllm serve`.
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,11 +13,10 @@ WORKDIR /root/
 
 # ======================================== Apt dependencies =============================================
 
-# vllm/vllm-openai base is an inference image — install cu12 dev headers so
-# TE / apex / flash-attn source builds find cusparse.h etc.
+# vllm/vllm-openai base is an inference image — add cu12 dev headers + cmake/git
+# so TE / apex / flash-attn source builds find cusparse.h etc.
 RUN apt update
-RUN apt install -y nvtop rsync dnsutils git \
-    cmake ninja-build build-essential \
+RUN apt install -y nvtop rsync dnsutils git cmake \
     cuda-nvrtc-dev-12-9 cuda-nvml-dev-12-9 cuda-profiler-api-12-9 cuda-nvtx-12-9 \
     libcusparse-dev-12-9 libcusolver-dev-12-9 libcufft-dev-12-9 libcurand-dev-12-9 \
     libcudnn9-dev-cuda-12
@@ -56,7 +55,7 @@ RUN git clone https://github.com/NVIDIA/Megatron-LM.git --recursive && \
     cd Megatron-LM && git checkout ${MEGATRON_COMMIT} && \
     pip install -e .
 
-RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@d64a639 --no-cache-dir --force-reinstall
+RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@a193d9dd1b877d33c64a41cfb3db9f867df2d926 --no-cache-dir --force-reinstall
 RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@bridge --no-deps --no-build-isolation
 RUN pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation
 
@@ -71,8 +70,7 @@ RUN pip install nvidia-cudnn-cu12==9.16.0.29
 # reinstall numpy 1.x for megatron
 RUN pip install "numpy<2"
 
-# Filter out sglang lines from requirements; we ship the --no-deps stub separately
-# and the full sglang transitive set conflicts with the vllm base environment.
+# Skip sglang lines (we install --no-deps above; the full transitive set conflicts).
 COPY requirements.txt /tmp/slime-requirements.txt
 RUN python3 - <<'PY' && \
     python3 -m pip install -r /tmp/slime-requirements-vllm.txt
@@ -108,11 +106,12 @@ RUN cd Megatron-LM && \
 
 # ====================================== Install main package ============================================
 
-RUN python3 -m pip install pytest
-
 COPY . /root/slime
 RUN cd /root/slime && \
     pip install -e . --no-deps
+
+RUN cd /root/slime/slime/backends/megatron_utils/kernels/int4_qat && \
+    pip install . --no-build-isolation
 
 WORKDIR /root/slime
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,11 +17,12 @@ WORKDIR /root/
 
 # vllm/vllm-openai base is an inference image — add cu12 dev headers + cmake/git
 # so TE / apex / flash-attn source builds find cusparse.h etc.
-RUN apt update
-RUN apt install -y nvtop rsync dnsutils git cmake \
+RUN apt-get update && apt-get install -y \
+    nvtop rsync dnsutils git cmake \
     cuda-nvrtc-dev-12-9 cuda-nvml-dev-12-9 cuda-profiler-api-12-9 cuda-nvtx-12-9 \
     libcusparse-dev-12-9 libcusolver-dev-12-9 libcufft-dev-12-9 libcurand-dev-12-9 \
-    libcudnn9-dev-cuda-12
+    libcudnn9-dev-cuda-12 && \
+    rm -rf /var/lib/apt/lists/*
 
 # vllm/vllm-openai base only ships python3; subsequent source builds invoke `python`.
 RUN ln -sf /usr/bin/python3 /usr/local/bin/python
@@ -60,8 +61,7 @@ RUN NVCC_APPEND_FLAGS="--threads 4" \
   --config-settings "--build-option=--cpp_ext --cuda_ext --parallel 8" git+https://github.com/NVIDIA/apex.git@10417aceddd7d5d05d7cbf7b0fc2daad1105f8b4
 
 RUN git clone https://github.com/NVIDIA/Megatron-LM.git --recursive && \
-    cd Megatron-LM && git checkout ${MEGATRON_COMMIT} && \
-    pip install -e .
+    cd Megatron-LM && git checkout ${MEGATRON_COMMIT}
 
 # Pinned to d64a639 (older than slime upstream's a193d9d); the newer commit
 # requires TMS_CUDA_MAJOR env var to build a multi-CUDA wheel.
@@ -102,6 +102,8 @@ RUN rm -rf /root/.cache/pip
 
 # ====================================== Patches ============================================
 
+# Patch megatron BEFORE pip install -e . so any patch hunks that touch setup.py
+# or C++/CUDA extensions are picked up by the build.
 COPY docker/patch/${PATCH_VERSION}/megatron.patch /root/Megatron-LM/
 RUN cd Megatron-LM && \
     git update-index --refresh && \
@@ -110,12 +112,11 @@ RUN cd Megatron-LM && \
       echo "Patch failed to apply cleanly. Please resolve conflicts." && \
       exit 1; \
     fi && \
-    rm megatron.patch
+    rm megatron.patch && \
+    pip install -e .
 
 # ====================================== Install main package ============================================
 
-# vime is a private repo, so git clone in build context isn't an option;
-# COPY the local working tree into the image.
 COPY . /root/slime
 RUN cd /root/slime && \
     pip install -e . --no-deps

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -98,6 +98,10 @@ RUN pip install "numpy<2"
 RUN pip install --no-deps "sglang==${SGLANG_VERSION}" sglang-router==0.3.2 && \
     pip install IPython
 
+# Pin vllm-router explicitly so the vllm rollout routing layer is a visible build step
+# (also in requirements.txt; pulling it here makes the layer cache-able and fail-fast).
+RUN pip install "vllm-router>=0.1.14"
+
 RUN rm -rf /root/.cache/pip
 
 # ====================================== Patches ============================================
@@ -125,6 +129,22 @@ RUN git clone https://github.com/vllm-project/vime.git /root/slime && \
 
 RUN cd /root/slime/slime/backends/megatron_utils/kernels/int4_qat && \
     pip install . --no-build-isolation
+
+# ====================================== Build-time smoke ============================================
+
+# Fail-fast import smoke + flashinfer version pin check. Catches ABI / version
+# regressions at build time instead of first GPU run.
+RUN python3 -c "\
+import vllm, sglang, slime, flashinfer; \
+from slime.backends.vllm_utils.vllm_engine import VLLMEngine; \
+print('vllm', vllm.__version__); \
+print('sglang', sglang.__version__); \
+print('flashinfer', flashinfer.__version__); \
+print('VLLMEngine import ok')"
+
+# Megatron stream serialization. vllm rollout + megatron actor co-located on
+# the same GPU need this; default value causes stream-level contention.
+ENV CUDA_DEVICE_MAX_CONNECTIONS=1
 
 # Reset ENTRYPOINT inherited from vllm/vllm-openai base (`vllm serve`).
 ENTRYPOINT []

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ARG PATCH_VERSION=latest
 ARG MEGATRON_COMMIT=1dcf0dafa884ad52ffb243625717a3471643e087
 ARG SGLANG_VERSION=0.5.10.post1
 
-SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
+# ======================================== Setup =============================================
 
 WORKDIR /root/
 
@@ -15,14 +15,12 @@ WORKDIR /root/
 
 # vllm/vllm-openai base is an inference image — install cu12 dev headers so
 # TE / apex / flash-attn source builds find cusparse.h etc.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      git rsync dnsutils nvtop \
-      cmake ninja-build build-essential \
-      cuda-nvrtc-dev-12-9 cuda-nvml-dev-12-9 cuda-profiler-api-12-9 cuda-nvtx-12-9 \
-      libcusparse-dev-12-9 libcusolver-dev-12-9 libcufft-dev-12-9 libcurand-dev-12-9 \
-      libcudnn9-dev-cuda-12 && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt update
+RUN apt install -y nvtop rsync dnsutils git \
+    cmake ninja-build build-essential \
+    cuda-nvrtc-dev-12-9 cuda-nvml-dev-12-9 cuda-profiler-api-12-9 cuda-nvtx-12-9 \
+    libcusparse-dev-12-9 libcusolver-dev-12-9 libcufft-dev-12-9 libcurand-dev-12-9 \
+    libcudnn9-dev-cuda-12
 
 # vllm/vllm-openai base only ships python3; subsequent source builds invoke `python`.
 RUN ln -sf /usr/bin/python3 /usr/local/bin/python

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,8 @@ ARG PATCH_VERSION=latest
 ARG MEGATRON_COMMIT=1dcf0dafa884ad52ffb243625717a3471643e087
 ARG SGLANG_VERSION=0.5.10.post1
 
+ARG ENABLE_CUDA_13=0
+
 # ======================================== Setup =============================================
 
 WORKDIR /root/
@@ -44,7 +46,13 @@ RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f
 RUN pip install flash-linear-attention==0.4.1
 RUN pip install tilelang -f https://tile-ai.github.io/whl/nightly/cu128/
 
-RUN pip -v install --no-build-isolation "transformer_engine[pytorch]==2.10.0"
+# TE does not have wheel on cuda 13 yet, thus need to install from source
+RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
+      pip install nvidia-mathdx==26.6.0 && \
+      pip -v install --no-build-isolation git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.10; \
+    else \
+      pip -v install --no-build-isolation "transformer_engine[pytorch]==2.10.0"; \
+    fi
 
 RUN NVCC_APPEND_FLAGS="--threads 4" \
   pip -v install --disable-pip-version-check --no-cache-dir \
@@ -59,10 +67,23 @@ RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@a193d9dd1b
 RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@bridge --no-deps --no-build-isolation
 RUN pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation
 
-# vime's slime/utils/arguments.py + slime/ray/rollout.py top-level import sglang_router.
-# Install --no-deps so it doesn't pull a full sglang stack into the vllm environment.
-RUN pip install --no-deps "sglang==${SGLANG_VERSION}" sglang-router==0.3.2 && \
-    pip install IPython
+# This patch from masahi will be included in later Triton releases
+RUN if [ "$ENABLE_CUDA_13" = "1" ]; then \
+    (cd /root && git clone -b feat/v350_plus_8045 https://github.com/fzyzcjy/triton.git && cd triton && pip install -r python/requirements.txt && pip install --verbose -e .); \
+  fi
+
+# Skip sglang lines from requirements (we install --no-deps below; the full
+# transitive set conflicts with the vllm base environment).
+COPY requirements.txt /tmp/requirements.txt
+RUN grep -vE '^[[:space:]]*(sglang|sglang-router)([[:space:]]|[<>=!]|$)' /tmp/requirements.txt > /tmp/requirements-vllm.txt && \
+    pip install --ignore-installed PyJWT && \
+    pip install -r /tmp/requirements-vllm.txt
+
+# Temporarily install another sgl-kernel version for GB300 without rebuilding the whole image
+RUN if [ "$ENABLE_CUDA_13" = "1" ]; then \
+    SGL_KERNEL_VERSION=0.3.17.post2 && \
+    python3 -m pip install https://github.com/sgl-project/whl/releases/download/v${SGL_KERNEL_VERSION}/sgl_kernel-${SGL_KERNEL_VERSION}+cu130-cp310-abi3-manylinux2014_$(uname -m).whl --force-reinstall --no-deps; \
+  fi
 
 # https://github.com/pytorch/pytorch/issues/168167
 RUN pip install nvidia-cudnn-cu12==9.16.0.29
@@ -70,25 +91,10 @@ RUN pip install nvidia-cudnn-cu12==9.16.0.29
 # reinstall numpy 1.x for megatron
 RUN pip install "numpy<2"
 
-# Skip sglang lines (we install --no-deps above; the full transitive set conflicts).
-COPY requirements.txt /tmp/slime-requirements.txt
-RUN python3 - <<'PY' && \
-    python3 -m pip install -r /tmp/slime-requirements-vllm.txt
-from pathlib import Path
-
-source = Path("/tmp/slime-requirements.txt")
-target = Path("/tmp/slime-requirements-vllm.txt")
-skip_prefixes = ("sglang", "sglang-router")
-
-lines = []
-for raw_line in source.read_text().splitlines():
-    normalized = raw_line.split("#", 1)[0].strip().lower()
-    if normalized.startswith(skip_prefixes):
-        continue
-    lines.append(raw_line)
-
-target.write_text("\n".join(lines) + "\n")
-PY
+# vime's slime/utils/arguments.py + slime/ray/rollout.py top-level import sglang_router;
+# the cu129 vllm base does not ship sglang, so install --no-deps stubs here.
+RUN pip install --no-deps "sglang==${SGLANG_VERSION}" sglang-router==0.3.2 && \
+    pip install IPython
 
 RUN rm -rf /root/.cache/pip
 
@@ -106,14 +112,14 @@ RUN cd Megatron-LM && \
 
 # ====================================== Install main package ============================================
 
-COPY . /root/slime
-RUN cd /root/slime && \
+ARG VIME_COMMIT=main
+RUN git clone https://github.com/vllm-project/vime.git /root/slime && \
+    cd /root/slime && \
+    git checkout ${VIME_COMMIT} && \
     pip install -e . --no-deps
 
 RUN cd /root/slime/slime/backends/megatron_utils/kernels/int4_qat && \
     pip install . --no-build-isolation
-
-WORKDIR /root/slime
 
 # Reset ENTRYPOINT inherited from vllm/vllm-openai base (`vllm serve`).
 ENTRYPOINT []

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,16 +3,9 @@ FROM ${BASE_IMAGE}
 
 # ======================================== Arguments =============================================
 
-# MEGATRON_COMMIT + PATCH_VERSION track slime upstream's docker/Dockerfile
-# (slime 1dcf0da / patch latest as of 2026-02-14). vllm 0.21 cu129 base gives
-# us torch 2.11.0+cu129, libcudart.so.12 natively, vllm + vllm-router pre-installed.
-ARG MEGATRON_COMMIT=1dcf0dafa884ad52ffb243625717a3471643e087
 ARG PATCH_VERSION=latest
-
-# Pinned to match slime upstream Dockerfile for parity (sglang here is install-on-top
-# via --no-deps; the cu129 base ships vllm, not sglang).
+ARG MEGATRON_COMMIT=1dcf0dafa884ad52ffb243625717a3471643e087
 ARG SGLANG_VERSION=0.5.10.post1
-ARG SLIME_TORCH_MEMORY_SAVER_COMMIT=d64a639
 
 SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
 
@@ -20,12 +13,8 @@ WORKDIR /root/
 
 # ======================================== Apt dependencies =============================================
 
-# TE 2.10 has no prebuilt wheel — always builds from source.  vllm/vllm-openai
-# base is an inference image, so the cu12 dev-header collection needed by the TE
-# source build (cusparse / cusolver / cufft / curand / cudnn / nvrtc / nvml /
-# profiler-api / nvtx) has to be installed explicitly.  cuda-cudart-12-9 is
-# already present in the base.  cmake / ninja / build-essential drive apex +
-# flash-attn 2/3 source builds.
+# vllm/vllm-openai base is an inference image — install cu12 dev headers so
+# TE / apex / flash-attn source builds find cusparse.h etc.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git rsync dnsutils nvtop \
@@ -35,89 +24,57 @@ RUN apt-get update && \
       libcudnn9-dev-cuda-12 && \
     rm -rf /var/lib/apt/lists/*
 
-# python → python3 symlink early so subsequent source builds (flash-attn hopper,
-# apex) that invoke `python` succeed. slime upstream's base (slimerl/sglang) has
-# this symlink already; vllm/vllm-openai base only ships python3.
+# vllm/vllm-openai base only ships python3; subsequent source builds invoke `python`.
 RUN ln -sf /usr/bin/python3 /usr/local/bin/python
 
 # ====================================== Python dependencies ============================================
 
-# flash-attn 2.7.4.post1 — slime upstream parity. TE 2.10 doesn't support newer
-# FA2 majors, so this version is the ceiling. Source compile (~3-5 min with MAX_JOBS).
+# The compilation is slow, thus should be put at top
+# TransformerEngines does not support too high FA2
 RUN MAX_JOBS=64 pip -v install flash-attn==2.7.4.post1 --no-build-isolation
 
-# flash-attn 3 hopper kernels — slime upstream parity. Source compile from the
-# dao-AILab/flash-attention `hopper/` subdir at the pinned commit. Installed under
-# `flash_attn_3/` so callers explicitly opt in (slime does, vllm has its own FA3 path).
+# The compilation is slow, thus should be put at top
 RUN git clone https://github.com/Dao-AILab/flash-attention.git && \
-    cd flash-attention/ && \
-    git checkout fbf24f67cf7f6442c5cfb2c1057f4bfc57e72d89 && \
-    git submodule update --init && \
-    cd hopper/ && \
+    cd flash-attention/ && git checkout fbf24f67cf7f6442c5cfb2c1057f4bfc57e72d89 && git submodule update --init && cd hopper/ && \
     MAX_JOBS=96 python setup.py install && \
-    python_path=$(python -c "import site; print(site.getsitepackages()[0])") && \
+    export python_path=`python -c "import site; print(site.getsitepackages()[0])"` && \
     mkdir -p $python_path/flash_attn_3 && \
     cp flash_attn_interface.py $python_path/flash_attn_3/flash_attn_interface.py && \
-    rm -rf /root/flash-attention/
+    rm -rf flash-attention/
 
-# TransformerEngine 2.10 — cu12 wheel is available, no source compile.
+RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
+
+RUN pip install flash-linear-attention==0.4.1
+RUN pip install tilelang -f https://tile-ai.github.io/whl/nightly/cu128/
+
 RUN pip -v install --no-build-isolation "transformer_engine[pytorch]==2.10.0"
 
-# apex from source — slime upstream parity. Enables rope/grad fusion in Megatron;
-# without this, launcher must pass --no-rope-fusion --no-gradient-accumulation-fusion.
-# Slow (~10 min) but cached on rebuild.
 RUN NVCC_APPEND_FLAGS="--threads 4" \
-    pip -v install --disable-pip-version-check --no-cache-dir --no-build-isolation \
-    --config-settings "--build-option=--cpp_ext --cuda_ext --parallel 8" \
-    git+https://github.com/NVIDIA/apex.git@10417aceddd7d5d05d7cbf7b0fc2daad1105f8b4
+  pip -v install --disable-pip-version-check --no-cache-dir \
+  --no-build-isolation \
+  --config-settings "--build-option=--cpp_ext --cuda_ext --parallel 8" git+https://github.com/NVIDIA/apex.git@10417aceddd7d5d05d7cbf7b0fc2daad1105f8b4
 
-# Megatron-LM (clone now, patch + install after the patch COPY layer below).
-RUN git clone https://github.com/NVIDIA/Megatron-LM.git --recursive /root/Megatron-LM && \
-    cd /root/Megatron-LM && \
-    git checkout "${MEGATRON_COMMIT}"
+RUN git clone https://github.com/NVIDIA/Megatron-LM.git --recursive && \
+    cd Megatron-LM && git checkout ${MEGATRON_COMMIT} && \
+    pip install -e .
 
-# Apply slime's Megatron patch.
-COPY docker/patch/${PATCH_VERSION}/megatron.patch /root/Megatron-LM/megatron.patch
-RUN cd /root/Megatron-LM && \
-    git update-index --refresh && \
-    git apply megatron.patch --3way && \
-    if grep -R -n '^<<<<<<< ' .; then \
-      echo "Megatron patch failed to apply cleanly. Please resolve conflicts." && \
-      exit 1; \
-    fi && \
-    rm megatron.patch && \
-    pip install -e . --no-deps
+RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@d64a639 --no-cache-dir --force-reinstall
+RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@bridge --no-deps --no-build-isolation
+RUN pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation
 
-# torch_memory_saver from source (slime parity) — pypi wheel ships cu12 binary so
-# would work too, but slime uses the source build for newer features.
-RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@${SLIME_TORCH_MEMORY_SAVER_COMMIT} --no-cache-dir --force-reinstall
-
-# mbridge + Megatron-Bridge + modelopt — needed by slime's --megatron-to-hf-mode bridge
-# checkpoint load path.
-RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps && \
-    pip install git+https://github.com/radixark/Megatron-Bridge.git@bridge --no-deps --no-build-isolation && \
-    pip install "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
-
-# fla + tilelang — linear-attention model variants (slime_plugins/models/qwen3_5.py,
-# qwen3_next.py). cu12 native wheels here, no version skew vs base.
-RUN pip install flash-linear-attention==0.4.1 && \
-    pip install tilelang -f https://tile-ai.github.io/whl/nightly/cu128/
-
-# sglang stubs — vime's slime/utils/arguments.py + slime/ray/rollout.py still import
-# sglang_router at module load. Install --no-deps so it doesn't drag a full sglang
-# stack into the cu12 environment. vllm rollout doesn't actually exercise sglang code.
+# vime's slime/utils/arguments.py + slime/ray/rollout.py top-level import sglang_router.
+# Install --no-deps so it doesn't pull a full sglang stack into the vllm environment.
 RUN pip install --no-deps "sglang==${SGLANG_VERSION}" sglang-router==0.3.2 && \
     pip install IPython
 
-# pytorch issue #168167 workaround (slime upstream's pin).
+# https://github.com/pytorch/pytorch/issues/168167
 RUN pip install nvidia-cudnn-cu12==9.16.0.29
 
-# Megatron requires numpy 1.x.
+# reinstall numpy 1.x for megatron
 RUN pip install "numpy<2"
 
-# Install slime runtime requirements while excluding the sglang lines (we ship the
-# stub via --no-deps above; the requirements file pulls sglang's full transitive set
-# which conflicts with the vllm-base environment).
+# Filter out sglang lines from requirements; we ship the --no-deps stub separately
+# and the full sglang transitive set conflicts with the vllm base environment.
 COPY requirements.txt /tmp/slime-requirements.txt
 RUN python3 - <<'PY' && \
     python3 -m pip install -r /tmp/slime-requirements-vllm.txt
@@ -137,20 +94,30 @@ for raw_line in source.read_text().splitlines():
 target.write_text("\n".join(lines) + "\n")
 PY
 
-ENV PYTHONPATH="/root/Megatron-LM:${PYTHONPATH}"
+RUN rm -rf /root/.cache/pip
 
-# pytest for in-container test runs. (python symlink is set early, above.)
+# ====================================== Patches ============================================
+
+COPY docker/patch/${PATCH_VERSION}/megatron.patch /root/Megatron-LM/
+RUN cd Megatron-LM && \
+    git update-index --refresh && \
+    git apply megatron.patch --3way && \
+    if grep -R -n '^<<<<<<< ' .; then \
+      echo "Patch failed to apply cleanly. Please resolve conflicts." && \
+      exit 1; \
+    fi && \
+    rm megatron.patch
+
+# ====================================== Install main package ============================================
+
 RUN python3 -m pip install pytest
 
-# Install slime itself last so changes to the source don't bust earlier layers.
 COPY . /root/slime
 RUN cd /root/slime && \
     pip install -e . --no-deps
 
 WORKDIR /root/slime
 
-# Reset ENTRYPOINT inherited from vllm/vllm-openai base (which sets
-# `["vllm serve"]`). Without this, every `docker run <image> <cmd>` invocation
-# gets `<cmd>` interpreted as an argument to `vllm serve`.
+# Reset ENTRYPOINT inherited from vllm/vllm-openai base (`vllm serve`).
 ENTRYPOINT []
 CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -149,29 +149,6 @@ RUN cd /root/slime && \
 
 WORKDIR /root/slime
 
-# Build-time smoke: catch missing imports here instead of at first `docker run`.
-RUN python3 - <<'PY'
-import importlib.metadata as metadata
-import vllm
-print("vllm import ok", getattr(vllm, "__version__", metadata.version("vllm")))
-print("sglang version", metadata.version("sglang"))
-print("sglang_router version", metadata.version("sglang-router"))
-print("transformer_engine version", metadata.version("transformer_engine"))
-print("torch", __import__("torch").__version__)
-import flash_attn  # noqa: F401
-print("flash_attn import ok", flash_attn.__version__)
-import apex  # noqa: F401
-print("apex import ok")
-import sglang  # noqa: F401
-print("sglang import ok", sglang.__version__)
-import sglang_router  # noqa: F401
-print("sglang_router import ok", sglang_router.__version__)
-from megatron.bridge import AutoBridge  # noqa: F401
-print("megatron.bridge import ok")
-import slime  # noqa: F401
-print("slime import ok")
-PY
-
 # Reset ENTRYPOINT inherited from vllm/vllm-openai base (which sets
 # `["vllm serve"]`). Without this, every `docker run <image> <cmd>` invocation
 # gets `<cmd>` interpreted as an argument to `vllm serve`.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,7 +63,9 @@ RUN git clone https://github.com/NVIDIA/Megatron-LM.git --recursive && \
     cd Megatron-LM && git checkout ${MEGATRON_COMMIT} && \
     pip install -e .
 
-RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@a193d9dd1b877d33c64a41cfb3db9f867df2d926 --no-cache-dir --force-reinstall
+# Pinned to d64a639 (older than slime upstream's a193d9d); the newer commit
+# requires TMS_CUDA_MAJOR env var to build a multi-CUDA wheel.
+RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@d64a639 --no-cache-dir --force-reinstall
 RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@bridge --no-deps --no-build-isolation
 RUN pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation
 
@@ -112,10 +114,10 @@ RUN cd Megatron-LM && \
 
 # ====================================== Install main package ============================================
 
-ARG VIME_COMMIT=main
-RUN git clone https://github.com/vllm-project/vime.git /root/slime && \
-    cd /root/slime && \
-    git checkout ${VIME_COMMIT} && \
+# vime is a private repo, so git clone in build context isn't an option;
+# COPY the local working tree into the image.
+COPY . /root/slime
+RUN cd /root/slime && \
     pip install -e . --no-deps
 
 RUN cd /root/slime/slime/backends/megatron_utils/kernels/int4_qat && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,28 +1,32 @@
 # Docker release rule
 
-We will publish 2 kinds of docker images:
-1. stable version, which based on official sglang release. We will store the patch on those versions.
-2. latest version, which aligns to `lmsysorg/sglang:latest`.
+vime now ships a single image variant, based on the official vllm release
+(`vllm/vllm-openai:v0.21.0-cu129-ubuntu2404`).  The image bundles the slime
+training stack (Megatron-LM, mbridge / Megatron-Bridge, modelopt, apex,
+flash-attn 2 + flash-attn 3 hopper, TE 2.10, flash-linear-attention,
+tilelang, torch_memory_saver) plus an `--no-deps` sglang stub for
+top-level imports.
 
-current stable version is:
+current stable version:
+- vllm 0.21.0 (cu129) + megatron `1dcf0dafa884ad52ffb243625717a3471643e087` + slime patch `docker/patch/latest/megatron.patch`
+
+Published image:
+- `aosheninferact/vime-vllm:cu129` (also tagged `latest`)
+
+Build locally:
+
+```bash
+docker build -f docker/Dockerfile -t vime/pr-9-vllm:cu129 .
+```
+
+Before each update, the validated path is a single-step Qwen3-0.6B vllm
+rollout train on 4× H200; broader coverage (multi-step, MoE, PD
+disaggregation, multi-node, spec decode, checkpoint save/load) is not
+yet wired into CI and should be exercised before tagging stable.
+
+History (sglang-based images, predates the vllm switch):
 - sglang v0.5.9 (bbe9c7eeb520b0a67e92d133dfc137a3688dc7f2), megatron dev 3714d81d418c9f1bca4594fc35f9e8289f652862
-
-history versions:
 - sglang v0.5.7 nightly-dev-20260107-dce8b060 (dce8b0606c06d3a191a24c7b8cbe8e238ab316c9), megatron dev 3714d81d418c9f1bca4594fc35f9e8289f652862
 - sglang v0.5.6 nightly-dev-20251208-5e2cda61 (5e2cda6158e670e64b926a9985d65826c537ac82), megatron v0.14.0 (23e00ed0963c35382dfe8a5a94fb3cda4d21e133)
 - sglang v0.5.5.post1 (303cc957e62384044dfa8e52d7d8af8abe12f0ac), megatron v0.14.0 (23e00ed0963c35382dfe8a5a94fb3cda4d21e133)
 - sglang v0.5.0rc0-cu126 (8ecf6b9d2480c3f600826c7d8fef6a16ed603c3f), megatron 48406695c4efcf1026a7ed70bb390793918dd97b
-
-The command to build:
-
-```bash
-just release
-```
-
-Before each update, we will test the following models with 64xH100:
-
-- Qwen3-4B sync
-- Qwen3-4B async
-- Qwen3-30B-A3B sync
-- Qwen3-30B-A3B fp8 sync
-- GLM-4.5-355B-A32B sync

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,26 +1,11 @@
-# Docker release rule
+# Docker
 
-vime ships a single image variant, based on the official vllm release
-(`vllm/vllm-openai:v0.21.0-cu129-ubuntu2404`), bundling the slime training
-stack (Megatron-LM, mbridge / Megatron-Bridge, modelopt, apex, flash-attn 2 +
-flash-attn 3 hopper, TE 2.10, flash-linear-attention, tilelang,
-torch_memory_saver).
-
-current stable version:
-- vllm 0.21.0 (cu129) + megatron `1dcf0dafa884ad52ffb243625717a3471643e087` + slime patch `docker/patch/latest/megatron.patch`
-
-Published image:
-- `aosheninferact/vime-vllm:cu129` (also tagged `latest`)
+vime ships one image, based on `vllm/vllm-openai:v0.21.0-cu129-ubuntu2404`:
+- Published: `aosheninferact/vime-vllm:cu129` (also `latest`)
+- Megatron pin: `1dcf0dafa884ad52ffb243625717a3471643e087` + `docker/patch/latest/megatron.patch`
 
 Build locally:
 
 ```bash
 docker build -f docker/Dockerfile -t vime/pr-9-vllm:cu129 .
 ```
-
-History (sglang-based images, predates the vllm switch):
-- sglang v0.5.9 (bbe9c7eeb520b0a67e92d133dfc137a3688dc7f2), megatron dev 3714d81d418c9f1bca4594fc35f9e8289f652862
-- sglang v0.5.7 nightly-dev-20260107-dce8b060 (dce8b0606c06d3a191a24c7b8cbe8e238ab316c9), megatron dev 3714d81d418c9f1bca4594fc35f9e8289f652862
-- sglang v0.5.6 nightly-dev-20251208-5e2cda61 (5e2cda6158e670e64b926a9985d65826c537ac82), megatron v0.14.0 (23e00ed0963c35382dfe8a5a94fb3cda4d21e133)
-- sglang v0.5.5.post1 (303cc957e62384044dfa8e52d7d8af8abe12f0ac), megatron v0.14.0 (23e00ed0963c35382dfe8a5a94fb3cda4d21e133)
-- sglang v0.5.0rc0-cu126 (8ecf6b9d2480c3f600826c7d8fef6a16ed603c3f), megatron 48406695c4efcf1026a7ed70bb390793918dd97b

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,4 @@
-# Docker
+# Docker release rule
 
 vime ships one image based on the official vllm image, published as
 `aosheninferact/vime-vllm:cu129` (also `latest`).
@@ -9,7 +9,7 @@ Build locally:
 docker build -f docker/Dockerfile -t vime/pr-9-vllm:cu129 .
 ```
 
-## Release rule
+## Release matrix
 
 Before tagging a new stable image, the following matrix must pass. All four
 are currently TODO — none has been wired into CI yet:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,11 +1,20 @@
 # Docker
 
-vime ships one image, based on `vllm/vllm-openai:v0.21.0-cu129-ubuntu2404`:
-- Published: `aosheninferact/vime-vllm:cu129` (also `latest`)
-- Megatron pin: `1dcf0dafa884ad52ffb243625717a3471643e087` + `docker/patch/latest/megatron.patch`
+vime ships one image based on the official vllm image, published as
+`aosheninferact/vime-vllm:cu129` (also `latest`).
 
 Build locally:
 
 ```bash
 docker build -f docker/Dockerfile -t vime/pr-9-vllm:cu129 .
 ```
+
+## Release rule
+
+Before tagging a new stable image, the following matrix must pass. All four
+are currently TODO — none has been wired into CI yet:
+
+- [ ] Qwen3-4B sync
+- [ ] Qwen3-4B async
+- [ ] Qwen3-30B-A3B sync
+- [ ] Qwen3-30B-A3B fp8 sync

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,11 +1,10 @@
 # Docker release rule
 
-vime now ships a single image variant, based on the official vllm release
-(`vllm/vllm-openai:v0.21.0-cu129-ubuntu2404`).  The image bundles the slime
-training stack (Megatron-LM, mbridge / Megatron-Bridge, modelopt, apex,
-flash-attn 2 + flash-attn 3 hopper, TE 2.10, flash-linear-attention,
-tilelang, torch_memory_saver) plus an `--no-deps` sglang stub for
-top-level imports.
+vime ships a single image variant, based on the official vllm release
+(`vllm/vllm-openai:v0.21.0-cu129-ubuntu2404`), bundling the slime training
+stack (Megatron-LM, mbridge / Megatron-Bridge, modelopt, apex, flash-attn 2 +
+flash-attn 3 hopper, TE 2.10, flash-linear-attention, tilelang,
+torch_memory_saver).
 
 current stable version:
 - vllm 0.21.0 (cu129) + megatron `1dcf0dafa884ad52ffb243625717a3471643e087` + slime patch `docker/patch/latest/megatron.patch`
@@ -18,11 +17,6 @@ Build locally:
 ```bash
 docker build -f docker/Dockerfile -t vime/pr-9-vllm:cu129 .
 ```
-
-Before each update, the validated path is a single-step Qwen3-0.6B vllm
-rollout train on 4× H200; broader coverage (multi-step, MoE, PD
-disaggregation, multi-node, spec decode, checkpoint save/load) is not
-yet wired into CI and should be exercised before tagging stable.
 
 History (sglang-based images, predates the vllm switch):
 - sglang v0.5.9 (bbe9c7eeb520b0a67e92d133dfc137a3688dc7f2), megatron dev 3714d81d418c9f1bca4594fc35f9e8289f652862


### PR DESCRIPTION
## Summary

Switches vime's `docker/Dockerfile` base from `slimerl/sglang:v0.5.10.post1` (cu12 sglang custom image) to `vllm/vllm-openai:v0.21.0-cu129-ubuntu2404` (cu12 vllm official image). Same vllm version, same RLHF HTTP API, same router CLI — just an aligned base.

## Why

- vime's rollout backend is **vllm**, but main's Dockerfile inherits slime's `slimerl/sglang` base which already ships sglang + cu12 torch. Layering vllm on top is the wrong direction.
- The earlier vime cu13 image (PR #9 + PR #12 cumulative) used `vllm/vllm-openai:v0.21.0` default tag (cu130) and paid for it: 41.3 GB final size, 12-minute TE source compile against cu13 dev headers, plus an extra `apt install cuda-cudart-12-9` to make `torch_memory_saver`'s pypi wheel resolve (its hook is linked to libcudart.so.12).
- cu129 is the **same vllm 0.21.0** with everything natively on cu12. Final image **19.6 GB** (less than half), TE source build links cleanly, `torch_memory_saver` works as-shipped, no cuda-cudart-12 apt hack.

## What's installed beyond the cu13 vime image

- `flash-attn==2.7.4.post1` source-compiled (slime upstream parity)
- `flash-attn` 3 hopper kernels source-compiled (slime upstream parity)
- `apex` from source (slime upstream parity)

apex enables Megatron's fusion kernels — launchers no longer need `--no-rope-fusion --no-gradient-accumulation-fusion`.

## What stayed

- Megatron `1dcf0da` + slime megatron.patch (latest)
- mbridge / Megatron-Bridge / nvidia-modelopt
- flash-linear-attention 0.4.1 + tilelang (linear-attention models)
- `sglang` + `sglang-router` via `--no-deps` stub (vime's `slime/utils/arguments.py` still top-level imports `sglang_router`)
- IPython, numpy<2, nvidia-cudnn-cu12 9.16 pin
- pytest + python→python3 symlink
- `ENTRYPOINT []` reset (vllm/vllm-openai base sets `vllm serve` by default)
- requirements.txt filter to skip sglang lines

## Verification

Local build + Qwen3-0.6B 1-step vllm rollout train (mounted PR #10's code into the image, 4× H200):

| Stage | Result |
|---|---|
| Build (apt + TE + flash-attn 2/3 + apex + slime) | ✅ 24/24 layers, ~50 min, **19.6 GB** |
| `import vllm/sglang/apex/flash_attn/megatron.bridge` smoke | ✅ |
| Ray cluster + RolloutManager + 4× vllm engine | ✅ |
| Megatron actor load HF ckpt via `--megatron-to-hf-mode bridge` | ✅ |
| **Fusion kernels** (no `--no-*-fusion` flags) | ✅ |
| First weight update triggered | ✅ |
| Hits PR #10 documented PR #12 weight-sync gap (`start_weight_update must be called before update_weights`) | ✅ same boundary as the cu13 image — within scope of PR #10 / PR #12 split |

## Test plan

- [ ] CI builds the new Dockerfile end-to-end (uses `docker/patch/latest/megatron.patch`, no other repo deps changed)
- [ ] Smoke-import all key packages in the resulting image
- [ ] (Optional) Re-run an existing slime e2e test (e.g. `test_qwen3.5_0.8B_gsm8k_short.py`) under this image to confirm fusion kernel coverage
- [ ] PR #12's cu13 path can be retired once this lands, or kept as `ENABLE_CUDA_13=1` toggle if cu13 hardware is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)