### PR TITLE
fix(vllm): unify weight-transfer HTTP handling

### DIFF
--- a/slime/backends/vllm_utils/arguments.py
+++ b/slime/backends/vllm_utils/arguments.py
@@ -200,6 +200,12 @@ def add_vllm_arguments(parser):
         default=512,
         help="Max concurrent inference requests sent to each vLLM server worker.",
     )
+    parser.add_argument(
+        "--vllm-weight-transfer-timeout-sec",
+        type=float,
+        default=900.0,
+        help="Timeout (seconds) for vLLM weight-transfer HTTP control-plane calls.",
+    )
     # vime-only orchestration knob: not part of vllm's CLI but read by
     # UpdateWeightFromDistributed._use_vllm_packed() to choose packed
     # broadcast vs per-bucket NCCL for dense models.
@@ -318,6 +324,7 @@ _VIME_ORCHESTRATION_DESTS = frozenset(
         "router_port",
         "router_request_timeout_secs",
         "vllm_server_concurrency",
+        "vllm_weight_transfer_timeout_sec",
         "vllm_weight_sync_packed",
     }
 )

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -32,6 +32,15 @@ def _normalize_vllm_wake_tags(tags: list[str] | None) -> list[str] | None:
     return normalized or None
 
 
+def _response_json(response: requests.Response) -> dict:
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        e.add_note(f"{response.text=}")
+        raise
+    return response.json()
+
+
 def get_base_gpu_id(args, rank):
     """First local GPU index on this node for rollout engine *rank* (colocate vs actor[/critic]-offset layout)."""
     num_gpus = min(args.num_gpus_per_node, args.rollout_num_gpus_per_engine)
@@ -455,12 +464,7 @@ class VLLMEngine(RayActor):
         return f"http://{self.server_host}:{self.server_port}"
 
     def _weight_transfer_http_timeout(self) -> float:
-        return float(
-            os.environ.get(
-                "SLIME_VLLM_WEIGHT_TRANSFER_UPDATE_TIMEOUT_SEC",
-                os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"),
-            )
-        )
+        return float(self.args.vllm_weight_transfer_timeout_sec)
 
     def init(
         self,
@@ -585,11 +589,7 @@ class VLLMEngine(RayActor):
             {"update_info": update_info},
             timeout=self._weight_transfer_http_timeout(),
         )
-        response.raise_for_status()
-        try:
-            return response.json()
-        except Exception:
-            return {"ok": True, "raw": response.text}
+        return _response_json(response)
 
     def health_generate(self, timeout: float = 5.0) -> bool:
         """Return True if ``GET /health`` succeeds (SGLang uses ``GET /health_generate`` for the same role)."""
@@ -717,11 +717,7 @@ class VLLMEngine(RayActor):
             params={"level": level},
             timeout=30,
         )
-        response.raise_for_status()
-        try:
-            return response.json()
-        except Exception:
-            return {"ok": True, "raw": response.text}
+        return _response_json(response)
 
     def resume_memory_occupation(self, tags: list[str] | None = None):
         """``POST /wake_up`` when sleep mode is on (SGLang: ``POST /resume_memory_occupation``); else a small placeholder dict."""
@@ -736,11 +732,7 @@ class VLLMEngine(RayActor):
             params=wake_params,
             timeout=30,
         )
-        response.raise_for_status()
-        try:
-            return response.json()
-        except Exception:
-            return {"ok": True, "raw": response.text}
+        return _response_json(response)
 
     def init_weight_transfer_engine(self, payload: dict) -> dict:
         """``POST /init_weight_transfer_engine`` with a caller-supplied payload (IPC path).
@@ -748,16 +740,12 @@ class VLLMEngine(RayActor):
         For IPC mode the payload is ``{"init_info": {}}``; for NCCL use
         ``init_weights_update_group`` which constructs the payload from typed args.
         """
