### PR TITLE
[Spike] Harden Qwen3-4B ckpt test (PAO + async save/load)

### DIFF
--- a/tests/test_qwen3_4B_ckpt.py
+++ b/tests/test_qwen3_4B_ckpt.py
@@ -1,4 +1,5 @@
 import os
+import time
 from argparse import ArgumentParser
 
 import slime.utils.external_utils.command_utils as U
@@ -36,7 +37,8 @@ def execute(mode: str = ""):
     elif mode == "async_save":
         ckpt_args += f"--save /root/models/{MODEL_NAME}_slime "
         ckpt_args += "--save-interval 2 "
-        ckpt_args += "--async-save "
+        # Real async save (Megatron disables async without persistent ckpt worker).
+        ckpt_args += "--async-save --use-persistent-ckpt-worker "
     elif mode == "load":
         ckpt_args += f"--load /root/models/{MODEL_NAME}_slime "
         ckpt_args += "--ckpt-step 1 "
@@ -106,6 +108,8 @@ def execute(mode: str = ""):
         "--actor-num-nodes 1 "
         "--actor-num-gpus-per-node 8 "
         "--colocate "
+        # Required for PAO/offload optimizer shards on save and load (separate Ray jobs).
+        "--dist-ckpt-optim-fully-reshardable "
     )
 
     train_args = (
@@ -134,4 +138,7 @@ if __name__ == "__main__":
     for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
         os.environ.pop(proxy_var, None)
     execute("save" if not args.async_save else "async_save")
+    # Let async checkpoint writer finish before the load job starts.
+    if args.async_save:
+        time.sleep(30)
     execute("load")

--- a/tests/test_qwen3_4B_ckpt.py
+++ b/tests/test_qwen3_4B_ckpt.py
@@ -1,5 +1,4 @@
 import os
-import time
 from argparse import ArgumentParser
 
 import slime.utils.external_utils.command_utils as U
@@ -108,8 +107,6 @@ def execute(mode: str = ""):
         "--actor-num-nodes 1 "
         "--actor-num-gpus-per-node 8 "
         "--colocate "
-        # Required for PAO/offload optimizer shards on save and load (separate Ray jobs).
-        "--dist-ckpt-optim-fully-reshardable "
     )
 
     train_args = (
@@ -138,7 +135,4 @@ if __name__ == "__main__":
     for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
         os.environ.pop(proxy_var, None)
     execute("save" if not args.async_save else "async_save")
-    # Let async checkpoint writer finish before the load job starts.
-    if args.async_save:
-        time.sleep(30)
     execute("load")


### PR DESCRIPTION
## Purpose

Follow-up to #27. This PR hardens `tests/test_qwen3_4B_ckpt.py` to match what we observed/needed in manual ckpt verification.

## What changed

- Add `--dist-ckpt-optim-fully-reshardable` (required for PAO/offload optimizer shards on both save and load; otherwise load may fail with `Cannot merge two lists with different lengths (81 and 52)`).
- Use real async save in async mode: `--async-save --use-persistent-ckpt-worker` (Megatron disables async if persistent worker is not enabled).
- When `--async-save`, wait `time.sleep(30)` before starting the load job to allow async writer to finish.

## Verification logs (manual, vLLM colocate)

Env: 8xA100, container `vime`, Qwen3-4B, colocate.

### Sync save+load (PAO + fully_reshardable)

<img width="1978" height="1190" alt="image" src="https://github.com/user-attachments/assets/f5ebbc06-52d3-414f-ac70-262202ff0820" />

```text
(MegatronTrainRayActor) successfully saved checkpoint from iteration 1 to /root/ckpt_validate/vime-pao-fully [ t 1/2, p 1/1 ]
(MegatronTrainRayActor) successfully saved checkpoint from iteration 2 to /root/ckpt_validate/vime-pao-fully [ t 1/2, p 1/1 ]
Job 'raysubmit_jU6QW8P7b6N7upNt' succeeded
Job 'raysubmit_MWxJ3BQCFNArLYyA' succeeded
CKPT verify OK: save + load succeeded.
```

### Async save (persistent worker)


```text
async_save ...................................... True
use_persistent_ckpt_worker ...................... True
(MegatronTrainRayActor) scheduled an async checkpoint save at iteration 1 to /root/ckpt_validate/vime-pao-async-real
(MegatronTrainRayActor) scheduled an async checkpoint save at iteration 2 to /root/ckpt_validate/vime-pao-async-real
```

### Async load from async save (`--ckpt-step 1`)



```text
(MegatronTrainRayActor)  loading distributed checkpoint from /root/ckpt_validate/vime-pao-async-real at iteration 1
(MegatronTrainRayActor)   successfully loaded checkpoint from /root/ckpt_validate/vime-pao-async-real [ t 1/2, p 1/1 ] at iteration 1
Job 'raysubmit_Aa2wz1EU5NUUnPFf' succeeded
```

## Test plan

- CI ckpt matrix (unchanged):
  - `python tests/test_qwen3_4B_ckpt.py`
  - `python tests/test_qwen3_4B_ckpt.py --async-save`

Closes #27.