### PR TITLE
fix(args): drop incorrect critic GPU add to rollout_num_gpus in colocate

### DIFF
--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1744,8 +1744,6 @@ def slime_validate_args(args):
                 f"* actor_num_nodes {args.actor_num_nodes}, overriding rollout_num_gpus to match actor_num_gpus_per_node * actor_num_nodes."
             )
             args.rollout_num_gpus = args.actor_num_gpus_per_node * args.actor_num_nodes
-            if args.use_critic:
-                args.rollout_num_gpus += args.critic_num_gpus_per_node * args.critic_num_nodes
 
     if args.offload_train is None:
         args.offload_train = False


### PR DESCRIPTION
## Summary

In `slime/utils/arguments.py`, the colocate branch over-allocates `args.rollout_num_gpus` when `--advantage-estimator ppo` (i.e. `args.use_critic = True`). The two lines being removed add `critic_num_gpus_per_node * critic_num_nodes` on top of the actor GPU count — but in colocate mode the critic shares the actor's placement group, so the rollout doesn't get extra GPUs.

Concretely, `slime/ray/placement_group.py:_create_placement_group` only allocates `actor_num_nodes * actor_num_gpus_per_node` bundles in colocate (see the `elif args.colocate:` branch), and `result[\"critic\"] = result[\"actor\"]` reuses that same PG. With the addition still in place, `_resolve_sglang_config` builds a `ServerGroupConfig(num_gpus=args.rollout_num_gpus)` larger than the PG itself, and `start_engines` (`slime/ray/rollout.py:134`) indexes `reordered_gpu_ids` out of range:

```
File \"/root/slime/slime/ray/rollout.py\", line 134, in start_engines
    base_gpu_id = int(reordered_gpu_ids[gpu_index])
                      ~~~~~~~~~~~~~~~~~^^^^^^^^^^^
IndexError: list index out of range
```

The blamed line was added in commit `371c0309` (LiLei, 2025-09-28). The override block that sets `rollout_num_gpus = actor * nodes` is correct on its own — only the `if args.use_critic: rollout_num_gpus += ...` lines need to go.

## Reproducer

`tests/test_qwen2.5_0.5B_ppo_critic_only_short.py` — uses `--advantage-estimator ppo` + `--colocate` + `--rollout-num-gpus 2` + `--actor-num-gpus-per-node 4`. Without this fix, the test crashes during `RolloutManager.__init__` with the `IndexError` above.

## Test plan

- [x] Reproduced the `IndexError` on `tests/test_qwen2.5_0.5B_ppo_critic_only_short.py` before the fix
- [x] After this 2-line removal, the test progresses past `start_engines` and completes 2 RL steps (`perf 1:` / `perf 2:` / `Job succeeded`)
- [ ] Re-run the rest of the colocate test matrix to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)