### PR TITLE
[Bugfix] stabilize actor offload wake/sleep flow (follow-up to #48)

### DIFF
--- a/slime/backends/megatron_utils/actor.py
+++ b/slime/backends/megatron_utils/actor.py
@@ -160,6 +160,8 @@ class MegatronTrainRayActor(TrainRayActor):
     def sleep(self) -> None:
         assert self.args.offload_train
 
+        if self.args.use_routing_replay:
+            RoutingReplay.clear_all()
         clear_memory(clear_host_memory=True)
         print_memory("before offload model")
         if (
@@ -169,7 +171,7 @@ class MegatronTrainRayActor(TrainRayActor):
             and hasattr(self.weight_updater, "disconnect_rollout_engines")
         ):
             self.weight_updater.disconnect_rollout_engines()
-        destroy_process_groups()
+            destroy_process_groups()
 
         torch_memory_saver.pause()
 
@@ -184,6 +186,8 @@ class MegatronTrainRayActor(TrainRayActor):
 
         clear_memory()
         reload_process_groups()
+        if self.role == "actor":
+            self._switch_model("actor")
         print_memory("after wake_up model")
 
     def _get_rollout_data(self, rollout_data_ref: Box) -> RolloutBatch:


### PR DESCRIPTION
## Summary

Follow-up to #48. This PR keeps the actor-side stability fix on top of #48's IPC contract/coordinator/gather changes.

Scope in this PR:

- `slime/backends/megatron_utils/actor.py`
  - clear routing replay before offload sleep when enabled
  - only destroy process groups in sleep path for non-colocate critic reconnect case
  - restore actor tag after wake-up (`self._switch_model("actor")`)

Related IPC correctness is handled in #48 (coordinator = slot-start rank, slot-wide gloo gather, single-RPC version-with-data).

Test case: `tests/test_qwen3_30B_A3B.py` on A800, 8× colocate, Megatron TP=4, `rollout-num-gpus-per-engine=8`.

## Failure mode

We hit a chain of failures while bringing up colocated IPC weight sync for Qwen3-30B-A3B. Below are the observed symptoms, NFS log paths, and key excerpts.

### 0) Checkpoint load appeared stuck (NFS mount)

Symptom: training looked hung at Megatron load:

```text
loading release distributed checkpoint from /root/Qwen3-30B-A3B_torch_dist
```

Cause: `/root/Qwen3-30B-A3B_torch_dist` was a symlink to NFS (`/data/nfs_87/xky/models/...`), so ~57G `torch_dist` was read over the mount.

Mitigation (operational, not in this PR): rsync checkpoint to container local disk (`/root/local_models/Qwen3-30B-A3B_torch_dist`) before training.

Log: `/data/nfs_87/xky/logs/test_qwen3_30B_A3B_20260527_074737.log`

---

### 1) Duplicate `start_weight_update` in colocate IPC path

Symptom:

```text
RuntimeError: start_weight_update called while a weight update is already active. Call finish_weight_update first.
```

Root cause: for one 8-GPU vLLM engine with Megatron TP=4, coordinator gating used `tp_rank == 0`. Both global rank 0 and rank 4 could enter the coordinator path and call `start_weight_update` twice.

Fix: #48 - gate coordinator on `rank == slot_start` (lowest global rank in the engine GPU slot).

Log: `/data/nfs_87/xky/logs/test_qwen3_30B_A3B_20260527_025345.log` (around line 1823)

```text
(Worker_TP1) RuntimeError: start_weight_update called while a weight update is already active. Call finish_weight_update first.
```

---

### 2) Missing IPC handles during tensor transfer

Symptom:

```text
ValueError: IPC handle not found for GPU UUID d2c381a3-522a-0b4f-8e39-20a919fc253f. Available UUIDs: [...]
```

Root cause: IPC payloads were gathered only within the Megatron TP subgroup (4 ranks), but the 8-GPU vLLM engine needs handles from the full engine slot (8 ranks).

Fix: #48 - build per-slot gloo group and `all_gather_object` across the full slot, not TP subgroup.

Log: `/data/nfs_87/xky/logs/test_qwen3_30B_A3B_20260527_031623.log` (line 1809)

---

### 3) `torch_memory_saver` crash after first successful weight sync

Symptom: Ray actor workers died right after `update_weights` reached 100%:

```text
[torch_memory_saver.cpp] CUresult error: 1 (invalid argument)  file=csrc/core.cpp func=free line=81
ray.exceptions.ActorDiedError: The actor died unexpectedly before finishing this task.
```

Context: first IPC sync completed (`Update weights: 100%|...| 115/115`, `finish_weight_update` 200 OK), then crash during offload/sleep transition after rollout 0 train.

Fix: this PR (`actor.py`) - stabilize sleep/wake: clear routing replay, avoid unconditional PG destroy on colocate sleep, restore actor model tag after wake-up.

Log: `/data/nfs_87/xky/logs/test_qwen3_30B_A3B_20260527_080824.log` (lines 2823, 2853)

---

### 4) Ray host-memory kill during second `update_weights`

Symptom:

```text
ray.exceptions.OutOfMemoryError: 1 worker(s) were killed due to the node running low on memory.
Memory ... was 952.93GB / 1003.08GB (0.950004), which exceeds the memory usage threshold of 0.950000
Top memory users: ray::MegatronTrainRayActor.update_weights (~99GB x 8 ranks)
```

Context: not GPU OOM - Ray killed workers when host RAM crossed the default 95% threshold during the second post-train weight sync.

Mitigation (operational): raise `RAY_memory_usage_threshold=0.99` when starting isolated Ray in the run script.

Log: `/data/nfs_87/xky/logs/test_qwen3_30B_A3B_20260527_092114.log` (line 2700)

---

## Fix (this PR)

### `slime/backends/megatron_utils/actor.py`

- clear `RoutingReplay` before offload sleep when `--use-routing-replay`
- only `destroy_process_groups()` in sleep when non-colocate critic reconnect path applies
- after `wake_up()`, call `self._switch_model("actor")` so the active model tag is restored

## Why actor.py change is needed (with #48)

#48 fixes IPC coordinator selection and slot-wide handle gather. Even after IPC sync succeeds, colocate + `offload_train` still needs a stable actor sleep/wake path. Without these actor adjustments we saw intermittent `torch_memory_saver` / `ActorDiedError` crashes after successful weight updates.

## Test plan

- [x] Reproduced failures (1)-(4) above before fixes
- [x] `pre-commit run --all-files`
- [x] `python -m pytest tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py -q` - 7 passed
- [x] End-to-end on A800 with local checkpoint copy

Successful run after fixes:

Log: `/data/nfs_87/xky/logs/test_qwen3_30B_A3B_20260527_094318.log`

```text
[2026-05-27 10:01:27] ... perf 2: {...}
[2026-05-27 10:01:53] ... rollout 2: {...}
[2026-05-27 10:02:52] ... step 2: {...}
Update weights: 100%|██████████| 115/115
2026-05-27 10:03:48 ... Job 'raysubmit_RDDgpg3WPpdD7nCX' succeeded
```

- [ ] Run full colocate CI matrix on clean image
