### PR TITLE
test(vllm): drop tests of APIs removed by PR #22 refactor

### DIFF
--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -83,7 +83,6 @@ def test_start_weight_update_posts_four_phase_endpoint(vllm_engine, monkeypatch)
     assert len(calls) == 1
     assert calls[0][0] == "start_weight_update"
     assert calls[0][1] == {"is_checkpoint_format": True}
-    assert calls[0][2] == vllm_engine._weight_transfer_http_timeout()
 
 
 @pytest.mark.unit
@@ -99,7 +98,9 @@ def test_finish_weight_update_posts_empty_body(vllm_engine, monkeypatch):
     result = vllm_engine.finish_weight_update()
 
     assert result == {"done": True}
-    assert calls == [("finish_weight_update", {}, vllm_engine._weight_transfer_http_timeout())]
+    assert len(calls) == 1
+    assert calls[0][0] == "finish_weight_update"
+    assert calls[0][1] == {}
 
 
 @pytest.mark.unit
@@ -150,56 +151,6 @@ def test_post_vllm_update_weights_http_wraps_update_info(vllm_engine, monkeypatc
     assert result == {"status": "ok"}
     assert seen[0][0] == "update_weights"
     assert seen[0][1] == {"update_info": {"names": ["w"], "packed": False}}
-
-
-@pytest.mark.unit
-def test_weight_transfer_http_timeout_reads_env(vllm_engine, monkeypatch):
-    monkeypatch.setenv("SLIME_VLLM_WEIGHT_TRANSFER_UPDATE_TIMEOUT_SEC", "123.5")
-    assert vllm_engine._weight_transfer_http_timeout() == 123.5
-
-
-@pytest.mark.unit
-def test_weight_transfer_http_timeout_fallback_to_legacy_env(vllm_engine, monkeypatch):
-    monkeypatch.delenv("SLIME_VLLM_WEIGHT_TRANSFER_UPDATE_TIMEOUT_SEC", raising=False)
-    monkeypatch.setenv("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "42")
-    assert vllm_engine._weight_transfer_http_timeout() == 42.0
-
-
-@pytest.mark.unit
-def test_response_json_or_fallback_parses_dict():
-    response = _MockResponse(json_data={"status": "ready"})
-    assert mod._response_json_or_fallback(response) == {"status": "ready"}
-
-
-@pytest.mark.unit
-def test_response_json_or_fallback_non_dict_wrapped():
-    response = _MockResponse()
-    response.json = lambda: ["a", "b"]  # type: ignore[method-assign]
-    assert mod._response_json_or_fallback(response) == {
-        "ok": False,
-        "error": "Response is not a dictionary",
-        "data": ["a", "b"],
-    }
-
-
-@pytest.mark.unit
-def test_response_json_or_fallback_invalid_json():
-    response = _MockResponse(text="not-json")
-    response.json = lambda: (_ for _ in ()).throw(ValueError("no json"))  # type: ignore[method-assign]
-    assert mod._response_json_or_fallback(response) == {
-        "ok": False,
-        "error": "Invalid JSON response",
-        "raw": "not-json",
-    }
-
-
-@pytest.mark.unit
-def test_http_base_requires_init(vllm_args):
-    from slime.backends.vllm_utils.vllm_engine import VLLMEngine
-
-    engine = VLLMEngine(vllm_args, rank=0)
-    with pytest.raises(RuntimeError, match="init\\(\\)"):
-        engine._http_base()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Follow-up to @knlnguyen1802's request on #22 ([comment](https://github.com/vllm-project/vime/pull/22#issuecomment-)) to send a small PR against `update_weights_tensor` rather than a manual edit.

Same kind of test/production drift as the one cleaned up in commit `2ee402b "Fix test"`, but for the other 8 unit tests that were also broken by the `132066f "Fix colocated mode weight sync"` refactor.

On the current `update_weights_tensor` HEAD, `pytest tests/unit/backends/vllm_utils/test_vllm_engine.py` returns **8 failed, 18 passed**. After this PR: **20 passed**.

## What broke

PR #22 commit `132066f` removed / inlined three things in [`slime/backends/vllm_utils/vllm_engine.py`](slime/backends/vllm_utils/vllm_engine.py):

| Removed API | Replacement |
| --- | --- |
| `VLLMEngine._weight_transfer_http_timeout()` | Inlined `float(os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"))` in `start_weight_update` / `finish_weight_update`; `_post_vllm_update_weights_http` uses a slightly different env-var precedence |
| Module-level `_response_json_or_fallback(response)` | Inlined `try: return response.json() except Exception: return {"ok": True, "raw": response.text}` |
| `_http_base()` init-guard (`RuntimeError` when `server_host` unset) | Removed; now bare attribute access |

But PR #21 had added tests against those exact APIs in [`tests/unit/backends/vllm_utils/test_vllm_engine.py`](tests/unit/backends/vllm_utils/test_vllm_engine.py), and commit `2ee402b` only cleaned up the two `_skipped_if_not_leader` tests, leaving the other 8 drifting.

## What this PR does

**Deletes** 6 tests of fully-removed APIs:

- `test_weight_transfer_http_timeout_reads_env`
- `test_weight_transfer_http_timeout_fallback_to_legacy_env`
- `test_response_json_or_fallback_parses_dict`
- `test_response_json_or_fallback_non_dict_wrapped`
- `test_response_json_or_fallback_invalid_json`
- `test_http_base_requires_init` (the happy path is still covered by `test_http_base_ipv6_host`)

**Trims** the dead `_weight_transfer_http_timeout()` reference from 2 tests but keeps their endpoint/payload assertions, which still pin real production behavior:

- `test_start_weight_update_posts_four_phase_endpoint`
- `test_finish_weight_update_posts_empty_body`

## Verification

```
$ pytest tests/unit/backends/vllm_utils/test_vllm_engine.py -q
....................                                                     [100%]
20 passed in 2.24s

$ pytest tests/unit/ --ignore=tests/unit/backends/megatron_utils -q
53 passed, 2 warnings in 29.38s

$ pre-commit run --all-files
... all hooks Passed
```

Diff is +3/-52 in a single file.