### PR TITLE
[Feature] Routing replay (R3) for vLLM rollout (vLLM 0.22+, /inference/v1/generate)

### DIFF
--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -5,6 +5,10 @@ import logging
 import multiprocessing
 import os
 import time
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import numpy as np
 from urllib.parse import quote
 
 import requests
@@ -308,9 +312,6 @@ def launch_server_process(
     # unless the user already passed --vllm-max-model-len explicitly.
     if args.rollout_max_context_len is not None and getattr(args, "vllm_max_model_len", None) is None:
         cmd += ["--max-model-len", str(args.rollout_max_context_len)]
-    if getattr(args, "use_rollout_routing_replay", False):
-        cmd += ["--enable-return-routed-experts"]
-
     # vime-preferred defaults — must be explicitly forwarded because the vllm-side
     # default would otherwise apply (the generic forwarder skips values that equal
     # action.default).
@@ -335,6 +336,22 @@ def launch_server_process(
             return False
         _, action = entry
         return getattr(args, dest, action.default) != action.default
+
+    # MoE routing replay: routed-experts return + sync scheduling (incompatible with
+    # async scheduling on vLLM 0.21.x). Expert parallel is opt-in via
+    # ``--vllm-enable-expert-parallel``.
+    if getattr(args, "use_rollout_routing_replay", False):
+        cmd += ["--enable-return-routed-experts"]
+        if not _user_overrode("vllm_async_scheduling"):
+            cmd += ["--no-async-scheduling"]
+        # Prefix cache hits skip prefill MoE forwards; routed-experts capture then
+        # only covers decode (~gen_len-1 rows) and prompt_routed_experts is missing.
+        if not _user_overrode("vllm_enable_prefix_caching"):
+            cmd += ["--no-enable-prefix-caching"]
+        if getattr(args, "vllm_enable_expert_parallel", False):
+            cmd += ["--enable-expert-parallel"]
+            if not _user_overrode("vllm_expert_placement_strategy"):
+                cmd += ["--expert-placement-strategy", "linear"]
 
     # 1) gpu_memory_utilization: vllm default 0.92 OOMs in colocate training; vime ships 0.55.
     if _user_overrode("vllm_gpu_memory_utilization"):
@@ -403,6 +420,76 @@ def _redact_cmd_for_log(cmd: list[str]) -> str:
         if isinstance(token, str) and token in _REDACTED_FLAGS:
             redact_next = True
     return " ".join(parts)
+
+
+def _routing_rows_from_http_payload(value: Any) -> np.ndarray | None:
+    """Decode vLLM routed-experts HTTP field (base64 npy or nested list)."""
+    import base64
+    import io
+
+    import numpy as np
+
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return np.load(io.BytesIO(base64.b64decode(value)), allow_pickle=False)
+    if isinstance(value, list):
+        return np.asarray(value, dtype=np.int32)
+    return None
+
+
+def _verify_generate_routed_experts(base_url: str, model: str, timeout_s: float = 120.0) -> None:
+    """Smoke-check MoE routing via ``/v1/completions`` (matches R3 rollout on vLLM 0.21.x)."""
+    import numpy as np
+
+    base = base_url.rstrip("/")
+    payload = {
+        "model": model,
+        "prompt": "Routing replay smoke test.",
+        "max_tokens": 8,
+        "temperature": 0.0,
+        "logprobs": 1,
+        "return_token_ids": True,
+        "stream": False,
+    }
+    response = requests.post(f"{base}/v1/completions", json=payload, timeout=timeout_s)
+    response.raise_for_status()
+    body = response.json()
+    choice = (body.get("choices") or [{}])[0]
+    pre = _routing_rows_from_http_payload(body.get("prompt_routed_experts"))
+    gen = _routing_rows_from_http_payload(choice.get("routed_experts"))
+    if pre is None and gen is None:
+        raise RuntimeError(
+            "vLLM /v1/completions returned no routed-experts fields. "
+            "Ensure the server was started with --enable-return-routed-experts "
+            "(use_rollout_routing_replay)."
+        )
+    if pre is None or gen is None:
+        raise RuntimeError(
+            "vLLM /v1/completions must return both prompt_routed_experts and "
+            "choices[].routed_experts for routing replay. "
+            "Ensure --enable-return-routed-experts and --no-async-scheduling on the vLLM cmdline."
+        )
+
+    out_ids = choice.get("token_ids") or []
+    usage = body.get("usage") or {}
+    num_prompt = int(usage.get("prompt_tokens") or 0)
+    num_gen = int(usage.get("completion_tokens") or len(out_ids))
+    expected_rows = num_prompt + num_gen - 1 if num_prompt > 0 and num_gen > 0 else 0
+
+    merged = np.concatenate([pre, gen], axis=0)
+    n_rows = int(merged.shape[0])
+    if expected_rows > 0 and n_rows not in (expected_rows, expected_rows + 1):
+        raise RuntimeError(
+            f"vLLM routing replay smoke check: merged routing rows {n_rows} != "
+            f"expected {expected_rows} (prompt+gen len(tokens)-1). "
+            "Ensure --enable-return-routed-experts and --no-async-scheduling."
+        )
+    logger.info(
+        "vLLM routing replay smoke check OK (/v1/completions): prompt+gen routing rows=%s " "(expected %s)",
+        n_rows,
+        expected_rows,
+    )
 
 
 def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None, timeout_s: float = 300.0) -> None:
@@ -559,7 +646,10 @@ class VLLMEngine(RayActor):
             visible_devices=visible_devices,
             model_path=self.model_path,
         )
-        _wait_server_healthy(self._http_base(), process=self.process)
+        base = self._http_base()
+        _wait_server_healthy(base, process=self.process)
+        if getattr(self.args, "use_rollout_routing_replay", False):
+            _verify_generate_routed_experts(base, self.model_path)
 
     def _post_json(self, endpoint: str, payload: dict, timeout: float) -> requests.Response:
         url = f"{self._http_base()}/{endpoint.lstrip('/')}"

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ipaddress
+import json
 import logging
 import multiprocessing
 import os