-        init_timeout_s = float(os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"))
+        init_timeout_s = self._weight_transfer_http_timeout()
         last_error = None
         for attempt in range(1, 4):
             try:
                 response = self._post_json("init_weight_transfer_engine", payload, timeout=init_timeout_s)
-                response.raise_for_status()
-                try:
-                    return response.json()
-                except Exception:
-                    return {"ok": True, "raw": response.text}
+                return _response_json(response)
             except Exception as e:
                 last_error = e
                 if attempt < 3:
@@ -772,11 +760,7 @@ class VLLMEngine(RayActor):
             {"is_checkpoint_format": is_checkpoint_format},
             timeout=self._weight_transfer_http_timeout(),
         )
-        response.raise_for_status()
-        try:
-            return response.json()
-        except Exception:
-            return {"ok": True, "raw": response.text}
+        return _response_json(response)
 
     def finish_weight_update(self) -> dict:
         """``POST /finish_weight_update`` — signals vLLM to exit IPC weight-update mode.
@@ -786,11 +770,7 @@ class VLLMEngine(RayActor):
         single-RPC version-with-data semantics.
         """
         response = self._post_json("finish_weight_update", {}, timeout=self._weight_transfer_http_timeout())
-        response.raise_for_status()
-        try:
-            return response.json()
-        except Exception:
-            return {"ok": True, "raw": response.text}
+        return _response_json(response)
 
     def check_weights(self, action: str):
         """No vLLM ``weights_checker`` route; return a placeholder (SGLang posts to ``/weights_checker``)."""
@@ -812,16 +792,12 @@ class VLLMEngine(RayActor):
                 "world_size": world_size,
             }
         }
-        init_timeout_s = float(os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"))
+        init_timeout_s = self._weight_transfer_http_timeout()
         last_error = None
         for attempt in range(1, 4):
             try:
                 response = self._post_json("init_weight_transfer_engine", payload, timeout=init_timeout_s)
-                response.raise_for_status()
-                try:
-                    return response.json()
-                except Exception:
-                    return {"ok": True, "raw": response.text}
+                return _response_json(response)
             except Exception as e:
                 last_error = e
                 if attempt < 3:
@@ -875,11 +851,7 @@ class VLLMEngine(RayActor):
             },
             timeout=600,
         )
-        response.raise_for_status()
-        try:
-            return response.json()
-        except Exception:
-            return {"ok": True, "raw": response.text}
+        return _response_json(response)
 
     def pause_generation(self):
         """``POST /pause`` with mode="keep" (SGLang: ``POST /pause_generation``); returns the ``requests.Response``."""

--- a/tests/unit/backends/vllm_utils/conftest.py
+++ b/tests/unit/backends/vllm_utils/conftest.py
@@ -14,6 +14,7 @@ def vllm_args() -> SimpleNamespace:
         hf_checkpoint="/tmp/model",
         router_ip=None,
         router_port=None,
+        vllm_weight_transfer_timeout_sec=900.0,
         num_gpus_per_node=8,
         rollout_num_gpus_per_engine=4,
         colocate=False,

--- a/tests/unit/backends/vllm_utils/test_arguments.py
+++ b/tests/unit/backends/vllm_utils/test_arguments.py
@@ -253,8 +253,20 @@ def test_orchestration_dests_use_new_names(args_mod):
     assert "router_ip" in args_mod._VIME_ORCHESTRATION_DESTS
     assert "router_port" in args_mod._VIME_ORCHESTRATION_DESTS
     assert "router_request_timeout_secs" in args_mod._VIME_ORCHESTRATION_DESTS
+    assert "vllm_weight_transfer_timeout_sec" in args_mod._VIME_ORCHESTRATION_DESTS
     assert "vllm_router_ip" not in args_mod._VIME_ORCHESTRATION_DESTS
     assert "vllm_router_port" not in args_mod._VIME_ORCHESTRATION_DESTS
