### PR TITLE
ci: gate e2e jobs on pre-commit success

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -25,7 +25,38 @@ concurrency:
 
 jobs:
 
+  pre-commit:
+    name: Run pre-commit (gate)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - name: Install pre-commit
+        run: pip install --upgrade pip pre-commit
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-
+
+      - name: Run pre-commit on all files
+        run: pre-commit run --all-files --show-diff-on-failure --color=always
+
+
   e2e-test-short:
+    needs: pre-commit
 
     if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'run-ci-short'))
 
@@ -109,6 +140,7 @@ jobs:
 
 
   e2e-test-sglang-config:
+    needs: pre-commit
 
     if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'run-ci-sglang-config'))
 
@@ -192,6 +224,7 @@ jobs:
 
 
   e2e-test-megatron:
+    needs: pre-commit
 
     if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'run-ci-megatron'))
 
@@ -275,6 +308,7 @@ jobs:
 
 
   e2e-test-precision:
+    needs: pre-commit
 
     if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'run-ci-precision'))
 
@@ -358,6 +392,7 @@ jobs:
 
 
   e2e-test-ckpt:
+    needs: pre-commit
 
     if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'run-ci-ckpt'))
 
@@ -441,6 +476,7 @@ jobs:
 
 
   e2e-test-plugin-contracts:
+    needs: pre-commit
 
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
 
@@ -506,6 +542,7 @@ jobs:
 
 
   e2e-test-image:
+    needs: pre-commit
 
     if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'run-ci-image'))
 
@@ -590,6 +627,7 @@ jobs:
 
 
   e2e-test-changed-detect:
+    needs: pre-commit
     if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'run-ci-changed'))
     runs-on: self-hosted
     outputs:
@@ -629,7 +667,7 @@ jobs:
           fi
 
   e2e-test-changed:
-    needs: e2e-test-changed-detect
+    needs: [pre-commit, e2e-test-changed-detect]
     if: needs.e2e-test-changed-detect.outputs.has_tests == 'true'
     runs-on: self-hosted
     strategy:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -38,21 +38,11 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-          cache: 'pip'
 
-      - name: Install pre-commit
-        run: pip install --upgrade pip pre-commit
-
-      - name: Cache pre-commit environments
-        uses: actions/cache@v5
+      - name: Run pre-commit
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            pre-commit-${{ runner.os }}-
-
-      - name: Run pre-commit on all files
-        run: pre-commit run --all-files --show-diff-on-failure --color=always
+          extra_args: --all-files --show-diff-on-failure --color=always
 
 
   e2e-test-short:

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -105,8 +105,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  pre-commit:
+    name: Run pre-commit (gate)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - name: Install pre-commit
+        run: pip install --upgrade pip pre-commit
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-
+
+      - name: Run pre-commit on all files
+        run: pre-commit run --all-files --show-diff-on-failure --color=always
+
 <% for job_name, config in jobs.items() %>
   << job_name >>:
+    needs: pre-commit
 <% if config.get('always') %>
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
 <% else %>
@@ -228,6 +259,7 @@ jobs:
 <% endfor %>
 
   e2e-test-changed-detect:
+    needs: pre-commit
     if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'run-ci-changed'))
     runs-on: self-hosted
     outputs:
@@ -267,7 +299,7 @@ jobs:
           fi
 
   e2e-test-changed:
-    needs: e2e-test-changed-detect
+    needs: [pre-commit, e2e-test-changed-detect]
     if: needs.e2e-test-changed-detect.outputs.has_tests == 'true'
     runs-on: self-hosted
     strategy:

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -119,21 +119,11 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-          cache: 'pip'
 
-      - name: Install pre-commit
-        run: pip install --upgrade pip pre-commit
-
-      - name: Cache pre-commit environments
-        uses: actions/cache@v5
+      - name: Run pre-commit
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            pre-commit-${{ runner.os }}-
-
-      - name: Run pre-commit on all files
-        run: pre-commit run --all-files --show-diff-on-failure --color=always
+          extra_args: --all-files --show-diff-on-failure --color=always
 
 <% for job_name, config in jobs.items() %>
   << job_name >>:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   run-pre-commit:
@@ -23,19 +24,45 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-          cache: 'pip'
 
-      - name: Install pre-commit
-        run: pip install --upgrade pip pre-commit
-
-      - name: Cache pre-commit environments
-        uses: actions/cache@v5
+      - name: Run pre-commit
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            pre-commit-${{ runner.os }}-
+          extra_args: --all-files --show-diff-on-failure --color=always
 
-      - name: Run pre-commit on all files
-        run: pre-commit run --all-files --show-diff-on-failure --color=always
-
+      - name: Comment fix instructions on failure
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            // Marker so this comment is idempotent across re-runs on the same PR.
+            const marker = '<!-- pre-commit-failure-comment -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            if (comments.some(c => c.body && c.body.includes(marker))) {
+              core.info('pre-commit failure comment already exists on this PR; skipping.');
+              return;
+            }
+            const body = [
+              marker,
+              `Hi @${context.payload.pull_request.user.login}, the pre-commit checks have failed. Please run:`,
+              '',
+              '```bash',
+              'uv pip install pre-commit',
+              'pre-commit install',
+              'pre-commit run --all-files',
+              '```',
+              '',
+              'Then commit the changes and push to your branch. After installing the hook with `pre-commit install`,',
+              '`pre-commit` will run automatically on changed files before each commit.',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   run-pre-commit:
@@ -24,45 +23,19 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.10'
+          cache: 'pip'
 
-      - name: Run pre-commit
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-        with:
-          extra_args: --all-files --show-diff-on-failure --color=always
+      - name: Install pre-commit
+        run: pip install --upgrade pip pre-commit
 
-      - name: Comment fix instructions on failure
-        if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+      - name: Cache pre-commit environments
+        uses: actions/cache@v5
         with:
-          script: |
-            // Marker so this comment is idempotent across re-runs on the same PR.
-            const marker = '<!-- pre-commit-failure-comment -->';
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-            if (comments.some(c => c.body && c.body.includes(marker))) {
-              core.info('pre-commit failure comment already exists on this PR; skipping.');
-              return;
-            }
-            const body = [
-              marker,
-              `Hi @${context.payload.pull_request.user.login}, the pre-commit checks have failed. Please run:`,
-              '',
-              '```bash',
-              'uv pip install pre-commit',
-              'pre-commit install',
-              'pre-commit run --all-files',
-              '```',
-              '',
-              'Then commit the changes and push to your branch. After installing the hook with `pre-commit install`,',
-              '`pre-commit` will run automatically on changed files before each commit.',
-            ].join('\n');
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body,
-            });
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-
+
+      - name: Run pre-commit on all files
+        run: pre-commit run --all-files --show-diff-on-failure --color=always
+