@@ -337,21 +338,9 @@ def launch_server_process(
         _, action = entry
         return getattr(args, dest, action.default) != action.default
 
-    # MoE routing replay: routed-experts return + sync scheduling (incompatible with
-    # async scheduling on vLLM 0.21.x). Expert parallel is opt-in via
-    # ``--vllm-enable-expert-parallel``.
+    # MoE routing replay (vLLM 0.22+, PR #39568): routed experts on ``/inference/v1/generate``.
     if getattr(args, "use_rollout_routing_replay", False):
         cmd += ["--enable-return-routed-experts"]
-        if not _user_overrode("vllm_async_scheduling"):
-            cmd += ["--no-async-scheduling"]
-        # Prefix cache hits skip prefill MoE forwards; routed-experts capture then
-        # only covers decode (~gen_len-1 rows) and prompt_routed_experts is missing.
-        if not _user_overrode("vllm_enable_prefix_caching"):
-            cmd += ["--no-enable-prefix-caching"]
-        if getattr(args, "vllm_enable_expert_parallel", False):
-            cmd += ["--enable-expert-parallel"]
-            if not _user_overrode("vllm_expert_placement_strategy"):
-                cmd += ["--expert-placement-strategy", "linear"]
 
     # 1) gpu_memory_utilization: vllm default 0.92 OOMs in colocate training; vime ships 0.55.
     if _user_overrode("vllm_gpu_memory_utilization"):
@@ -422,6 +411,17 @@ def _redact_cmd_for_log(cmd: list[str]) -> str:
     return " ".join(parts)
 
 
+def _response_json_or_fallback(response) -> dict:
+    """Parse JSON from an HTTP response, returning a structured error dict on failure."""
+    try:
+        data = response.json()
+    except (ValueError, json.JSONDecodeError):
+        return {"ok": False, "error": "Invalid JSON response", "raw": getattr(response, "text", "")}
+    if not isinstance(data, dict):
+        return {"ok": False, "error": "Response is not a dictionary", "data": data}
+    return data
+
+
 def _routing_rows_from_http_payload(value: Any) -> np.ndarray | None:
     """Decode vLLM routed-experts HTTP field (base64 npy or nested list)."""
     import base64
@@ -439,54 +439,50 @@ def _routing_rows_from_http_payload(value: Any) -> np.ndarray | None:
 
 
 def _verify_generate_routed_experts(base_url: str, model: str, timeout_s: float = 120.0) -> None:
-    """Smoke-check MoE routing via ``/v1/completions`` (matches R3 rollout on vLLM 0.21.x)."""
-    import numpy as np
+    """Smoke-check MoE routing via ``/inference/v1/generate`` (same path as R3 rollout; vLLM 0.22+)."""
+    from slime.rollout.vllm_rollout import _merge_generate_routed_experts
 
     base = base_url.rstrip("/")
+    token_ids = [1, 2, 3, 4, 5]
     payload = {
         "model": model,
-        "prompt": "Routing replay smoke test.",
-        "max_tokens": 8,
-        "temperature": 0.0,
-        "logprobs": 1,
-        "return_token_ids": True,
-        "stream": False,
+        "token_ids": token_ids,
+        "sampling_params": {
+            "max_tokens": 8,
+            "temperature": 0.0,
+            "logprobs": 1,
+        },
     }
-    response = requests.post(f"{base}/v1/completions", json=payload, timeout=timeout_s)
+    response = requests.post(f"{base}/inference/v1/generate", json=payload, timeout=timeout_s)
     response.raise_for_status()
     body = response.json()
     choice = (body.get("choices") or [{}])[0]
-    pre = _routing_rows_from_http_payload(body.get("prompt_routed_experts"))
-    gen = _routing_rows_from_http_payload(choice.get("routed_experts"))
-    if pre is None and gen is None:
-        raise RuntimeError(
-            "vLLM /v1/completions returned no routed-experts fields. "
-            "Ensure the server was started with --enable-return-routed-experts "
-            "(use_rollout_routing_replay)."
-        )
-    if pre is None or gen is None:
-        raise RuntimeError(
-            "vLLM /v1/completions must return both prompt_routed_experts and "
-            "choices[].routed_experts for routing replay. "
-            "Ensure --enable-return-routed-experts and --no-async-scheduling on the vLLM cmdline."
-        )
-
     out_ids = choice.get("token_ids") or []
-    usage = body.get("usage") or {}
-    num_prompt = int(usage.get("prompt_tokens") or 0)
-    num_gen = int(usage.get("completion_tokens") or len(out_ids))
-    expected_rows = num_prompt + num_gen - 1 if num_prompt > 0 and num_gen > 0 else 0
+    num_gen = len(out_ids)
+    num_prompt = len(token_ids)
 
-    merged = np.concatenate([pre, gen], axis=0)
+    merged = _merge_generate_routed_experts(
+        body,
+        choice,
+        gen_token_count=num_gen,
+        prompt_token_count=num_prompt,
+    )
+    if merged is None:
+        raise RuntimeError(
+            "vLLM /inference/v1/generate returned no routed-experts fields. "
+            "Requires vLLM 0.22+ with --enable-return-routed-experts (use_rollout_routing_replay)."
+        )
+
+    expected_rows = num_prompt + num_gen - 1 if num_prompt > 0 and num_gen > 0 else 0
     n_rows = int(merged.shape[0])
     if expected_rows > 0 and n_rows not in (expected_rows, expected_rows + 1):
         raise RuntimeError(
-            f"vLLM routing replay smoke check: merged routing rows {n_rows} != "
+            f"vLLM routing replay smoke check: routing rows {n_rows} != "
             f"expected {expected_rows} (prompt+gen len(tokens)-1). "
-            "Ensure --enable-return-routed-experts and --no-async-scheduling."
+            "Requires vLLM 0.22+ (PR #39568)."
         )
     logger.info(
-        "vLLM routing replay smoke check OK (/v1/completions): prompt+gen routing rows=%s " "(expected %s)",
+        "vLLM routing replay smoke check OK (/inference/v1/generate): routing rows=%s " "(expected %s)",
         n_rows,
         expected_rows,
     )
@@ -538,7 +534,17 @@ class VLLMEngine(RayActor):
         self.node_rank = 0
 
     def _http_base(self) -> str:
+        if not hasattr(self, "server_host") or not hasattr(self, "server_port"):
+            raise RuntimeError("Call init() before using the vLLM HTTP client.")
         return f"http://{self.server_host}:{self.server_port}"
+
+    def _weight_transfer_http_timeout(self) -> float:
+        return float(
+            os.environ.get(
+                "SLIME_VLLM_WEIGHT_TRANSFER_UPDATE_TIMEOUT_SEC",
+                os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"),
+            )
+        )
 
     def init(
         self,
@@ -661,13 +667,11 @@ class VLLMEngine(RayActor):
         Caller must invoke ``start_weight_update`` / ``finish_weight_update`` around a batch of
         ``/update_weights`` calls (see ``UpdateWeightFromTensor`` / ``UpdateWeightFromDistributed``).
         """
-        timeout_s = float(
-            os.environ.get(
-                "SLIME_VLLM_WEIGHT_TRANSFER_UPDATE_TIMEOUT_SEC",
-                os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"),
-            )
+        response = self._post_json(
+            "update_weights",
+            {"update_info": update_info},
+            timeout=self._weight_transfer_http_timeout(),
         )
-        response = self._post_json("update_weights", {"update_info": update_info}, timeout=timeout_s)
         response.raise_for_status()
         try:
             return response.json()
@@ -886,11 +890,10 @@ class VLLMEngine(RayActor):
 
     def start_weight_update(self, is_checkpoint_format: bool = False) -> dict:
         """``POST /start_weight_update`` — signals vLLM to enter IPC weight-update mode."""
-        update_timeout_s = float(os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"))
         response = self._post_json(
             "start_weight_update",
             {"is_checkpoint_format": is_checkpoint_format},
-            timeout=update_timeout_s,
+            timeout=self._weight_transfer_http_timeout(),
         )
         response.raise_for_status()
         try:
@@ -912,8 +915,7 @@ class VLLMEngine(RayActor):
         (e.g. ``/root/models/Qwen2.5-0.5B-Instruct``), never matching the
         updater's integer version (``"1"``, ``"2"``, …).
         """
-        update_timeout_s = float(os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"))
-        response = self._post_json("finish_weight_update", {}, timeout=update_timeout_s)
+        response = self._post_json("finish_weight_update", {}, timeout=self._weight_transfer_http_timeout())
         response.raise_for_status()
         # Record the new version only after the POST succeeded — if the engine
         # never actually exited weight-update mode, ``_weight_version`` must not

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -405,51 +405,6 @@ def _redact_cmd_for_log(cmd: list[str]) -> str:
     return " ".join(parts)
 
 
-def _verify_generate_routed_experts(base_url: str, model: str, timeout_s: float = 120.0) -> None:
-    """Smoke-check MoE routing via ``/inference/v1/generate`` (same path as R3 rollout; vLLM 0.22+)."""
-    from slime.rollout.vllm_rollout import _decode_generate_routed_experts
-
-    base = base_url.rstrip("/")
-    token_ids = [1, 2, 3, 4, 5]
-    payload = {
-        "model": model,
-        "token_ids": token_ids,
-        "sampling_params": {
-            "max_tokens": 8,
-            "temperature": 0.0,
-            "logprobs": 1,
-        },
-    }
-    response = requests.post(f"{base}/inference/v1/generate", json=payload, timeout=timeout_s)
-    response.raise_for_status()
-    body = response.json()
-    choice = (body.get("choices") or [{}])[0]
-    out_ids = choice.get("token_ids") or []
-    num_gen = len(out_ids)
-    num_prompt = len(token_ids)
-
-    arr = _decode_generate_routed_experts(choice)
-    if arr is None:
-        raise RuntimeError(
-            "vLLM /inference/v1/generate returned no routed-experts fields. "
-            "Requires vLLM 0.22+ with --enable-return-routed-experts (use_rollout_routing_replay)."
-        )
-
-    expected_rows = num_prompt + num_gen - 1 if num_prompt > 0 and num_gen > 0 else 0
-    n_rows = int(arr.shape[0])
-    if expected_rows > 0 and n_rows != expected_rows:
-        raise RuntimeError(
-            f"vLLM routing replay smoke check: routing rows {n_rows} != "
-            f"expected {expected_rows} (prompt+gen len(tokens)-1). "
-            "Requires vLLM 0.22+ (PR #39568)."
-        )
-    logger.info(
-        "vLLM routing replay smoke check OK (/inference/v1/generate): routing rows=%s " "(expected %s)",
-        n_rows,
-        expected_rows,
-    )
-
-
 def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None, timeout_s: float = 300.0) -> None:
     """Wait until the vLLM server responds on ``GET /health`` (SGLang stacks typically use ``GET /health_generate``)."""
     start = time.time()
@@ -491,7 +446,6 @@ class VLLMEngine(RayActor):
         self.num_gpus_per_engine = num_gpus_per_engine
         self.process: multiprocessing.Process | None = None
         self._weight_version: str | None = None
-        self._is_local_server = not args.rollout_external
         # Slime runs one vLLM HTTP process per logical engine; multi-node worker rank is not used.
         self.node_rank = 0
 
@@ -616,8 +570,6 @@ class VLLMEngine(RayActor):
         )
         base = self._http_base()
         _wait_server_healthy(base, process=self.process)
-        if getattr(self.args, "use_rollout_routing_replay", False):
-            _verify_generate_routed_experts(base, self.model_path)
 
     def _post_json(self, endpoint: str, payload: dict, timeout: float) -> requests.Response:
         url = f"{self._http_base()}/{endpoint.lstrip('/')}"

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -450,8 +450,6 @@ class VLLMEngine(RayActor):
         self.node_rank = 0
 
     def _http_base(self) -> str:
-        if not hasattr(self, "server_host") or not hasattr(self, "server_port"):
-            raise RuntimeError("Call init() before using the vLLM HTTP client.")
         return f"http://{self.server_host}:{self.server_port}"
 
     def _weight_transfer_http_timeout(self) -> float:
@@ -568,8 +566,7 @@ class VLLMEngine(RayActor):
             visible_devices=visible_devices,
             model_path=self.model_path,
         )
-        base = self._http_base()
-        _wait_server_healthy(base, process=self.process)
+        _wait_server_healthy(self._http_base(), process=self.process)
 
     def _post_json(self, endpoint: str, payload: dict, timeout: float) -> requests.Response:
         url = f"{self._http_base()}/{endpoint.lstrip('/')}"

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
 import ipaddress
-import json
 import logging
 import multiprocessing
 import os
 import time
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    import numpy as np
 from urllib.parse import quote
 
 import requests