+
+
+@pytest.mark.unit
+def test_add_vllm_arguments_parses_weight_transfer_timeout(args_mod, monkeypatch):
+    monkeypatch.setattr(args_mod.AsyncEngineArgs, "add_cli_args", staticmethod(lambda parser: parser))
+    parser = argparse.ArgumentParser(add_help=False)
+    args_mod.add_vllm_arguments(parser)
+    default, _ = parser.parse_known_args([])
+    assert default.vllm_weight_transfer_timeout_sec == 900.0
+    parsed, _ = parser.parse_known_args(["--vllm-weight-transfer-timeout-sec", "123.5"])
+    assert parsed.vllm_weight_transfer_timeout_sec == 123.5
 
 
 def _realistic_add_vllm_arguments(parser):
@@ -263,6 +275,12 @@ def _realistic_add_vllm_arguments(parser):
     parser.add_argument("--router-ip", dest="router_ip", type=str, default=None)
     parser.add_argument("--router-port", dest="router_port", type=int, default=None)
     parser.add_argument("--vllm-server-concurrency", dest="vllm_server_concurrency", type=int, default=512)
+    parser.add_argument(
+        "--vllm-weight-transfer-timeout-sec",
+        dest="vllm_weight_transfer_timeout_sec",
+        type=float,
+        default=900.0,
+    )
     return parser
 
 
@@ -285,6 +303,7 @@ def test_action_table_excludes_orchestration(args_mod, monkeypatch):
     assert "router_ip" not in table
     assert "router_port" not in table
     assert "vllm_server_concurrency" not in table
+    assert "vllm_weight_transfer_timeout_sec" not in table
 
 
 @pytest.mark.unit

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -20,7 +20,9 @@ class _MockResponse:
 
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
-            raise RuntimeError(f"HTTP {self.status_code}")
+            error = requests.exceptions.HTTPError(f"HTTP {self.status_code}")
+            error.response = self  # type: ignore[assignment]
+            raise error
 
     def json(self) -> dict:
         if self._json_data is None:
