### PR TITLE
fix(weight-sync): record IPC weight version on engines so ci_test passes

### DIFF
--- a/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -342,8 +342,14 @@ class UpdateWeightFromTensor:
             dist.barrier(group=get_gloo_group())
 
         # ── 5. Signal colocated engines to exit weight-update mode ───────────
+        # Thread the just-incremented weight_version through finish_weight_update
+        # so each colocated engine records it on ``self._weight_version``. The IPC
+        # path otherwise bypasses ``update_weights_from_tensor`` (the normal hook
+        # for setting it) and ci_test's engine-vs-updater check at
+        # slime/backends/megatron_utils/actor.py would mismatch (engine reports
+        # the model path from /v1/models; updater reports the integer version).
         if self._ipc_engine_coordinator:
-            ray.get(self._ipc_engine.finish_weight_update.remote())
+            ray.get(self._ipc_engine.finish_weight_update.remote(weight_version=str(self.weight_version)))
         dist.barrier(group=get_gloo_group())
 
         # ── 6. Post-process quantization (if needed) and resume ───────────────

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -808,11 +808,30 @@ class VLLMEngine(RayActor):
         except Exception:
             return {"ok": True, "raw": response.text}
 
-    def finish_weight_update(self) -> dict:
-        """``POST /finish_weight_update`` — signals vLLM to exit IPC weight-update mode."""
+    def finish_weight_update(self, weight_version: str | None = None) -> dict:
+        """``POST /finish_weight_update`` — signals vLLM to exit IPC weight-update mode.
+
+        ``weight_version`` records the version the trainer just transferred via IPC.
+        The IPC path bypasses ``update_weights_from_tensor`` (which is the normal
+        place ``_weight_version`` gets recorded for the distributed/NCCL path), so
+        callers must thread the new version through here for ``get_weight_version``
+        to report it back. Otherwise ci_test's engine-vs-updater version check
+        (slime/backends/megatron_utils/actor.py) fails the first time IPC weight
+        sync runs — ``_weight_version`` stays ``None`` and ``get_weight_version``
+        falls back to ``GET /v1/models``, which returns the model path string
+        (e.g. ``/root/models/Qwen2.5-0.5B-Instruct``), never matching the
+        updater's integer version (``"1"``, ``"2"``, …).
+        """
         update_timeout_s = float(os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"))
         response = self._post_json("finish_weight_update", {}, timeout=update_timeout_s)
         response.raise_for_status()
+        # Record the new version only after the POST succeeded — if the engine
+        # never actually exited weight-update mode, ``_weight_version`` must not
+        # advance, otherwise a retry would skip the resync. (Defensive: per the
+        # current call sites, any exception above propagates out of
+        # ``update_weights`` and the ci_test check below it would not run.)
+        if weight_version is not None:
+            self._weight_version = str(weight_version)
         try:
             return response.json()
         except Exception:


### PR DESCRIPTION
## Summary

After #22 added the colocated CUDA IPC weight sync path, the IPC branch in `UpdateWeightFromTensor.update_weights` bypasses `VLLMEngine.update_weights_from_tensor` entirely — data moves through `IPCWeightTransferEngine.trainer_send_weights` directly, not the `/update_weights` RPC. That RPC is the normal place where the engine's `self._weight_version` is recorded; the IPC path leaves it at the initial `None`.

## Failure mode

The first time IPC weight sync runs with `--ci-test`, `actor.update_weights` (`slime/backends/megatron_utils/actor.py`) picks a random rollout engine, calls `get_weight_version()`, and compares against the trainer-side `weight_updater.weight_version`. Because the engine's `_weight_version` is still `None`, `get_weight_version` falls back to `GET /v1/models` and returns the model path string (e.g. `/root/models/Qwen2.5-0.5B-Instruct`); the updater returns the integer version string (`"1"`, `"2"`, …). They never match:

```
RuntimeError: Weight version mismatch!
  Engine: /root/models/Qwen2.5-0.5B-Instruct, Updater: 1
```

Reproducer: any colocated test with `--ci-test` that reaches the first `update_weights`, e.g. `tests/test_qwen2.5_0.5B_short.py` or `tests/test_qwen2.5_0.5B_ppo_critic_only_short.py`.

## Fix

Thread the version through the IPC `finish_weight_update` hook:

- `VLLMEngine.finish_weight_update(weight_version: str | None = None)` now sets `self._weight_version = str(weight_version)` before issuing the `POST /finish_weight_update`.
- `UpdateWeightFromTensor.update_weights` (step 5) passes `str(self.weight_version)` when the coordinator rank fires the per-engine `finish_weight_update` RPC.

Each colocated engine's coordinator rank fires its own `finish_weight_update`, so every engine ends up with the new version recorded. The distributed/NCCL path is unchanged — it already writes `_weight_version` via `update_weights_from_tensor`.

## Test plan

- [x] Reproduced the `RuntimeError: Weight version mismatch!` on `tests/test_qwen2.5_0.5B_short.py` (colocate + IPC + ci_test) before the patch
- [x] Verified the same test passes 2 full RL steps after the patch (perf 1 / perf 2 / Job succeeded)
- [x] Verified ``tests/test_qwen2.5_0.5B_ppo_critic_only_short.py`` (which adds PPO+critic on top of colocate+IPC+ci_test) also runs end-to-end after this patch (paired with the #41 colocate-critic fix)
- [ ] Run the full PPO/colocate CI matrix on a clean image