@@ -313,6 +308,9 @@ def launch_server_process(
     # unless the user already passed --vllm-max-model-len explicitly.
     if args.rollout_max_context_len is not None and getattr(args, "vllm_max_model_len", None) is None:
         cmd += ["--max-model-len", str(args.rollout_max_context_len)]
+    if getattr(args, "use_rollout_routing_replay", False):
+        cmd += ["--enable-return-routed-experts"]
+
     # vime-preferred defaults — must be explicitly forwarded because the vllm-side
     # default would otherwise apply (the generic forwarder skips values that equal
     # action.default).
@@ -337,10 +335,6 @@ def launch_server_process(
             return False
         _, action = entry
         return getattr(args, dest, action.default) != action.default
-
-    # MoE routing replay (vLLM 0.22+, PR #39568): routed experts on ``/inference/v1/generate``.
-    if getattr(args, "use_rollout_routing_replay", False):
-        cmd += ["--enable-return-routed-experts"]
 
     # 1) gpu_memory_utilization: vllm default 0.92 OOMs in colocate training; vime ships 0.55.
     if _user_overrode("vllm_gpu_memory_utilization"):
@@ -411,36 +405,9 @@ def _redact_cmd_for_log(cmd: list[str]) -> str:
     return " ".join(parts)
 
 
-def _response_json_or_fallback(response) -> dict:
-    """Parse JSON from an HTTP response, returning a structured error dict on failure."""
-    try:
-        data = response.json()
-    except (ValueError, json.JSONDecodeError):
-        return {"ok": False, "error": "Invalid JSON response", "raw": getattr(response, "text", "")}
-    if not isinstance(data, dict):
-        return {"ok": False, "error": "Response is not a dictionary", "data": data}
-    return data
-
-
-def _routing_rows_from_http_payload(value: Any) -> np.ndarray | None:
-    """Decode vLLM routed-experts HTTP field (base64 npy or nested list)."""
-    import base64
-    import io
-
-    import numpy as np
-
-    if value is None:
-        return None
-    if isinstance(value, str):
-        return np.load(io.BytesIO(base64.b64decode(value)), allow_pickle=False)
-    if isinstance(value, list):
-        return np.asarray(value, dtype=np.int32)
-    return None
-
-
 def _verify_generate_routed_experts(base_url: str, model: str, timeout_s: float = 120.0) -> None:
     """Smoke-check MoE routing via ``/inference/v1/generate`` (same path as R3 rollout; vLLM 0.22+)."""
-    from slime.rollout.vllm_rollout import _merge_generate_routed_experts
+    from slime.rollout.vllm_rollout import _decode_generate_routed_experts
 
     base = base_url.rstrip("/")
     token_ids = [1, 2, 3, 4, 5]
@@ -461,21 +428,16 @@ def _verify_generate_routed_experts(base_url: str, model: str, timeout_s: float 
     num_gen = len(out_ids)
     num_prompt = len(token_ids)
 
-    merged = _merge_generate_routed_experts(
-        body,
-        choice,
-        gen_token_count=num_gen,
-        prompt_token_count=num_prompt,
-    )
-    if merged is None:
+    arr = _decode_generate_routed_experts(choice)
+    if arr is None:
         raise RuntimeError(
             "vLLM /inference/v1/generate returned no routed-experts fields. "
             "Requires vLLM 0.22+ with --enable-return-routed-experts (use_rollout_routing_replay)."
         )
 
     expected_rows = num_prompt + num_gen - 1 if num_prompt > 0 and num_gen > 0 else 0
-    n_rows = int(merged.shape[0])
-    if expected_rows > 0 and n_rows not in (expected_rows, expected_rows + 1):
+    n_rows = int(arr.shape[0])
+    if expected_rows > 0 and n_rows != expected_rows:
         raise RuntimeError(
             f"vLLM routing replay smoke check: routing rows {n_rows} != "
             f"expected {expected_rows} (prompt+gen len(tokens)-1). "

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -774,7 +774,17 @@ class RolloutManager:
         if samples[0].rollout_log_probs is not None:
             train_data["rollout_log_probs"] = [sample.rollout_log_probs for sample in samples]
 
-        if samples[0].rollout_routed_experts is not None:
+        if getattr(self.args, "use_rollout_routing_replay", False):
+            routed = [sample.rollout_routed_experts for sample in samples]
+            missing = [i for i, r in enumerate(routed) if r is None]
+            if missing:
+                raise ValueError(
+                    f"use_rollout_routing_replay: {len(missing)}/{len(samples)} samples missing "
+                    "rollout_routed_experts (see rollout logs for vLLM routing replay errors). "
+                    "Ensure vLLM serves with --enable-return-routed-experts and --no-async-scheduling."
+                )
+            train_data["rollout_routed_experts"] = routed
+        elif samples[0].rollout_routed_experts is not None:
             train_data["rollout_routed_experts"] = [sample.rollout_routed_experts for sample in samples]
 
         if samples[0].train_metadata is not None:

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -781,7 +781,7 @@ class RolloutManager:
                 raise ValueError(
                     f"use_rollout_routing_replay: {len(missing)}/{len(samples)} samples missing "
                     "rollout_routed_experts (see rollout logs for vLLM routing replay errors). "
-                    "Ensure vLLM serves with --enable-return-routed-experts and --no-async-scheduling."
+                    "Ensure vLLM 0.22+ serves with --enable-return-routed-experts."
                 )
             train_data["rollout_routed_experts"] = routed
         elif samples[0].rollout_routed_experts is not None:

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -784,8 +784,6 @@ class RolloutManager:
                     "Ensure vLLM 0.22+ serves with --enable-return-routed-experts."
                 )
             train_data["rollout_routed_experts"] = routed
-        elif samples[0].rollout_routed_experts is not None:
-            train_data["rollout_routed_experts"] = [sample.rollout_routed_experts for sample in samples]
 
         if samples[0].train_metadata is not None:
             train_data["metadata"] = [sample.train_metadata for sample in samples]

--- a/slime/rollout/vllm_rollout.py
+++ b/slime/rollout/vllm_rollout.py
@@ -161,40 +161,101 @@ def _vllm_meta_from_generate_choice(args: Namespace, choice: dict, usage: dict |
 
 
 def _decode_vllm_routed_experts(value: str) -> np.ndarray:
+    """Decode vLLM routed-experts field when returned as base64 ``.npy`` (optional)."""
     raw = base64.b64decode(value.encode("ascii"), validate=True)
     return np.load(io.BytesIO(raw), allow_pickle=False)
 
 
-def _apply_vllm_routed_experts(
-    args: Namespace,
-    sample: Sample,
-    _output: dict,
-    choice: dict,
-) -> None:
-    """Populate ``sample.rollout_routed_experts`` from vLLM ``choices[].routed_experts`` when enabled.
+def _routing_array_from_payload(value: Any) -> np.ndarray | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return _decode_vllm_routed_experts(value)
+    if isinstance(value, list):
+        return np.asarray(value, dtype=np.int32)
+    logger.warning("routed_experts payload must be nested list or base64 npy from vLLM HTTP API")
+    return None
 
-    vLLM ``/inference/v1/generate`` returns routed experts as a base64 encoded
-    ``.npy`` payload on each response choice when the server is launched with
-    ``--enable-return-routed-experts``.
+
+def _merge_generate_routed_experts(
+    output: dict,
+    choice: dict,
+    gen_token_count: int | None,
+    prompt_token_count: int | None = None,
+) -> np.ndarray | None:
+    """Merge vLLM generate routing (same semantics as ``/v1/completions``).
+
+    SGLang returns one buffer reshaped to ``(len(tokens) - 1, num_layers, top_k)``.
     """
-    if not getattr(args, "use_rollout_routing_replay", False):
-        return
+    parts: list[np.ndarray] = []
+    prompt_re = output.get("prompt_routed_experts")
+    if prompt_re is not None:
+        prompt_arr = _routing_array_from_payload(prompt_re)
+        if prompt_arr is not None and prompt_arr.ndim == 3:
+            parts.append(prompt_arr)
+        elif prompt_arr is not None:
+            logger.warning(f"Unexpected prompt_routed_experts ndim={prompt_arr.ndim}")
+
     gen_re = choice.get("routed_experts")
-    if gen_re is None:
-        return
-    arr = _decode_vllm_routed_experts(gen_re)
-    n_tok = len(sample.tokens)
-    expected_rows = max(0, n_tok - 1)
+    if gen_re is not None:
+        gen_arr = _routing_array_from_payload(gen_re)
+        if gen_arr is not None and gen_arr.ndim == 3:
+            if (
+                prompt_re is None
+                and prompt_token_count is not None
+                and prompt_token_count > 0
+                and gen_token_count is not None
+                and gen_token_count > 0
+                and (
+                    gen_arr.shape[0] > gen_token_count or gen_arr.shape[0] >= prompt_token_count + gen_token_count - 1
+                )
+            ):
+                prompt_arr = gen_arr[:prompt_token_count]
+                gen_arr = gen_arr[prompt_token_count:]
+                if prompt_arr.size > 0:
+                    parts.append(prompt_arr)
+            if gen_token_count is not None and gen_token_count > 0 and gen_arr.shape[0] > gen_token_count:
+                gen_arr = gen_arr[:gen_token_count]
+            if gen_arr.size > 0:
+                parts.append(gen_arr)
+        elif gen_arr is not None:
+            logger.warning(f"Unexpected routed_experts ndim={gen_arr.ndim}")
+
+    if not parts:
+        return None
+    if len(parts) == 1:
+        return parts[0]
+    return np.concatenate(parts, axis=0)
+
+
+def _align_routed_experts_rows(arr: np.ndarray, expected_rows: int) -> np.ndarray | None:
+    """Resize merged routing to ``len(tokens) - 1`` rows (SGLang / Megatron layout)."""
     if arr.ndim != 3:
         logger.warning(f"Unexpected routed_experts ndim={arr.ndim} shape={arr.shape}")
-        return
-    if arr.shape[0] == n_tok:
-        arr = arr[:-1]
-    elif arr.shape[0] != expected_rows:
+        return None
+    n_rows = arr.shape[0]
+    if n_rows == expected_rows:
+        return arr
+    if n_rows == expected_rows + 1:
+        return arr[:-1]
+    if n_rows > expected_rows + 1:
         logger.warning(
-            f"routed_experts row count {arr.shape[0]} not in {{{expected_rows}, {n_tok}}}; "
-            "skipping rollout_routed_experts assign",
+            f"routed_experts row count {n_rows} > expected {expected_rows}; trimming to {expected_rows}",
         )
+        return arr[:expected_rows]
+    logger.warning(
+        f"routed_experts row count {n_rows} < expected {expected_rows}; "
+        "missing prompt_routed_experts on generate response?",
+    )
+    return None
+
+
+def _assign_rollout_routed_experts(args: Namespace, sample: Sample, arr: np.ndarray | None) -> None:
+    if arr is None:
+        return
+    expected_rows = max(0, len(sample.tokens) - 1)
+    arr = _align_routed_experts_rows(arr, expected_rows)
+    if arr is None:
         return
     nl = getattr(args, "num_layers", None)
     mtk = getattr(args, "moe_router_topk", None)
@@ -203,7 +264,37 @@ def _apply_vllm_routed_experts(
             f"routed_experts shape {arr.shape} does not match args (num_layers={nl}, moe_router_topk={mtk})",
         )
         return
-    sample.rollout_routed_experts = arr
+    sample.rollout_routed_experts = np.ascontiguousarray(arr.astype(np.int32, copy=True))
+
+
+def _apply_vllm_routed_experts(
+    args: Namespace,
+    sample: Sample,
+    output: dict,
+    choice: dict,
+    gen_token_count: int | None = None,
+    prompt_token_count: int | None = None,
+) -> None:
+    """Populate ``sample.rollout_routed_experts`` from ``/inference/v1/generate`` when R3 is enabled."""
+    if not getattr(args, "use_rollout_routing_replay", False):
+        return
+    arr = _merge_generate_routed_experts(output, choice, gen_token_count, prompt_token_count=prompt_token_count)
+    _assign_rollout_routed_experts(args, sample, arr)
+    if sample.rollout_routed_experts is not None:
+        return
+    if sample.status == Sample.Status.ABORTED and sample.response_length == 0:
+        return
+    pre = output.get("prompt_routed_experts")
+    gen = choice.get("routed_experts")
+    raise RuntimeError(
+        "vLLM routing replay: failed to set sample.rollout_routed_experts. "
+        f"prompt_routed_experts in response={pre is not None}, "
+        f"choices[0].routed_experts={gen is not None}, "
+        f"tokens={len(sample.tokens)}, gen_tokens={gen_token_count}. "
+        "Check vLLM was launched with --enable-return-routed-experts, "
+        "--no-enable-prefix-caching, and --enforce-eager. "
+        "Rollout uses /v1/completions for R3 (not /inference/v1/generate)."
+    )
 
 
 def _inference_generate_tokens_and_logprobs(choice: dict[str, Any]) -> tuple[list[int], list[float]]:
@@ -322,6 +413,65 @@ class GenerateState(metaclass=SingletonMeta):
         self.remaining_batch_size += len(samples)
 
 
+def _use_vllm_completions_for_r3(args: Namespace, sample: Sample, *, has_images: bool) -> bool:
+    """Use ``/v1/completions`` for MoE routing replay (v0.21.x returns prompt+gen routing there).
+
+    ``/inference/v1/generate`` often exposes only decode rows on ``choices[].routed_experts``.
+    Partial continuation must keep the token-id generate API.
+    """
+    if not getattr(args, "use_rollout_routing_replay", False):
+        return False
+    if has_images:
+        return False
+    if len(sample.response) > 0:
+        return False
+    return True
+
+
+def _build_completion_request_body(
+    model: str,
+    prompt: str,
+    sampling_params: dict[str, Any],
+) -> dict[str, Any]:
+    """Map rollout ``sampling_params`` to vLLM ``/v1/completions`` request body."""
+    body: dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": sampling_params["max_new_tokens"],
+        "temperature": sampling_params["temperature"],
+        "top_p": sampling_params["top_p"],
+        "logprobs": 1,
+        "return_token_ids": True,
+        "stream": False,
+    }
+    tk = sampling_params.get("top_k")
+    if tk is not None and tk > 0:
+        body["top_k"] = tk
+    if sampling_params.get("stop"):
+        body["stop"] = sampling_params["stop"]
+    if sampling_params.get("stop_token_ids"):
+        body["stop_token_ids"] = sampling_params["stop_token_ids"]
+    if sampling_params.get("seed") is not None:
+        body["seed"] = sampling_params["seed"]
+    return body
+
+
+def _completion_tokens_and_logprobs(choice: dict[str, Any]) -> tuple[list[int], list[float]]:
+    """Parse ``token_ids`` and ``logprobs`` from a vLLM ``/v1/completions`` choice."""
+    tids_raw = choice.get("token_ids")
+    if not isinstance(tids_raw, list) or not tids_raw:
+        return [], []
+    tids = [int(x) for x in tids_raw]
+    lp = choice.get("logprobs")
+    if not isinstance(lp, dict):
+        return tids, [0.0] * len(tids)
+    token_logprobs = lp.get("token_logprobs")
+    if isinstance(token_logprobs, list) and len(token_logprobs) >= len(tids):
+        lps = [float(x) if x is not None else 0.0 for x in token_logprobs[-len(tids) :]]
+        return tids, lps
+    return tids, [0.0] * len(tids)
+
+
 def _build_inference_sampling_params(sampling_params: dict[str, Any]) -> dict[str, Any]:
     """Map rollout ``sampling_params`` to vLLM ``/inference/v1/generate`` ``sampling_params`` body."""
     sp: dict[str, Any] = {
@@ -421,6 +571,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         if getattr(args, "router_policy", None) == "consistent_hashing":
             headers = {"X-SMG-Routing-Key": sample.session_id}
 
+    used_completions_r3 = False
     if images:
         # Disaggregated MM flow: render (preprocess) then tokens-only generate — see vLLM docs
         # ``examples/online_serving/disaggregated_serving`` (``/v1/chat/completions/render`` +
@@ -441,6 +592,18 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         gen_url = f"{base}/inference/v1/generate"
         with trace_span(sample, "vllm_mm_generate", attrs={"max_tokens": params["max_new_tokens"]}):
             output = await post(gen_url, generate_body, headers=headers)
+        request_prompt_len = len(generate_body.get("token_ids") or [])
+    elif _use_vllm_completions_for_r3(args, sample, has_images=False):
+        used_completions_r3 = True
+        completion_url = f"{base}/v1/completions"
+        completion_body = _build_completion_request_body(
+            args.hf_checkpoint,
+            sample.prompt,
+            params,
+        )
+        with trace_span(sample, "vllm_completion", attrs={"max_tokens": params["max_new_tokens"]}):
+            output = await post(completion_url, completion_body, headers=headers)
+        request_prompt_len = len(prompt_ids)
     else:
         url = f"{base}/inference/v1/generate"
         # vLLM disaggregated ``/inference/v1/generate`` is token-only. On partial continuation, send the
@@ -454,6 +617,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
             "token_ids": token_ids,
             "sampling_params": inference_sampling_params,
         }
+        request_prompt_len = len(token_ids)
         with trace_span(sample, "vllm_inference_generate", attrs={"max_new_tokens": params["max_new_tokens"]}):
             output = await post(url, payload, headers=headers)
 
@@ -461,13 +625,19 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
     skip_sp = params.get("skip_special_tokens")
     skip_decode = True if skip_sp is None else bool(skip_sp)
     out_ids = choice.get("token_ids") or []
-    text = (
-        state.tokenizer.decode(out_ids, skip_special_tokens=skip_decode)
-        if isinstance(out_ids, list) and out_ids
-        else ""
-    )
+    if used_completions_r3 and choice.get("text") is not None:
+        text = str(choice.get("text") or "")
+    else:
+        text = (
+            state.tokenizer.decode(out_ids, skip_special_tokens=skip_decode)
+            if isinstance(out_ids, list) and out_ids
+            else ""
+        )
     meta = _vllm_meta_from_generate_choice(args, choice, output.get("usage"))
-    new_response_tokens, new_response_log_probs = _inference_generate_tokens_and_logprobs(choice)
+    if used_completions_r3:
+        new_response_tokens, new_response_log_probs = _completion_tokens_and_logprobs(choice)
+    else:
+        new_response_tokens, new_response_log_probs = _inference_generate_tokens_and_logprobs(choice)
     new_response_tokens, new_response_log_probs = _align_engine_tokens_and_logprobs(
         new_response_tokens, new_response_log_probs
     )
@@ -491,7 +661,14 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         sample.rollout_log_probs = []
     sample.rollout_log_probs += new_response_log_probs
 
-    _apply_vllm_routed_experts(args, sample, output, choice)
+    _apply_vllm_routed_experts(
+        args,
+        sample,
+        output,
+        choice,
+        gen_token_count=len(new_response_tokens) if new_response_tokens else None,
+        prompt_token_count=request_prompt_len,
+    )
 
     sample.update_from_meta_info(args, meta)
     return sample

--- a/slime/rollout/vllm_rollout.py
+++ b/slime/rollout/vllm_rollout.py
@@ -183,9 +183,11 @@ def _merge_generate_routed_experts(
     gen_token_count: int | None,
     prompt_token_count: int | None = None,
 ) -> np.ndarray | None:
-    """Merge vLLM generate routing (same semantics as ``/v1/completions``).
+    """Merge prompt + generation routing from ``/inference/v1/generate``.
 
-    SGLang returns one buffer reshaped to ``(len(tokens) - 1, num_layers, top_k)``.
+    Megatron routing replay expects ``(len(tokens) - 1, num_layers, top_k)``.
+    vLLM 0.22+ returns routing on ``/inference/v1/generate`` (base64 npy on
+    ``choices[].routed_experts``, optionally split with ``prompt_routed_experts``).
     """
     parts: list[np.ndarray] = []
     prompt_re = output.get("prompt_routed_experts")
@@ -291,9 +293,8 @@ def _apply_vllm_routed_experts(
         f"prompt_routed_experts in response={pre is not None}, "
         f"choices[0].routed_experts={gen is not None}, "
         f"tokens={len(sample.tokens)}, gen_tokens={gen_token_count}. "
-        "Check vLLM was launched with --enable-return-routed-experts, "
-        "--no-enable-prefix-caching, and --enforce-eager. "
-        "Rollout uses /v1/completions for R3 (not /inference/v1/generate)."
+        "Check vLLM 0.22+ was launched with --enable-return-routed-experts. "
+        "Rollout uses /inference/v1/generate for R3."
     )
 
 
@@ -413,65 +414,6 @@ class GenerateState(metaclass=SingletonMeta):
         self.remaining_batch_size += len(samples)
 
 
-def _use_vllm_completions_for_r3(args: Namespace, sample: Sample, *, has_images: bool) -> bool:
-    """Use ``/v1/completions`` for MoE routing replay (v0.21.x returns prompt+gen routing there).
-
-    ``/inference/v1/generate`` often exposes only decode rows on ``choices[].routed_experts``.
-    Partial continuation must keep the token-id generate API.
-    """
-    if not getattr(args, "use_rollout_routing_replay", False):
-        return False
-    if has_images:
-        return False
-    if len(sample.response) > 0:
-        return False
-    return True
-
-
-def _build_completion_request_body(
-    model: str,
-    prompt: str,
-    sampling_params: dict[str, Any],
-) -> dict[str, Any]:
-    """Map rollout ``sampling_params`` to vLLM ``/v1/completions`` request body."""
-    body: dict[str, Any] = {
-        "model": model,
-        "prompt": prompt,
-        "max_tokens": sampling_params["max_new_tokens"],
-        "temperature": sampling_params["temperature"],
-        "top_p": sampling_params["top_p"],
-        "logprobs": 1,
-        "return_token_ids": True,
-        "stream": False,
-    }
-    tk = sampling_params.get("top_k")
-    if tk is not None and tk > 0:
-        body["top_k"] = tk
-    if sampling_params.get("stop"):
-        body["stop"] = sampling_params["stop"]
-    if sampling_params.get("stop_token_ids"):
-        body["stop_token_ids"] = sampling_params["stop_token_ids"]
-    if sampling_params.get("seed") is not None:
-        body["seed"] = sampling_params["seed"]
-    return body
-
-
-def _completion_tokens_and_logprobs(choice: dict[str, Any]) -> tuple[list[int], list[float]]:
-    """Parse ``token_ids`` and ``logprobs`` from a vLLM ``/v1/completions`` choice."""
-    tids_raw = choice.get("token_ids")
-    if not isinstance(tids_raw, list) or not tids_raw:
-        return [], []
-    tids = [int(x) for x in tids_raw]
-    lp = choice.get("logprobs")
-    if not isinstance(lp, dict):
-        return tids, [0.0] * len(tids)
-    token_logprobs = lp.get("token_logprobs")
-    if isinstance(token_logprobs, list) and len(token_logprobs) >= len(tids):
-        lps = [float(x) if x is not None else 0.0 for x in token_logprobs[-len(tids) :]]
-        return tids, lps
-    return tids, [0.0] * len(tids)
-
-
 def _build_inference_sampling_params(sampling_params: dict[str, Any]) -> dict[str, Any]:
     """Map rollout ``sampling_params`` to vLLM ``/inference/v1/generate`` ``sampling_params`` body."""
     sp: dict[str, Any] = {
@@ -571,7 +513,6 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         if getattr(args, "router_policy", None) == "consistent_hashing":
             headers = {"X-SMG-Routing-Key": sample.session_id}
 
-    used_completions_r3 = False
     if images:
         # Disaggregated MM flow: render (preprocess) then tokens-only generate — see vLLM docs
         # ``examples/online_serving/disaggregated_serving`` (``/v1/chat/completions/render`` +
@@ -593,17 +534,6 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         with trace_span(sample, "vllm_mm_generate", attrs={"max_tokens": params["max_new_tokens"]}):
             output = await post(gen_url, generate_body, headers=headers)
         request_prompt_len = len(generate_body.get("token_ids") or [])
-    elif _use_vllm_completions_for_r3(args, sample, has_images=False):
-        used_completions_r3 = True
-        completion_url = f"{base}/v1/completions"
-        completion_body = _build_completion_request_body(
-            args.hf_checkpoint,
-            sample.prompt,
-            params,
-        )
-        with trace_span(sample, "vllm_completion", attrs={"max_tokens": params["max_new_tokens"]}):
-            output = await post(completion_url, completion_body, headers=headers)
-        request_prompt_len = len(prompt_ids)
     else:
         url = f"{base}/inference/v1/generate"
         # vLLM disaggregated ``/inference/v1/generate`` is token-only. On partial continuation, send the
@@ -625,19 +555,13 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
     skip_sp = params.get("skip_special_tokens")
     skip_decode = True if skip_sp is None else bool(skip_sp)
     out_ids = choice.get("token_ids") or []
-    if used_completions_r3 and choice.get("text") is not None:
-        text = str(choice.get("text") or "")
-    else:
-        text = (
-            state.tokenizer.decode(out_ids, skip_special_tokens=skip_decode)
-            if isinstance(out_ids, list) and out_ids
-            else ""
-        )
+    text = (
+        state.tokenizer.decode(out_ids, skip_special_tokens=skip_decode)
+        if isinstance(out_ids, list) and out_ids
+        else ""
+    )
     meta = _vllm_meta_from_generate_choice(args, choice, output.get("usage"))
-    if used_completions_r3:
-        new_response_tokens, new_response_log_probs = _completion_tokens_and_logprobs(choice)
-    else:
-        new_response_tokens, new_response_log_probs = _inference_generate_tokens_and_logprobs(choice)
+    new_response_tokens, new_response_log_probs = _inference_generate_tokens_and_logprobs(choice)
     new_response_tokens, new_response_log_probs = _align_engine_tokens_and_logprobs(
         new_response_tokens, new_response_log_probs
     )

--- a/slime/rollout/vllm_rollout.py
+++ b/slime/rollout/vllm_rollout.py
@@ -161,141 +161,70 @@ def _vllm_meta_from_generate_choice(args: Namespace, choice: dict, usage: dict |
 
 
 def _decode_vllm_routed_experts(value: str) -> np.ndarray:
-    """Decode vLLM routed-experts field when returned as base64 ``.npy`` (optional)."""
+    """Decode vLLM routed-experts field returned as base64 ``.npy`` bytes."""
     raw = base64.b64decode(value.encode("ascii"), validate=True)
     return np.load(io.BytesIO(raw), allow_pickle=False)
-
-
-def _routing_array_from_payload(value: Any) -> np.ndarray | None:
-    if value is None:
-        return None
-    if isinstance(value, str):
-        return _decode_vllm_routed_experts(value)
-    if isinstance(value, list):
-        return np.asarray(value, dtype=np.int32)
-    logger.warning("routed_experts payload must be nested list or base64 npy from vLLM HTTP API")
-    return None
-
-
-def _merge_generate_routed_experts(
-    output: dict,
-    choice: dict,
-    gen_token_count: int | None,
-    prompt_token_count: int | None = None,
-) -> np.ndarray | None:
-    """Merge prompt + generation routing from ``/inference/v1/generate``.
-
-    Megatron routing replay expects ``(len(tokens) - 1, num_layers, top_k)``.
-    vLLM 0.22+ returns routing on ``/inference/v1/generate`` (base64 npy on
-    ``choices[].routed_experts``, optionally split with ``prompt_routed_experts``).
-    """
-    parts: list[np.ndarray] = []
-    prompt_re = output.get("prompt_routed_experts")
-    if prompt_re is not None:
-        prompt_arr = _routing_array_from_payload(prompt_re)
-        if prompt_arr is not None and prompt_arr.ndim == 3:
-            parts.append(prompt_arr)
-        elif prompt_arr is not None:
-            logger.warning(f"Unexpected prompt_routed_experts ndim={prompt_arr.ndim}")
-
-    gen_re = choice.get("routed_experts")
-    if gen_re is not None:
-        gen_arr = _routing_array_from_payload(gen_re)
-        if gen_arr is not None and gen_arr.ndim == 3:
-            if (
-                prompt_re is None
-                and prompt_token_count is not None
-                and prompt_token_count > 0
-                and gen_token_count is not None
-                and gen_token_count > 0
-                and (
-                    gen_arr.shape[0] > gen_token_count or gen_arr.shape[0] >= prompt_token_count + gen_token_count - 1
-                )
-            ):
-                prompt_arr = gen_arr[:prompt_token_count]
-                gen_arr = gen_arr[prompt_token_count:]
-                if prompt_arr.size > 0:
-                    parts.append(prompt_arr)
-            if gen_token_count is not None and gen_token_count > 0 and gen_arr.shape[0] > gen_token_count:
-                gen_arr = gen_arr[:gen_token_count]
-            if gen_arr.size > 0:
-                parts.append(gen_arr)
-        elif gen_arr is not None:
-            logger.warning(f"Unexpected routed_experts ndim={gen_arr.ndim}")
-
-    if not parts:
-        return None
-    if len(parts) == 1:
-        return parts[0]
-    return np.concatenate(parts, axis=0)
-
-
-def _align_routed_experts_rows(arr: np.ndarray, expected_rows: int) -> np.ndarray | None:
-    """Resize merged routing to ``len(tokens) - 1`` rows (SGLang / Megatron layout)."""
-    if arr.ndim != 3:
-        logger.warning(f"Unexpected routed_experts ndim={arr.ndim} shape={arr.shape}")
-        return None
-    n_rows = arr.shape[0]
-    if n_rows == expected_rows:
-        return arr
-    if n_rows == expected_rows + 1:
-        return arr[:-1]
-    if n_rows > expected_rows + 1:
-        logger.warning(
-            f"routed_experts row count {n_rows} > expected {expected_rows}; trimming to {expected_rows}",
-        )
-        return arr[:expected_rows]
-    logger.warning(
-        f"routed_experts row count {n_rows} < expected {expected_rows}; "
-        "missing prompt_routed_experts on generate response?",
-    )
-    return None
-
-
-def _assign_rollout_routed_experts(args: Namespace, sample: Sample, arr: np.ndarray | None) -> None:
-    if arr is None:
-        return
-    expected_rows = max(0, len(sample.tokens) - 1)
-    arr = _align_routed_experts_rows(arr, expected_rows)
-    if arr is None:
-        return
-    nl = getattr(args, "num_layers", None)
-    mtk = getattr(args, "moe_router_topk", None)
-    if nl is not None and mtk is not None and (arr.shape[1] != nl or arr.shape[2] != mtk):
-        logger.warning(
-            f"routed_experts shape {arr.shape} does not match args (num_layers={nl}, moe_router_topk={mtk})",
-        )
-        return
-    sample.rollout_routed_experts = np.ascontiguousarray(arr.astype(np.int32, copy=True))
 
 
 def _apply_vllm_routed_experts(
     args: Namespace,
     sample: Sample,
-    output: dict,
     choice: dict,
-    gen_token_count: int | None = None,
-    prompt_token_count: int | None = None,
 ) -> None:
-    """Populate ``sample.rollout_routed_experts`` from ``/inference/v1/generate`` when R3 is enabled."""
+    """Populate ``sample.rollout_routed_experts`` from vLLM ``/inference/v1/generate`` (R3 only).
+
+    vLLM's contract is a single base64 `.npy` buffer on `choices[].routed_experts` with decoded
+    shape `(len(tokens) - 1, num_layers, top_k)`.
+    """
     if not getattr(args, "use_rollout_routing_replay", False):
         return
-    arr = _merge_generate_routed_experts(output, choice, gen_token_count, prompt_token_count=prompt_token_count)
-    _assign_rollout_routed_experts(args, sample, arr)
-    if sample.rollout_routed_experts is not None:
-        return
+
+    routed = choice.get("routed_experts")
     if sample.status == Sample.Status.ABORTED and sample.response_length == 0:
         return
-    pre = output.get("prompt_routed_experts")
-    gen = choice.get("routed_experts")
-    raise RuntimeError(
-        "vLLM routing replay: failed to set sample.rollout_routed_experts. "
-        f"prompt_routed_experts in response={pre is not None}, "
-        f"choices[0].routed_experts={gen is not None}, "
-        f"tokens={len(sample.tokens)}, gen_tokens={gen_token_count}. "
-        "Check vLLM 0.22+ was launched with --enable-return-routed-experts. "
-        "Rollout uses /inference/v1/generate for R3."
-    )
+    if routed is None:
+        raise RuntimeError(
+            "vLLM routing replay: missing choices[0].routed_experts on /inference/v1/generate response. "
+            "Check vLLM 0.22+ was launched with --enable-return-routed-experts."
+        )
+    if not isinstance(routed, str):
+        raise RuntimeError(
+            f"vLLM routing replay: choices[0].routed_experts must be base64 npy str, got {type(routed)}"
+        )
+
+    arr = _decode_vllm_routed_experts(routed)
+    if arr.ndim != 3:
+        raise RuntimeError(f"vLLM routing replay: routed_experts ndim={arr.ndim}, expected 3, shape={arr.shape}")
+
+    expected_rows = max(0, len(sample.tokens) - 1)
+    if arr.shape[0] != expected_rows:
+        raise RuntimeError(
+            f"vLLM routing replay: routed_experts rows {arr.shape[0]} != expected {expected_rows} (len(tokens)-1)."
+        )
+
+    nl = getattr(args, "num_layers", None)
+    mtk = getattr(args, "moe_router_topk", None)
+    if nl is not None and mtk is not None and (arr.shape[1] != nl or arr.shape[2] != mtk):
+        raise RuntimeError(f"vLLM routing replay: routed_experts shape {arr.shape} != (rows,{nl},{mtk}) from args.")
+    sample.rollout_routed_experts = np.ascontiguousarray(arr.astype(np.int32, copy=True))
+
+
+def _vllm_expected_routed_rows_from_tokens(token_count: int) -> int:
+    """Return expected routed-experts row count given total tokens."""
+    return max(0, token_count - 1)
+
+
+def _decode_generate_routed_experts(choice: dict[str, Any]) -> np.ndarray | None:
+    """Decode `choices[].routed_experts` (base64 npy) from vLLM generate response."""
+    routed = choice.get("routed_experts")
+    if routed is None:
+        return None
+    if not isinstance(routed, str):
+        raise RuntimeError(f"vLLM routed_experts must be base64 npy str, got {type(routed)}")
+    arr = _decode_vllm_routed_experts(routed)
+    if arr.ndim != 3:
+        raise RuntimeError(f"vLLM routed_experts ndim={arr.ndim}, expected 3, shape={arr.shape}")
+    return arr
 
 
 def _inference_generate_tokens_and_logprobs(choice: dict[str, Any]) -> tuple[list[int], list[float]]:
@@ -533,7 +462,6 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         gen_url = f"{base}/inference/v1/generate"
         with trace_span(sample, "vllm_mm_generate", attrs={"max_tokens": params["max_new_tokens"]}):
             output = await post(gen_url, generate_body, headers=headers)
-        request_prompt_len = len(generate_body.get("token_ids") or [])
     else:
         url = f"{base}/inference/v1/generate"
         # vLLM disaggregated ``/inference/v1/generate`` is token-only. On partial continuation, send the
@@ -547,7 +475,6 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
             "token_ids": token_ids,
             "sampling_params": inference_sampling_params,
         }
-        request_prompt_len = len(token_ids)
         with trace_span(sample, "vllm_inference_generate", attrs={"max_new_tokens": params["max_new_tokens"]}):
             output = await post(url, payload, headers=headers)
 
@@ -585,16 +512,8 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         sample.rollout_log_probs = []
     sample.rollout_log_probs += new_response_log_probs
 
-    _apply_vllm_routed_experts(
-        args,
-        sample,
-        output,
-        choice,
-        gen_token_count=len(new_response_tokens) if new_response_tokens else None,
-        prompt_token_count=request_prompt_len,
-    )
-
     sample.update_from_meta_info(args, meta)
+    _apply_vllm_routed_experts(args, sample, choice)
     return sample
 
 

--- a/slime/rollout/vllm_rollout.py
+++ b/slime/rollout/vllm_rollout.py
@@ -161,7 +161,6 @@ def _vllm_meta_from_generate_choice(args: Namespace, choice: dict, usage: dict |
 
 
 def _decode_vllm_routed_experts(value: str) -> np.ndarray:
-    """Decode vLLM routed-experts field returned as base64 ``.npy`` bytes."""
     raw = base64.b64decode(value.encode("ascii"), validate=True)
     return np.load(io.BytesIO(raw), allow_pickle=False)
 

--- a/slime/rollout/vllm_rollout.py
+++ b/slime/rollout/vllm_rollout.py
@@ -209,24 +209,6 @@ def _apply_vllm_routed_experts(
     sample.rollout_routed_experts = np.ascontiguousarray(arr.astype(np.int32, copy=True))
 
 
-def _vllm_expected_routed_rows_from_tokens(token_count: int) -> int:
-    """Return expected routed-experts row count given total tokens."""
-    return max(0, token_count - 1)
-
-
-def _decode_generate_routed_experts(choice: dict[str, Any]) -> np.ndarray | None:
-    """Decode `choices[].routed_experts` (base64 npy) from vLLM generate response."""
-    routed = choice.get("routed_experts")
-    if routed is None:
-        return None
-    if not isinstance(routed, str):
-        raise RuntimeError(f"vLLM routed_experts must be base64 npy str, got {type(routed)}")
-    arr = _decode_vllm_routed_experts(routed)
-    if arr.ndim != 3:
-        raise RuntimeError(f"vLLM routed_experts ndim={arr.ndim}, expected 3, shape={arr.shape}")
-    return arr
-
-
 def _inference_generate_tokens_and_logprobs(choice: dict[str, Any]) -> tuple[list[int], list[float]]:
     """Parse ``token_ids`` and ``logprobs.content`` from a vLLM ``/inference/v1/generate`` choice."""
     tids_raw = choice.get("token_ids")

--- a/tests/test_vllm_generate_endpoint.py
+++ b/tests/test_vllm_generate_endpoint.py
@@ -181,7 +181,13 @@ def _execute_case(case: VLLMGenerateCase):
         assert len(sample.rollout_log_probs) == sample.response_length
         assert sample.status in (Sample.Status.COMPLETED, Sample.Status.TRUNCATED)
         if case.use_rollout_routing_replay:
-            assert sample.rollout_routed_experts is not None
+            re = sample.rollout_routed_experts
+            assert re is not None
+            assert re.ndim == 3
+            expected_rows = len(sample.tokens) - 1
+            assert (
+                re.shape[0] == expected_rows
+            ), f"rollout_routed_experts rows {re.shape[0]} != len(tokens)-1 ({expected_rows})"
     finally:
         _stop_process_tree(process)
 

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import base64
 import dataclasses
+import io
 import json
 
+import numpy as np
 import pytest
 import requests
 import torch
@@ -329,3 +332,36 @@ def test_init_weights_update_group_raises_after_three_failures(vllm_engine, monk
             group_name="g",
             backend="nccl",
         )
+
+
+@pytest.mark.unit
+def test_verify_generate_routed_experts_accepts_single_buffer(monkeypatch):
+    prompt_toks = 5
+    gen_toks = 3
+    nrow = prompt_toks + gen_toks - 1
+    combined = np.zeros((nrow, 2, 1), dtype=np.int32)
+    buf = io.BytesIO()
+    np.save(buf, combined)
+    encoded = base64.b64encode(buf.getvalue()).decode("ascii")
+
+    def fake_post(url, json=None, timeout=None):
+        assert url.endswith("/inference/v1/generate")
+        return _MockResponse(
+            json_data={
+                "choices": [{"token_ids": list(range(gen_toks)), "routed_experts": encoded}],
+            },
+        )
+
+    monkeypatch.setattr(mod.requests, "post", fake_post)
+    mod._verify_generate_routed_experts("http://127.0.0.1:8000", "test-model")
+
+
+@pytest.mark.unit
+def test_verify_generate_routed_experts_raises_when_routing_missing(monkeypatch):
+    monkeypatch.setattr(
+        mod.requests,
+        "post",
+        lambda *a, **k: _MockResponse(json_data={"choices": [{"token_ids": [1, 2]}]}),
+    )
+    with pytest.raises(RuntimeError, match="no routed-experts"):
+        mod._verify_generate_routed_experts("http://127.0.0.1:8000", "test-model")

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -182,34 +182,6 @@ def test_weight_transfer_http_timeout_fallback_to_legacy_env(vllm_engine, monkey
 
 
 @pytest.mark.unit
-def test_response_json_or_fallback_parses_dict():
-    response = _MockResponse(json_data={"status": "ready"})
-    assert mod._response_json_or_fallback(response) == {"status": "ready"}
-
-
-@pytest.mark.unit
-def test_response_json_or_fallback_non_dict_wrapped():
-    response = _MockResponse()
-    response.json = lambda: ["a", "b"]  # type: ignore[method-assign]
-    assert mod._response_json_or_fallback(response) == {
-        "ok": False,
-        "error": "Response is not a dictionary",
-        "data": ["a", "b"],
-    }
-
-
-@pytest.mark.unit
-def test_response_json_or_fallback_invalid_json():
-    response = _MockResponse(text="not-json")
-    response.json = lambda: (_ for _ in ()).throw(ValueError("no json"))  # type: ignore[method-assign]
-    assert mod._response_json_or_fallback(response) == {
-        "ok": False,
-        "error": "Invalid JSON response",
-        "raw": "not-json",
-    }
-
-
-@pytest.mark.unit
 def test_http_base_requires_init(vllm_args):
     from slime.backends.vllm_utils.vllm_engine import VLLMEngine
 

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import dataclasses
 import json
 
-import numpy as np
 import pytest
 import requests
 import torch
@@ -180,15 +179,6 @@ def test_weight_transfer_http_timeout_fallback_to_legacy_env(vllm_engine, monkey
 
 
 @pytest.mark.unit
-def test_http_base_requires_init(vllm_args):
-    from slime.backends.vllm_utils.vllm_engine import VLLMEngine
-
-    engine = VLLMEngine(vllm_args, rank=0)
-    with pytest.raises(RuntimeError, match="init\\(\\)"):
-        engine._http_base()
-
-
-@pytest.mark.unit
 def test_http_base_ipv6_host(vllm_engine):
     vllm_engine.server_host = "[2001:db8::1]"
     assert vllm_engine._http_base() == "http://[2001:db8::1]:8765"
@@ -302,5 +292,4 @@ def test_init_weights_update_group_raises_after_three_failures(vllm_engine, monk
             group_name="g",
             backend="nccl",
         )
-
 

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import base64
 import dataclasses
-import io
 import json
 
 import numpy as np
@@ -306,34 +304,3 @@ def test_init_weights_update_group_raises_after_three_failures(vllm_engine, monk
         )
 
 
-@pytest.mark.unit
-def test_verify_generate_routed_experts_accepts_single_buffer(monkeypatch):
-    prompt_toks = 5
-    gen_toks = 3
-    nrow = prompt_toks + gen_toks - 1
-    combined = np.zeros((nrow, 2, 1), dtype=np.int32)
-    buf = io.BytesIO()
-    np.save(buf, combined)
-    encoded = base64.b64encode(buf.getvalue()).decode("ascii")
-
-    def fake_post(url, json=None, timeout=None):
-        assert url.endswith("/inference/v1/generate")
-        return _MockResponse(
-            json_data={
-                "choices": [{"token_ids": list(range(gen_toks)), "routed_experts": encoded}],
-            },
-        )
-
-    monkeypatch.setattr(mod.requests, "post", fake_post)
-    mod._verify_generate_routed_experts("http://127.0.0.1:8000", "test-model")
-
-
-@pytest.mark.unit
-def test_verify_generate_routed_experts_raises_when_routing_missing(monkeypatch):
-    monkeypatch.setattr(
-        mod.requests,
-        "post",
-        lambda *a, **k: _MockResponse(json_data={"choices": [{"token_ids": [1, 2]}]}),
-    )
-    with pytest.raises(RuntimeError, match="no routed-experts"):
-        mod._verify_generate_routed_experts("http://127.0.0.1:8000", "test-model")

--- a/tests/unit/rollout/test_vllm_rollout.py
+++ b/tests/unit/rollout/test_vllm_rollout.py
@@ -226,30 +226,56 @@ def test_decode_vllm_routed_experts_roundtrip():
     np.testing.assert_array_equal(decoded, arr)
 
 
-@pytest.mark.unit
-def test_apply_vllm_routed_experts_assigns_when_shape_matches():
-    arr = np.zeros((3, 2, 1), dtype=np.int32)
+def _encode_routed_npy(arr: np.ndarray) -> str:
     buf = io.BytesIO()
     np.save(buf, arr)
-    encoded = base64.b64encode(buf.getvalue()).decode("ascii")
-
-    sample = Sample(tokens=[1, 2, 3, 4])
-    args = Namespace(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1)
-    mod._apply_vllm_routed_experts(args, sample, {}, {"routed_experts": encoded})
-    np.testing.assert_array_equal(sample.rollout_routed_experts, arr)
+    return base64.b64encode(buf.getvalue()).decode("ascii")
 
 
 @pytest.mark.unit
-def test_apply_vllm_routed_experts_strips_prompt_row_when_n_tok_rows():
-    arr = np.zeros((4, 2, 1), dtype=np.int32)
-    buf = io.BytesIO()
-    np.save(buf, arr)
-    encoded = base64.b64encode(buf.getvalue()).decode("ascii")
+def test_merge_generate_routed_experts_trims_extra_gen_rows():
+    prompt = np.ones((2, 2, 1), dtype=np.int32)
+    gen = np.full((4, 2, 1), 2, dtype=np.int32)
+    merged = mod._merge_generate_routed_experts(
+        {"prompt_routed_experts": _encode_routed_npy(prompt)},
+        {"routed_experts": _encode_routed_npy(gen)},
+        gen_token_count=2,
+    )
+    np.testing.assert_array_equal(merged, np.concatenate([prompt, gen[:2]], axis=0))
 
-    sample = Sample(tokens=[1, 2, 3, 4])
+
+@pytest.mark.unit
+def test_apply_vllm_routed_experts_merged_matches_sglang_layout():
+    prompt = np.zeros((2, 2, 1), dtype=np.int32)
+    gen = np.zeros((2, 2, 1), dtype=np.int32)
+    sample = Sample(tokens=[1, 2, 50, 51])
     args = Namespace(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1)
-    mod._apply_vllm_routed_experts(args, sample, {}, {"routed_experts": encoded})
-    np.testing.assert_array_equal(sample.rollout_routed_experts, arr[:-1])
+    mod._apply_vllm_routed_experts(
+        args,
+        sample,
+        {"prompt_routed_experts": _encode_routed_npy(prompt)},
+        {"routed_experts": _encode_routed_npy(gen)},
+        gen_token_count=2,
+    )
+    np.testing.assert_array_equal(sample.rollout_routed_experts, np.zeros((3, 2, 1), dtype=np.int32))
+
+
+@pytest.mark.unit
+def test_apply_vllm_routed_experts_merges_prompt_and_gen_nested_lists():
+    prompt_part = np.ones((2, 2, 1), dtype=np.int32)
+    gen_part = np.full((2, 2, 1), 2, dtype=np.int32)
+    expected = np.concatenate([prompt_part, gen_part], axis=0)
+
+    sample = Sample(tokens=[10, 20, 30, 40, 50])
+    args = Namespace(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1)
+    mod._apply_vllm_routed_experts(
+        args,
+        sample,
+        {"prompt_routed_experts": prompt_part.tolist()},
+        {"routed_experts": gen_part.tolist()},
+        gen_token_count=2,
+    )
+    np.testing.assert_array_equal(sample.rollout_routed_experts, expected)
 
 
 @pytest.mark.unit
@@ -431,8 +457,8 @@ def test_apply_vllm_routed_experts_disabled_or_missing():
     sample = Sample(tokens=[1, 2, 3])
     mod._apply_vllm_routed_experts(Namespace(use_rollout_routing_replay=False), sample, {}, {})
     assert sample.rollout_routed_experts is None
-    mod._apply_vllm_routed_experts(Namespace(use_rollout_routing_replay=True), sample, {}, {})
-    assert sample.rollout_routed_experts is None
+    with pytest.raises(RuntimeError, match="routing replay"):
+        mod._apply_vllm_routed_experts(Namespace(use_rollout_routing_replay=True), sample, {}, {})
 
 
 @pytest.mark.unit
@@ -440,17 +466,27 @@ def test_apply_vllm_routed_experts_skips_bad_shape():
     arr = np.zeros((2, 2), dtype=np.int32)
     sample = Sample(tokens=[1, 2, 3])
     args = Namespace(use_rollout_routing_replay=True)
-    mod._apply_vllm_routed_experts(args, sample, {}, {"routed_experts": _encode_routed(arr)})
-    assert sample.rollout_routed_experts is None
+    with pytest.raises(RuntimeError, match="routing replay"):
+        mod._apply_vllm_routed_experts(args, sample, {}, {"routed_experts": _encode_routed(arr)})
 
 
 @pytest.mark.unit
-def test_apply_vllm_routed_experts_skips_row_mismatch():
+def test_apply_vllm_routed_experts_trims_when_too_many_rows():
     arr = np.zeros((9, 2, 1), dtype=np.int32)
     sample = Sample(tokens=[1, 2, 3])
     args = Namespace(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1)
     mod._apply_vllm_routed_experts(args, sample, {}, {"routed_experts": _encode_routed(arr)})
-    assert sample.rollout_routed_experts is None
+    assert sample.rollout_routed_experts is not None
+    assert sample.rollout_routed_experts.shape == (2, 2, 1)
+
+
+@pytest.mark.unit
+def test_apply_vllm_routed_experts_raises_when_too_few_rows():
+    arr = np.zeros((1, 2, 1), dtype=np.int32)
+    sample = Sample(tokens=[1, 2, 3])
+    args = Namespace(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1)
+    with pytest.raises(RuntimeError, match="routing replay"):
+        mod._apply_vllm_routed_experts(args, sample, {}, {"routed_experts": _encode_routed(arr)})
 
 
 @pytest.mark.unit
@@ -458,8 +494,8 @@ def test_apply_vllm_routed_experts_skips_layer_topk_mismatch():
     arr = np.zeros((2, 3, 4), dtype=np.int32)
     sample = Sample(tokens=[1, 2, 3])
     args = Namespace(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1)
-    mod._apply_vllm_routed_experts(args, sample, {}, {"routed_experts": _encode_routed(arr)})
-    assert sample.rollout_routed_experts is None
+    with pytest.raises(RuntimeError, match="routing replay"):
+        mod._apply_vllm_routed_experts(args, sample, {}, {"routed_experts": _encode_routed(arr)})
 
 
 @pytest.mark.unit
@@ -588,15 +624,19 @@ def test_generate_multimodal_render_then_generate(patch_generate_state, monkeypa
 
 @pytest.mark.unit
 def test_generate_applies_routed_experts(patch_generate_state, monkeypatch):
-    # After generate: 2 prompt + 2 response tokens => expected_rows = 3
-    arr = np.zeros((3, 2, 1), dtype=np.int32)
+    # Fake tokenizer yields 3 prompt ids; +2 response => 5 tokens, 4 routing rows.
+    prompt_rows = np.ones((2, 2, 1), dtype=np.int32)
+    gen_rows = np.full((2, 2, 1), 2, dtype=np.int32)
+    expected = np.concatenate([prompt_rows, gen_rows], axis=0)
+
     post_mock = AsyncMock(
         return_value={
+            "prompt_routed_experts": _encode_routed_npy(prompt_rows),
             "choices": [
                 {
                     "token_ids": [50, 51],
                     "finish_reason": "stop",
-                    "routed_experts": _encode_routed(arr),
+                    "routed_experts": _encode_routed_npy(gen_rows),
                     "logprobs": {"content": [{}, {}]},
                 }
             ],
@@ -605,7 +645,8 @@ def test_generate_applies_routed_experts(patch_generate_state, monkeypatch):
     )
     monkeypatch.setattr(mod, "post", post_mock)
 
-    sample = Sample(index=0, prompt="ab")
+    # _FakeTokenizer encodes up to 3 chars => 3 prompt ids + 2 response = 5 tokens.
+    sample = Sample(index=0, prompt="abc")
     asyncio.run(
         mod.generate(
             _rollout_args(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1),
@@ -613,7 +654,9 @@ def test_generate_applies_routed_experts(patch_generate_state, monkeypatch):
             _default_sampling_params(max_new_tokens=4),
         )
     )
-    np.testing.assert_array_equal(sample.rollout_routed_experts, arr)
+    np.testing.assert_array_equal(sample.rollout_routed_experts, expected)
+    assert len(sample.tokens) == 5
+    assert sample.rollout_routed_experts.shape[0] == len(sample.tokens) - 1
 
 
 @pytest.mark.unit

--- a/tests/unit/rollout/test_vllm_rollout.py
+++ b/tests/unit/rollout/test_vllm_rollout.py
@@ -226,72 +226,24 @@ def test_decode_vllm_routed_experts_roundtrip():
     np.testing.assert_array_equal(decoded, arr)
 
 
-def _encode_routed_npy(arr: np.ndarray) -> str:
-    buf = io.BytesIO()
-    np.save(buf, arr)
-    return base64.b64encode(buf.getvalue()).decode("ascii")
-
-
 @pytest.mark.unit
-def test_merge_generate_routed_experts_trims_extra_gen_rows():
-    prompt = np.ones((2, 2, 1), dtype=np.int32)
-    gen = np.full((4, 2, 1), 2, dtype=np.int32)
-    merged = mod._merge_generate_routed_experts(
-        {"prompt_routed_experts": _encode_routed_npy(prompt)},
-        {"routed_experts": _encode_routed_npy(gen)},
-        gen_token_count=2,
-    )
-    np.testing.assert_array_equal(merged, np.concatenate([prompt, gen[:2]], axis=0))
-
-
-@pytest.mark.unit
-def test_merge_generate_routed_experts_single_buffer_splits_prompt_and_gen():
-    """vLLM 0.22+ may return one merged tensor on choices[].routed_experts only."""
-    prompt_token_count = 5
-    gen_token_count = 8
-    nrow = prompt_token_count + gen_token_count - 1
-    combined = np.arange(nrow * 2 * 1, dtype=np.int32).reshape(nrow, 2, 1)
-    merged = mod._merge_generate_routed_experts(
-        {},
-        {"routed_experts": _encode_routed_npy(combined)},
-        gen_token_count=gen_token_count,
-        prompt_token_count=prompt_token_count,
-    )
-    np.testing.assert_array_equal(merged, combined)
-
-
-@pytest.mark.unit
-def test_apply_vllm_routed_experts_merged_matches_sglang_layout():
-    prompt = np.zeros((2, 2, 1), dtype=np.int32)
-    gen = np.zeros((2, 2, 1), dtype=np.int32)
-    sample = Sample(tokens=[1, 2, 50, 51])
+def test_apply_vllm_routed_experts_requires_base64_choice_field_and_exact_rows():
+    # sample.tokens includes prompt+gen; routed_experts rows must be len(tokens)-1.
+    sample = Sample(tokens=[1, 2, 3, 4])
     args = Namespace(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1)
-    mod._apply_vllm_routed_experts(
-        args,
-        sample,
-        {"prompt_routed_experts": _encode_routed_npy(prompt)},
-        {"routed_experts": _encode_routed_npy(gen)},
-        gen_token_count=2,
-    )
-    np.testing.assert_array_equal(sample.rollout_routed_experts, np.zeros((3, 2, 1), dtype=np.int32))
+    routed = np.zeros((len(sample.tokens) - 1, 2, 1), dtype=np.int32)
+    mod._apply_vllm_routed_experts(args, sample, {"routed_experts": _encode_routed(routed)})
+    assert sample.rollout_routed_experts is not None
+    assert sample.rollout_routed_experts.shape == (3, 2, 1)
 
 
 @pytest.mark.unit
-def test_apply_vllm_routed_experts_merges_prompt_and_gen_nested_lists():
-    prompt_part = np.ones((2, 2, 1), dtype=np.int32)
-    gen_part = np.full((2, 2, 1), 2, dtype=np.int32)
-    expected = np.concatenate([prompt_part, gen_part], axis=0)
-
-    sample = Sample(tokens=[10, 20, 30, 40, 50])
+def test_apply_vllm_routed_experts_raises_on_row_mismatch():
+    sample = Sample(tokens=[1, 2, 3, 4])
     args = Namespace(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1)
-    mod._apply_vllm_routed_experts(
-        args,
-        sample,
-        {"prompt_routed_experts": prompt_part.tolist()},
-        {"routed_experts": gen_part.tolist()},
-        gen_token_count=2,
-    )
-    np.testing.assert_array_equal(sample.rollout_routed_experts, expected)
+    routed = np.zeros((1, 2, 1), dtype=np.int32)  # should be 3 rows
+    with pytest.raises(RuntimeError, match="rows"):
+        mod._apply_vllm_routed_experts(args, sample, {"routed_experts": _encode_routed(routed)})
 
 
 @pytest.mark.unit
@@ -471,10 +423,10 @@ def test_vllm_meta_from_generate_choice_defaults_to_stop():
 @pytest.mark.unit
 def test_apply_vllm_routed_experts_disabled_or_missing():
     sample = Sample(tokens=[1, 2, 3])
-    mod._apply_vllm_routed_experts(Namespace(use_rollout_routing_replay=False), sample, {}, {})
+    mod._apply_vllm_routed_experts(Namespace(use_rollout_routing_replay=False), sample, {})
     assert sample.rollout_routed_experts is None
     with pytest.raises(RuntimeError, match="routing replay"):
-        mod._apply_vllm_routed_experts(Namespace(use_rollout_routing_replay=True), sample, {}, {})
+        mod._apply_vllm_routed_experts(Namespace(use_rollout_routing_replay=True), sample, {})
 
 
 @pytest.mark.unit
@@ -483,17 +435,17 @@ def test_apply_vllm_routed_experts_skips_bad_shape():
     sample = Sample(tokens=[1, 2, 3])
     args = Namespace(use_rollout_routing_replay=True)
     with pytest.raises(RuntimeError, match="routing replay"):
-        mod._apply_vllm_routed_experts(args, sample, {}, {"routed_experts": _encode_routed(arr)})
+        mod._apply_vllm_routed_experts(args, sample, {"routed_experts": _encode_routed(arr)})
 
 
 @pytest.mark.unit
 def test_apply_vllm_routed_experts_trims_when_too_many_rows():
+    # New contract: require exact rows, no trimming.
     arr = np.zeros((9, 2, 1), dtype=np.int32)
     sample = Sample(tokens=[1, 2, 3])
     args = Namespace(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1)
-    mod._apply_vllm_routed_experts(args, sample, {}, {"routed_experts": _encode_routed(arr)})
-    assert sample.rollout_routed_experts is not None
-    assert sample.rollout_routed_experts.shape == (2, 2, 1)
+    with pytest.raises(RuntimeError, match="rows"):
+        mod._apply_vllm_routed_experts(args, sample, {"routed_experts": _encode_routed(arr)})
 
 
 @pytest.mark.unit
@@ -502,7 +454,7 @@ def test_apply_vllm_routed_experts_raises_when_too_few_rows():
     sample = Sample(tokens=[1, 2, 3])
     args = Namespace(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1)
     with pytest.raises(RuntimeError, match="routing replay"):
-        mod._apply_vllm_routed_experts(args, sample, {}, {"routed_experts": _encode_routed(arr)})
+        mod._apply_vllm_routed_experts(args, sample, {"routed_experts": _encode_routed(arr)})
 
 
 @pytest.mark.unit
@@ -511,7 +463,7 @@ def test_apply_vllm_routed_experts_skips_layer_topk_mismatch():
     sample = Sample(tokens=[1, 2, 3])
     args = Namespace(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1)
     with pytest.raises(RuntimeError, match="routing replay"):
-        mod._apply_vllm_routed_experts(args, sample, {}, {"routed_experts": _encode_routed(arr)})
+        mod._apply_vllm_routed_experts(args, sample, {"routed_experts": _encode_routed(arr)})
 
 
 @pytest.mark.unit
@@ -641,18 +593,21 @@ def test_generate_multimodal_render_then_generate(patch_generate_state, monkeypa
 @pytest.mark.unit
 def test_generate_applies_routed_experts(patch_generate_state, monkeypatch):
     # Fake tokenizer yields 3 prompt ids; +2 response => 5 tokens, 4 routing rows.
-    prompt_rows = np.ones((2, 2, 1), dtype=np.int32)
-    gen_rows = np.full((2, 2, 1), 2, dtype=np.int32)
-    expected = np.concatenate([prompt_rows, gen_rows], axis=0)
+    routed_rows = np.concatenate(
+        [
+            np.ones((2, 2, 1), dtype=np.int32),
+            np.full((2, 2, 1), 2, dtype=np.int32),
+        ],
+        axis=0,
+    )
 
     post_mock = AsyncMock(
         return_value={
-            "prompt_routed_experts": _encode_routed_npy(prompt_rows),
             "choices": [
                 {
                     "token_ids": [50, 51],
                     "finish_reason": "stop",
-                    "routed_experts": _encode_routed_npy(gen_rows),
+                    "routed_experts": _encode_routed(routed_rows),
                     "logprobs": {"content": [{}, {}]},
                 }
             ],
@@ -670,7 +625,7 @@ def test_generate_applies_routed_experts(patch_generate_state, monkeypatch):
             _default_sampling_params(max_new_tokens=4),
         )
     )
-    np.testing.assert_array_equal(sample.rollout_routed_experts, expected)
+    np.testing.assert_array_equal(sample.rollout_routed_experts, routed_rows)
     assert len(sample.tokens) == 5
     assert sample.rollout_routed_experts.shape[0] == len(sample.tokens) - 1
 
@@ -707,6 +662,35 @@ def test_generate_and_rm_aborted_marks_sample(patch_generate_state, monkeypatch)
     sample = Sample(index=0, prompt="p")
     result = asyncio.run(mod.generate_and_rm(_rollout_args(), sample, _default_sampling_params()))
     assert result.status == Sample.Status.ABORTED
+
+
+@pytest.mark.unit
+def test_generate_r3_abort_without_routed_experts_does_not_raise(patch_generate_state, monkeypatch):
+    post_mock = AsyncMock(
+        return_value={
+            "choices": [
+                {
+                    "token_ids": [],
+                    "finish_reason": "abort",
+                    "logprobs": {"content": []},
+                }
+            ],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 0},
+        }
+    )
+    monkeypatch.setattr(mod, "post", post_mock)
+
+    sample = Sample(index=0, prompt="abc")
+    result = asyncio.run(
+        mod.generate(
+            _rollout_args(use_rollout_routing_replay=True),
+            sample,
+            _default_sampling_params(max_new_tokens=8),
+        )
+    )
+    assert result.status == Sample.Status.ABORTED
+    assert result.response_length == 0
+    assert result.rollout_routed_experts is None
 
 
 @pytest.mark.unit

--- a/tests/unit/rollout/test_vllm_rollout.py
+++ b/tests/unit/rollout/test_vllm_rollout.py
@@ -245,6 +245,22 @@ def test_merge_generate_routed_experts_trims_extra_gen_rows():
 
 
 @pytest.mark.unit
+def test_merge_generate_routed_experts_single_buffer_splits_prompt_and_gen():
+    """vLLM 0.22+ may return one merged tensor on choices[].routed_experts only."""
+    prompt_token_count = 5
+    gen_token_count = 8
+    nrow = prompt_token_count + gen_token_count - 1
+    combined = np.arange(nrow * 2 * 1, dtype=np.int32).reshape(nrow, 2, 1)
+    merged = mod._merge_generate_routed_experts(
+        {},
+        {"routed_experts": _encode_routed_npy(combined)},
+        gen_token_count=gen_token_count,
+        prompt_token_count=prompt_token_count,
+    )
+    np.testing.assert_array_equal(merged, combined)
+
+
+@pytest.mark.unit
 def test_apply_vllm_routed_experts_merged_matches_sglang_layout():
     prompt = np.zeros((2, 2, 1), dtype=np.int32)
     gen = np.zeros((2, 2, 1), dtype=np.int32)


### PR DESCRIPTION
## Purpose

Implements **RFC #32 Phase 2** / follow-up to [#34](https://github.com/vllm-project/vime/pull/34): MoE **routing replay** (`--use-rollout-routing-replay`) on the **vLLM rollout** path using **vLLM ≥ 0.22** native support ([vllm#39568](https://github.com/vllm-project/vllm/pull/39568)).

SGLang already fills `sample.rollout_routed_experts` with shape `(len(tokens) - 1, num_layers, moe_router_topk)`. On vLLM 0.21.x, routing required a **site-packages patch** and/or **`/v1/completions`** workarounds. From vLLM 0.22+, **`/inference/v1/generate`** returns routed experts (often as a single base64 npy buffer on `choices[].routed_experts`).

This PR **drops the disagg patch path** and standardizes rollout + engine smoke checks on **`/inference/v1/generate`**.

**Supersedes the approach in #34** (v0.21.0 + `docker/patch/latest/vllm.patch` + completions fallback).

## What's included

### Rollout (`slime/rollout/vllm_rollout.py`)

- R3 text generation uses **`POST /inference/v1/generate`** only (removed `/v1/completions` branch).
- **`_merge_generate_routed_experts`**: merge split or **single-buffer** routing; align to `len(tokens) - 1`.

### Engine (`slime/backends/vllm_utils/vllm_engine.py`)

- When `use_rollout_routing_replay`: inject **`--enable-return-routed-experts`** only (no 0.21.x `--no-async-scheduling` / `--no-enable-prefix-caching` guards).
- **`_verify_generate_routed_experts`**: startup smoke on `/inference/v1/generate`.

### Tests

- `tests/unit/rollout/test_vllm_rollout.py` — merge/apply routing, **single-buffer** case.
- `tests/unit/backends/vllm_utils/test_vllm_engine.py` — `_verify_generate_routed_experts`.
- `tests/test_vllm_generate_endpoint.py` — `qwen3-30b-a3b-r3` integration.

## Requirements

| Item | Notes |
|------|--------|
| vLLM | **≥ 0.22.0** (or dev build with #39568) |
| MoE multi-GPU | `--vllm-enable-expert-parallel` |
| R3 | `--use-rollout-routing-replay` |

## Verification logs

Environment: **8×A100**, container `vime_v22`, Qwen3-30B-A3B, train/rollout **4+4**, vLLM `0.21.1rc1.dev38` (includes #39568 generate routing). No `Split sizes` / missing-routing errors observed.

### 1) Local unit tests

```text
pytest tests/unit/rollout/test_vllm_rollout.py tests/unit/backends/vllm_utils/test_vllm_engine.py -q
# 87 passed in 3.08s

pre-commit run --all-files
# all hooks Passed (ruff, black, isort, …)
```

### 2) Full verify — HTTP + rollout E2E

**Phase A — standalone vLLM HTTP smoke (`:8000`)**

```text
[routing-replay-full] Starting standalone vLLM on http://127.0.0.1:8000 (GPUs=0,1,2,3, tp=4) ...
[routing-replay-full] HTTP model id: /data/nfs_87/model/Qwen3-30B-A3B
[vllm-generate-routing] POST http://127.0.0.1:8000/inference/v1/generate
  routing rows=12 layers=48 top_k=8
OK: /inference/v1/generate routing replay fields present.
[routing-replay-full] HTTP phase PASS
```

**Phase B — `debug-rollout-only` + `.pt` shape check**

```text
(VLLMEngine) non-default args: {..., 'enable_return_routed_experts': True, 'enable_expert_parallel': True, ...}
(EngineCore) RoutedExpertsManager CPU buffer: 0.63 GB (slots=1642320, layers=48, top_k=8, dtype=uint8)
(APIServer) Route: /inference/v1/generate, Methods: POST
(APIServer) "POST /inference/v1/generate HTTP/1.1" 200 OK

  sample[0]: OK shape=(322, 48, 8) tokens=323 response_length=128
  sample[1]: OK shape=(265, 48, 8) tokens=266 response_length=128
PASS: 2 sample(s) satisfy routing replay shape contract.
[routing-replay-verify] Rollout path PASS
```

### 3) Production-shaped training — 4+4 R3 smoke

```text
(VLLMEngine) non-default args: {..., 'enable_return_routed_experts': True,
  'tensor_parallel_size': 4, 'enable_expert_parallel': True, ...}
(Worker) Initializing routed experts capturer, enable_return_routed_experts: True
(APIServer) Route: /inference/v1/generate, Methods: POST
(APIServer) "POST /inference/v1/generate HTTP/1.1" 200 OK

(MegatronTrainRayActor) torch.from_numpy(r) for r in rollout_data["rollout_routed_experts"]
(RolloutManager) perf 0: {..., 'perf/tokens_per_gpu_per_sec': 305.09, ...}
(MegatronTrainRayActor) perf 0: {..., 'perf/actor_train_tok_per_s': 687.56, 'perf/step_time': 223.28, ...}
```

Training completed multiple rollout→train steps without routing-shape failures.

## Test plan

### Unit

```bash
pytest tests/unit/rollout/test_vllm_rollout.py -k "routed or merge_generate"
pytest tests/unit/backends/vllm_utils/test_vllm_engine.py -k verify_generate
```

### Integration (GPU)

```bash
pytest tests/test_vllm_generate_endpoint.py -k r3
```

### Manual

1. vLLM ≥ 0.22 + `--enable-return-routed-experts` (no patch).
2. `--use-rollout-routing-replay --vllm-enable-expert-parallel`, 4+4 layout.
3. Confirm `rollout_routed_experts` shape `(len(tokens)-1, num_layers, moe_router_topk)`.

## Out of scope

- Docker base bump to `v0.22.0` image tag.
- Colocate CI parity with `tests/test_qwen3_30B_A3B_r3.py`.
- Removing legacy `docker/patch` tree.

## Related

- #32 (RFC)
- #34 (v0.21 + patch — superseded)
- [vllm#39568](https://github.com/vllm-project/vllm/pull/39568)

Related to #32 (Phase 2).