@@ -221,16 +223,74 @@ def test_post_vllm_update_weights_http_wraps_update_info(vllm_engine, monkeypatc
 
 
 @pytest.mark.unit
-def test_weight_transfer_http_timeout_reads_env(vllm_engine, monkeypatch):
-    monkeypatch.setenv("SLIME_VLLM_WEIGHT_TRANSFER_UPDATE_TIMEOUT_SEC", "123.5")
+def test_weight_transfer_http_timeout_reads_config(vllm_engine):
+    vllm_engine.args.vllm_weight_transfer_timeout_sec = 123.5
     assert vllm_engine._weight_transfer_http_timeout() == 123.5
 
 
 @pytest.mark.unit
-def test_weight_transfer_http_timeout_fallback_to_legacy_env(vllm_engine, monkeypatch):
-    monkeypatch.delenv("SLIME_VLLM_WEIGHT_TRANSFER_UPDATE_TIMEOUT_SEC", raising=False)
-    monkeypatch.setenv("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "42")
-    assert vllm_engine._weight_transfer_http_timeout() == 42.0
+def test_weight_transfer_http_timeout_uses_argument_default(vllm_engine):
+    assert vllm_engine.args.vllm_weight_transfer_timeout_sec == 900.0
+    assert vllm_engine._weight_transfer_http_timeout() == 900.0
+
+
+@pytest.mark.unit
+def test_start_weight_update_uses_config_timeout(vllm_engine, monkeypatch):
+    vllm_engine.args.vllm_weight_transfer_timeout_sec = 123.5
+    calls: list[tuple] = []
+
+    def fake_post(endpoint: str, payload: dict, timeout: float):
+        calls.append((endpoint, payload, timeout))
+        return _MockResponse(json_data={"ok": True})
+
+    monkeypatch.setattr(vllm_engine, "_post_json", fake_post)
+
+    vllm_engine.start_weight_update()
+    assert calls[0][2] == 123.5
+
+
+@pytest.mark.unit
+def test_init_weights_update_group_uses_config_timeout(vllm_engine, monkeypatch):
+    vllm_engine.args.vllm_weight_transfer_timeout_sec = 123.5
+    calls: list[tuple] = []
+
+    def fake_post(endpoint: str, payload: dict, timeout: float):
+        calls.append((endpoint, payload, timeout))
+        return _MockResponse(json_data={"initialized": True})
+
+    monkeypatch.setattr(vllm_engine, "_post_json", fake_post)
+
+    vllm_engine.init_weights_update_group(
+        "127.0.0.1",
+        29500,
+        rank_offset=1,
+        world_size=4,
+        group_name="unused",
+        backend="nccl",
+    )
+    assert calls[0][2] == 123.5
+
+
+@pytest.mark.unit
+def test_response_json_parses_dict():
+    response = _MockResponse(json_data={"status": "ready"})
+    assert mod._response_json(response) == {"status": "ready"}
+
+
+@pytest.mark.unit
+def test_response_json_invalid_json_raises():
+    response = _MockResponse(text="not-json")
+    response.json = lambda: (_ for _ in ()).throw(ValueError("no json"))  # type: ignore[method-assign]
+    with pytest.raises(ValueError, match="no json"):
+        mod._response_json(response)
+
+
+@pytest.mark.unit
+def test_response_json_http_error_adds_response_text_note():
+    response = _MockResponse(json_data={"error": "bad"}, text="server exploded", status_code=500)
+    with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+        mod._response_json(response)
+    assert "response.text='server exploded'" in exc_info.value.__notes__
 
 
 @pytest.mark.unit
@@ -347,4 +407,3 @@ def test_init_weights_update_group_raises_after_three_failures(vllm_engine, monk
             group_name="g",
             backend="nccl",
         )
-


### PR DESCRIPTION
Follow-up to #22 and rebased over #49 / current `main`. PR #49 merged the R3 routing-replay work and partially centralized the vLLM weight-transfer timeout path, but current `main` still had two issues in the vLLM control plane:

- Response parsing failures were converted to `{"ok": True, "raw": ...}` in several endpoints, which can hide bad/plain-text responses as success.
- `init_weight_transfer_engine` / `init_weights_update_group` still used a separate timeout path from the rest of the weight-transfer calls.

## Why this is not duplicating #49

#49 was a routing replay feature PR. It did touch `vllm_engine.py`, and it left `start_weight_update` / `finish_weight_update` using a timeout helper, but it did not make response parsing fail loud and did not move all weight-transfer control-plane calls to a config-backed timeout. This PR is now scoped to those remaining control-plane fixes.

## Changes

- Replace the old fallback parser with a slime-style `_response_json(response)` helper:
  - `raise_for_status()` first.
  - Attach `response.text` to HTTP errors with `Exception.add_note`, matching the SGLang engine pattern.
  - Parse JSON directly and let invalid JSON fail instead of returning `ok: True`.
- Add `--vllm-weight-transfer-timeout-sec` (default `900.0`) as the vime config knob for vLLM weight-transfer HTTP control-plane calls.
- Exclude that vime-only config knob from forwarding to `vllm serve`.
- Route `update_weights`, `start_weight_update`, `finish_weight_update`, `init_weight_transfer_engine`, and `init_weights_update_group` through the same timeout helper.
- Remove the old `SLIME_VLLM_WEIGHT_TRANSFER_*_TIMEOUT_SEC` env-var path from this code.

## Tests

```bash
uv run --active python -m pytest tests/unit/backends/vllm_utils/test_vllm_engine.py tests/unit/backends/vllm_utils/test_arguments.py -q
# 66 passed, 2 warnings in 85.43s

uv run --active pre-commit run --files slime/backends/vllm_utils/arguments.py slime/backends/vllm_utils/vllm_engine.py tests/unit/backends/vllm_utils/test_arguments.py tests/unit/backends/vllm_utils/test_vllm_engine.py
# all selected hooks passed
```

## AI assistance

AI assistance was used to inspect related PRs/reference implementations and update this PR. The human submitter should review every changed line and validate the behavior before merge.