### PR DESCRIPTION
## Summary

Add a `pre-commit` gate job to the `PR Test` workflow. Every existing e2e job in `pr-test.yml` (`e2e-test-short`, `e2e-test-megatron`, `e2e-test-ckpt`, `e2e-test-image`, `e2e-test-changed*`, `e2e-test-plugin-contracts`, ...) now has `needs: pre-commit`. If the gate fails, every downstream job — including self-hosted GPU jobs — is skipped.

`.github/workflows/pre-commit.yml` is untouched (byte-identical to `main`), so any branch-protection rule that references its `pre-commit / Run pre-commit` check still works. The new gate inside `PR Test` is an additional, internal gate.

## Why this is not duplicating an existing PR

`gh pr list --repo vllm-project/vime --state open` searches for "pre-commit ci" and "needs pre-commit" returned no matches. Closest unrelated PR: #18 (`[Clean] Remove SGlang runtime code`).

## Code changes

| File | Change |
|------|--------|
| `.github/workflows/pr-test.yml.j2` | Add a `pre-commit` job at the top using `pre-commit/action@<sha>` (v3.0.1, SHA-pinned). Add `needs: pre-commit` to every job in the `jobs.items()` loop and to `e2e-test-changed-detect`. Change `e2e-test-changed` to `needs: [pre-commit, e2e-test-changed-detect]`. |
| `.github/workflows/pr-test.yml` | Regenerated from the `.j2` template via `python .github/workflows/generate_github_workflows.py`. |

`pre-commit/action@<sha>` is the same action vLLM uses ([reference](https://github.com/vllm-project/vllm/blob/main/.github/workflows/pre-commit.yml)); SHA-pinned because it is a newly-added dependency.

## Behavior

- **Push to main**: unchanged — `pre-commit.yml` runs as before. `PR Test` does not run on push (its `push` trigger is commented out).
- **PR opened / synchronized**: `pre-commit.yml` runs as a separate status check (as today). Inside `PR Test`, the new `pre-commit` gate also runs; if it fails, all downstream e2e jobs (labeled and always-on) are skipped.
- **Label added** (e.g. `run-ci-megatron`): the `PR Test` workflow is triggered; the gate runs first; only if it passes does the labeled GPU job start. This is the primary cost saving — self-hosted GPU runners no longer fire on lint-broken code.
- **`workflow_dispatch`**: gate runs first, then every job runs (matches existing behavior).

There will be one extra pre-commit run per PR (one in `pre-commit.yml`, one as the gate in `pr-test.yml`) — both on the free `ubuntu-latest` runner. This is the cost of keeping `pre-commit.yml` byte-identical so existing branch protection isn't disturbed.

## Test commands run

```bash
# Regen round-trip
uv run --with jinja2 python .github/workflows/generate_github_workflows.py

# YAML parses
uv run --with pyyaml python -c "
import yaml; yaml.safe_load(open('.github/workflows/pr-test.yml')); print('YAML OK')
"
# -> YAML OK

# pre-commit hooks pass on the touched files
uv run --with pre-commit pre-commit run --files \
    .github/workflows/pr-test.yml .github/workflows/pr-test.yml.j2
# -> check yaml / case conflicts / private key / large files: Passed
#    (other hooks: no files to check / Skipped)

# Sanity: every e2e-* job in the generated YAML has `needs: pre-commit`
grep -nE '^  [a-z][a-z0-9-]+:|^    needs:' .github/workflows/pr-test.yml
```

Functional verification ("does GitHub actually skip the e2e jobs when the gate fails") will happen on this PR itself once CI runs — please review the GitHub Actions run on this PR before merging.

## What I deliberately did NOT do

- **vLLM's `pre-run-check`** (author-reputation gate: requires `ready`/`verified` label OR author ≥ 4 merged PRs to even run pre-commit). vime is a smaller project with a controlled contributor set; this is overkill today.
- **Auto-comment on pre-commit failure** (mergify-style help comment with `uv pip install pre-commit` instructions). Was prototyped on this branch (commits 8d785e6 history) but reverted in favor of simplicity. Easy to add later as a focused PR if maintainers find it useful.
- **Migrating to SHA-pin all third-party actions.** Existing vime workflows tag-pin (`actions/checkout@v6`); this PR only SHA-pins the newly-added `pre-commit/action`. Consistent SHA migration is a separate decision.

## AI assistance disclosure

This PR was prepared with assistance from Claude Code (Opus 4.7). The submitting human (aoshen02) reviewed every changed line and ran the verification commands above. Per `AGENTS.md` §1.
