### PR TITLE
[BugFix]:Fix vLLM IPC weight transfer for MiMo MTP training

### DIFF
--- a/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -59,14 +59,20 @@ def _current_gpu_uuid() -> str:
 
 def _build_ipc_update_info_from_named_tensors(
     named_tensors: Iterable[tuple[str, torch.Tensor]],
-) -> dict[str, list]:
-    """Build vLLM IPC ``update_info`` payload from tensors on this rank's GPU."""
+) -> tuple[dict[str, list], list[torch.Tensor]]:
+    """Build vLLM IPC ``update_info`` payload from tensors on this rank's GPU.
+
+    Return the contiguous tensor refs with the payload. ``reduce_tensor`` only
+    exports CUDA IPC metadata, so the producer storage must stay alive until the
+    receiver opens the handle.
+    """
     from torch.multiprocessing.reductions import reduce_tensor
 
     names: list[str] = []
     dtype_names: list[str] = []
     shapes: list[list[int]] = []
     ipc_handles: list[dict[str, tuple]] = []
+    weight_refs: list[torch.Tensor] = []
     gpu_uuid = _current_gpu_uuid()
 
     for name, tensor in named_tensors:
@@ -74,14 +80,19 @@ def _build_ipc_update_info_from_named_tensors(
         dtype_names.append(str(tensor.dtype).split(".")[-1])
         shapes.append(list(tensor.shape))
         weight = tensor.detach().contiguous()
-        ipc_handles.append({gpu_uuid: reduce_tensor(weight)})
+        weight_refs.append(weight)
+        _, ipc_args = reduce_tensor(weight)
+        ipc_handles.append({gpu_uuid: ipc_args})
 
-    return {
-        "names": names,
-        "dtype_names": dtype_names,
-        "shapes": shapes,
-        "ipc_handles": ipc_handles,
-    }
+    return (
+        {
+            "names": names,
+            "dtype_names": dtype_names,
+            "shapes": shapes,
+            "ipc_handles": ipc_handles,
+        },
+        weight_refs,
+    )
 
 
 def _serialize_ipc_update_info(info: dict[str, list]) -> str:
@@ -400,7 +411,7 @@ class UpdateWeightFromTensor:
             )
             return
 
-        local_info = _build_ipc_update_info_from_named_tensors(hf_named_tensors)
+        local_info, weight_refs = _build_ipc_update_info_from_named_tensors(hf_named_tensors)
         payload = _serialize_ipc_update_info(local_info)
 
         tp_group = mpu.get_tensor_model_parallel_group()
@@ -423,6 +434,9 @@ class UpdateWeightFromTensor:
             ray.get(self._ipc_engine.update_weights.remote(dict(update_info=merged)))
 
         dist.barrier(group=tp_group)
+        # Keep CUDA IPC producer tensors alive until every TP worker has opened
+        # the handles and the coordinator's HTTP update has completed.
+        del weight_refs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py
+++ b/tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py
@@ -289,7 +289,7 @@ def test_non_coordinator_skips_start_finish(upw_vllm):
         "megatron.core.mpu.get_tensor_model_parallel_rank", return_value=1
     ), patch(
         f"{MODULE_PATH}._build_ipc_update_info_from_named_tensors",
-        return_value=dummy_info,
+        return_value=(dummy_info, []),
     ), patch(
         f"{MODULE_PATH}._serialize_ipc_update_info", return_value="payload"
     ), patch(


### PR DESCRIPTION
## Propose

Related: https://github.com/vllm-project/vime/issues/11

The failure happened because Vime passed the full reduce_tensor() return pair into vLLM IPC weight transfer, while vLLM expected only the CUDA IPC rebuild args, causing list_args[6] to index into the wrong object.
The fix extracts and sends only ipc_args, while keeping the producer tensors alive until vLLM workers finish opening the CUDA IPC handles.

## Test Plan

```
root@job-2f05f13a3e65b678-gvjxv:/proj-tango-pvc/users/zhipeng.wang/wo
rkspace/vime# python -m pytest tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py -q
======================== test session starts ========================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0
rootdir: /proj-tango-pvc/users/zhipeng.wang/workspace/vime
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 6 items                                                   

tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py . [ 16%]
.....                                                         [100%]

========================= slowest durations =========================
0.04s setup    tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py::test_colocated_lifecycle_uses_vllm_sleep_and_weight_transfer_apis
0.01s call     tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py::test_ipc_init_runs_once

(16 durations < 0.005s hidden.  Use -vv to show these durations.)
========================= 6 passed in 2.04s =========================
```

```
root@job-2f05f13a3e65b678-gvjxv:/proj-tango-pvc/users/zhipeng.wang/wo
rkspace/vime# python tpython tests/ci/gpu_lock_exec.py --count 8 -- python tests/test_mimo_7B_mtp_only_grad.py
[gpu_lock_exec] Acquired GPUs: 0,1,2,3,4,5,6,7
EXEC: mkdir -p /root/models /root/datasets
EXEC: hf download XiaomiMiMo/MiMo-7B-RL --local-dir /root/models/MiMo-7B-RL
Fetching 15 files: 100%|████████████| 15/15 [00:00<00:00, 733.52it/s]
Download complete: : 0.00B [00:00, ?B/s]              ✓ Downloaded/s]
  path: /root/models/MiMo-7B-RL
Download complete: : 0.00B [00:00, ?B/s]
EXEC: hf download --repo-type dataset zhuzilin/dapo-math-17k --local-dir /root/datasets/dapo-math-17k
Fetching 2 files: 100%|███████████████| 2/2 [00:00<00:00, 606.16it/s]
Download complete: : 0.00B [00:00, ?B/s]              ✓ Downloaded/s]
  path: /root/datasets/dapo-math-17k
Download complete: : 0.00B [00:00, ?B/s]
convert_checkpoint skip /root/models/MiMo-7B-RL_torch_dist since exists
Skip wandb configuration since WANDB_API_KEY is not found
EXEC: sleep 3; ray stop --force; pkill -9 ray; pkill -9 slime; sleep 3; pkill -9 ray; pkill -9 slime; pkill -9 redis; true; 
Did not find any active Ray processes.
EXEC: export PYTHONBUFFERED=16 && ray start --head --node-ip-address 127.0.0.1 --num-gpus 8 --disable-usage-stats
Usage stats collection is disabled.

Local node IP: 192.168.5.34

--------------------
Ray runtime started.
--------------------

Next steps
  To add another node to this Ray cluster, run
    ray start --address='192.168.5.34:6379'
  
  To connect to this Ray cluster:
    import ray
    ray.init(_node_ip_address='192.168.5.34')
  
  To submit a Ray job using the Ray Jobs CLI:
    RAY_API_SERVER_ADDRESS='http://127.0.0.1:8265' ray job submit --working-dir . -- python my_script.py
  
  See https://docs.ray.io/en/latest/cluster/running-applications/job-submission/index.html 
  for more information on submitting Ray jobs to the Ray cluster.
  
  To terminate the Ray runtime, run
    ray stop
  
  To view the status of the cluster, use
    ray status
  
  To monitor and debug Ray, view the dashboard at 
    127.0.0.1:8265
  
  If connection to the dashboard fails, check your firewall settings and network configuration.

.......

actor train:   0%|          | 0/1 [00:00<?, ?microbatch/s]
(MegatronTrainRayActor pid=93777) 
actor train: 100%|██████████| 1/1 [00:03<00:00,  3.14s/microbatch]
(MegatronTrainRayActor pid=94257) [2026-05-27 15:00:15] memory_utils.py:47 - [Rank 5] Memory-Usage after wake_up model: {'gpu': '5', 'total_GB': 79.18, 'free_GB': 47.28, 'used_GB': 31.9, 'allocated_GB': 25.54, 'reserved_GB': 25.77, 'host_total_GB': 2015.51, 'host_available_GB': 1651.53, 'host_used_GB': 363.98, 'host_free_GB': 739.05} [repeated 7x across cluster]
(MegatronTrainRayActor pid=94257) [2026-05-27 15:00:15] reloadable_process_group.py:166 - Reloading 33 process groups in pid 94257 [repeated 6x across cluster]
(MegatronTrainRayActor pid=93777) /root/Megatron-LM/megatron/core/pipeline_parallel/schedules.py:190: UserWarning: The AccumulateGrad node's stream does not match the stream of the node that produced the incoming gradient. This may incur unnecessary synchronization and break CUDA graph capture if the AccumulateGrad node's stream is the default stream. This mismatch is caused by an AccumulateGrad node created prior to the current iteration being kept alive. This can happen if the autograd graph is still being kept alive by tensors such as the loss, or if you are using DDP, which will stash a reference to the node. To resolve the mismatch, delete all references to the autograd graph or ensure that DDP initialization is performed under the same stream as subsequent forwards. If the mismatch is intentional, you can use torch.autograd.graph.set_warn_on_accumulate_grad_stream_mismatch(False) to suppress this warning. (Triggered internally at /pytorch/torch/csrc/autograd/input_buffer.cpp:240.)
(MegatronTrainRayActor pid=93777)   Variable._execution_engine.run_backward(
(MegatronTrainRayActor pid=93777) [2026-05-27 15:00:21] _rank_utils.py:43 - Implicit initialization of Rerun State Machine!
(MegatronTrainRayActor pid=93777) [2026-05-27 15:00:21] _rank_utils.py:43 - RerunStateMachine initialized in mode RerunMode.DISABLED
(MegatronTrainRayActor pid=93777) [2026-05-27 15:00:24] ci_utils.py:47 - [CI MTP Grad Check] Step 0: MTP params with non-zero grad: 11, non-MTP params with non-zero grad: 0
(VLLMEngine pid=89190) (APIServer pid=89711) INFO 05-27 15:00:24 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 58.1%
(MegatronTrainRayActor pid=93777) [2026-05-27 15:00:27] model.py:779 - step 0: {'train/loss': 0.0, 'train/pg_loss': 0.0, 'train/entropy_loss': 0.16761371493339539, 'train/pg_clipfrac': 0.0, 'train/ppo_kl': 0.0, 'train/train_rollout_logprob_abs_diff': 0.02739192172884941, 'train/grad_norm': 1.7108789721367799, 'train/mtp_loss': 0.4822637736797333, 'train/lr-pg_0': 1e-06, 'train/lr-pg_1': 1e-06, 'train/step': 0}
(MegatronTrainRayActor pid=93777) 
                                                                  
[2026-05-27 15:00:27] timer.py:32 - Timer actor_train end (elapsed: 10.7s)
(MegatronTrainRayActor pid=93777) [2026-05-27 15:00:27] timer.py:32 - Timer train end (elapsed: 11.1s)
(MegatronTrainRayActor pid=93777) [2026-05-27 15:00:27] timer.py:24 - Timer train_wait start
(MegatronTrainRayActor pid=94257) /root/Megatron-LM/megatron/core/pipeline_parallel/schedules.py:190: UserWarning: The AccumulateGrad node's stream does not match the stream of the node that produced the incoming gradient. This may incur unnecessary synchronization and break CUDA graph capture if the AccumulateGrad node's stream is the default stream. This mismatch is caused by an AccumulateGrad node created prior to the current iteration being kept alive. This can happen if the autograd graph is still being kept alive by tensors such as the loss, or if you are using DDP, which will stash a reference to the node. To resolve the mismatch, delete all references to the autograd graph or ensure that DDP initialization is performed under the same stream as subsequent forwards. If the mismatch is intentional, you can use torch.autograd.graph.set_warn_on_accumulate_grad_stream_mismatch(False) to suppress this warning. (Triggered internally at /pytorch/torch/csrc/autograd/input_buffer.cpp:240.) [repeated 7x across cluster]
(MegatronTrainRayActor pid=94257)   Variable._execution_engine.run_backward( [repeated 7x across cluster]
(MegatronTrainRayActor pid=93777) [2026-05-27 15:00:27] train_metric_utils.py:44 - perf 0: {'perf/sleep_time': 19.366883516311646, 'perf/update_weights_time': 3.431673765182495, 'perf/wake_up_time': 8.399599313735962, 'perf/data_preprocess_time': 0.0020987987518310547, 'perf/train_wait_time': 18.47326922416687, 'perf/actor_train_time': 10.695215225219727, 'perf/train_time': 11.110627174377441, 'perf/actor_train_tflops': 1.1541478344174605, 'perf/actor_train_tok_per_s': 227.01740440666245, 'perf/step_time': 29.58389639854431, 'perf/wait_time_ratio': 0.6244366521333496}
(MegatronTrainRayActor pid=93777) [2026-05-27 15:00:27] timer.py:24 - Timer sleep start
(MegatronTrainRayActor pid=94256) [2026-05-27 15:00:28] memory_utils.py:47 - [Rank 7] Memory-Usage before offload model: {'gpu': '7', 'total_GB': 79.18, 'free_GB': 36.39, 'used_GB': 42.79, 'allocated_GB': 33.71, 'reserved_GB': 33.92, 'host_total_GB': 2015.51, 'host_available_GB': 1642.06, 'host_used_GB': 373.45, 'host_free_GB': 729.56}
(VLLMEngine pid=89186) (APIServer pid=89709) INFO:     192.168.5.34:40218 - "GET /health HTTP/1.1" 200 OK
(MegatronTrainRayActor pid=93777) [2026-05-27 15:00:55] memory_utils.py:47 - [Rank 0] Memory-Usage after offload model: {'gpu': '0', 'total_GB': 79.18, 'free_GB': 70.65, 'used_GB': 8.53, 'allocated_GB': 33.71, 'reserved_GB': 33.95, 'host_total_GB': 2015.51, 'host_available_GB': 1374.4, 'host_used_GB': 641.11, 'host_free_GB': 461.84}
(MegatronTrainRayActor pid=93777) [2026-05-27 15:00:55] timer.py:32 - Timer sleep end (elapsed: 27.6s)
(MegatronTrainRayActor pid=94253) [2026-05-27 15:00:24] ci_utils.py:47 - [CI MTP Grad Check] Step 0: MTP params with non-zero grad: 11, non-MTP params with non-zero grad: 0 [repeated 7x across cluster]
(MegatronTrainRayActor pid=94257) [2026-05-27 15:00:28] memory_utils.py:47 - [Rank 5] Memory-Usage before offload model: {'gpu': '5', 'total_GB': 79.18, 'free_GB': 35.4, 'used_GB': 43.78, 'allocated_GB': 33.71, 'reserved_GB': 33.97, 'host_total_GB': 2015.51, 'host_available_GB': 1642.14, 'host_used_GB': 373.37, 'host_free_GB': 729.63} [repeated 7x across cluster]
(VLLMEngine pid=89186) (APIServer pid=89709) INFO 05-27 15:00:56 [api_router.py:39] wake up the engine with tags: ['weights']
(VLLMEngine pid=89186) (EngineCore pid=90354) INFO 05-27 15:00:56 [abstract.py:349] It took 0.465588 seconds to wake up tags ['weights'].
(VLLMEngine pid=89186) (APIServer pid=89709) INFO:     192.168.5.34:40222 - "POST /wake_up?tags=weights HTTP/1.1" 200 OK
(MegatronTrainRayActor pid=93777) [2026-05-27 15:00:56] timer.py:24 - Timer update_weights start
(MegatronTrainRayActor pid=93777) [2026-05-27 15:00:56] reloadable_process_group.py:166 - Reloading 33 process groups in pid 93777
(MegatronTrainRayActor pid=93777) [2026-05-27 15:00:56] memory_utils.py:47 - [Rank 0] Memory-Usage before update_weights: {'gpu': '0', 'total_GB': 79.18, 'free_GB': 63.49, 'used_GB': 15.69, 'allocated_GB': 33.71, 'reserved_GB': 33.95, 'host_total_GB': 2015.51, 'host_available_GB': 1367.78, 'host_used_GB': 647.72, 'host_free_GB': 455.22}
(VLLMEngine pid=89186) (APIServer pid=89709) INFO 05-27 15:00:56 [api_router.py:39] Resetting prefix cache...
(VLLMEngine pid=89186) (EngineCore pid=90354) INFO 05-27 15:00:56 [block_pool.py:482] Successfully reset prefix cache
(VLLMEngine pid=89186) (APIServer pid=89709) INFO:     192.168.5.34:40224 - "POST /reset_prefix_cache?reset_running_requests=False&reset_external=False HTTP/1.1" 200 OK
(VLLMEngine pid=89186) (APIServer pid=89709) INFO:     192.168.5.34:40232 - "POST /sleep?level=0 HTTP/1.1" 200 OK
(VLLMEngine pid=89186) (APIServer pid=89709) INFO:     192.168.5.34:40238 - "POST /start_weight_update HTTP/1.1" 200 OK
(MegatronTrainRayActor pid=93777) 
Update weights:   0%|          | 0/27 [00:00<?, ?it/s]
(VLLMEngine pid=89188) (APIServer pid=89741) INFO:     192.168.5.34:50480 - "POST /update_weights HTTP/1.1" 200 OK
(MegatronTrainRayActor pid=94254) /usr/local/lib/python3.12/dist-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
(MegatronTrainRayActor pid=94254)   return func(*args, **kwargs)
(MegatronTrainRayActor pid=93777) 
Update weights:   4%|▎         | 1/27 [00:00<00:24,  1.07it/s]
(MegatronTrainRayActor pid=93777) 
Update weights:  11%|█         | 3/27 [00:01<00:06,  3.46it/s]
(MegatronTrainRayActor pid=93777) 
Update weights:  19%|█▊        | 5/27 [00:01<00:03,  5.90it/s]
(MegatronTrainRayActor pid=93777) 
Update weights:  26%|██▌       | 7/27 [00:01<00:02,  8.20it/s]
(MegatronTrainRayActor pid=93777) 
Update weights:  33%|███▎      | 9/27 [00:01<00:01, 10.32it/s]
(MegatronTrainRayActor pid=93777) 
Update weights:  41%|████      | 11/27 [00:01<00:01, 11.91it/s]
(MegatronTrainRayActor pid=93777) 
Update weights:  52%|█████▏    | 14/27 [00:01<00:00, 14.58it/s]
(MegatronTrainRayActor pid=93777) 
Update weights:  63%|██████▎   | 17/27 [00:01<00:00, 16.65it/s]
(VLLMEngine pid=89190) (APIServer pid=89711) INFO:     192.168.5.34:43050 - "GET /health HTTP/1.1" 200 OK [repeated 3x across cluster]
(MegatronTrainRayActor pid=93777) 
Update weights:  74%|███████▍  | 20/27 [00:01<00:00, 16.84it/s]
(MegatronTrainRayActor pid=93777) 
Update weights:  81%|████████▏ | 22/27 [00:02<00:00, 15.37it/s]
(MegatronTrainRayActor pid=93777) 
Update weights:  89%|████████▉ | 24/27 [00:02<00:00, 15.56it/s]
(MegatronTrainRayActor pid=93777) 
Update weights:  96%|█████████▋| 26/27 [00:02<00:00, 16.10it/s]
(VLLMEngine pid=89188) (Worker_TP0 pid=90653) WARNING 05-27 15:00:59 [layerwise.py:253] RotaryEmbedding: Failed to load weights
(VLLMEngine pid=89188) (Worker_TP1 pid=90654) WARNING 05-27 15:00:59 [layerwise.py:253] RotaryEmbedding: Failed to load weights
(MegatronTrainRayActor pid=93777) 
Update weights: 100%|██████████| 27/27 [00:02<00:00, 11.15it/s]
(VLLMEngine pid=89186) (APIServer pid=89709) INFO:     192.168.5.34:40478 - "POST /finish_weight_update HTTP/1.1" 200 OK
(VLLMEngine pid=89186) (APIServer pid=89709) INFO 05-27 15:00:59 [api_router.py:39] wake up the engine with tags: ['weights', 'kv_cache']
(VLLMEngine pid=89186) (EngineCore pid=90354) WARNING 05-27 15:00:59 [abstract.py:342] Tag weights is not in sleeping tags {'kv_cache'}
(VLLMEngine pid=89186) (APIServer pid=89709) INFO:     192.168.5.34:40486 - "POST /wake_up?tags=weights&tags=kv_cache HTTP/1.1" 200 OK
(MegatronTrainRayActor pid=93777) [2026-05-27 15:00:59] memory_utils.py:47 - [Rank 0] Memory-Usage after update_weights: {'gpu': '0', 'total_GB': 79.18, 'free_GB': 55.75, 'used_GB': 23.43, 'allocated_GB': 33.71, 'reserved_GB': 40.43, 'host_total_GB': 2015.51, 'host_available_GB': 1367.34, 'host_used_GB': 648.17, 'host_free_GB': 454.77}
(MegatronTrainRayActor pid=93777) [2026-05-27 15:00:59] timer.py:32 - Timer update_weights end (elapsed: 3.1s)
(VLLMEngine pid=89186) (APIServer pid=89709) INFO 05-27 15:00:59 [api_router.py:39] wake up the engine with tags: ['kv_cache']
(RolloutManager pid=88529) 2026-05-27 15:01:00  INFO vllm_router_rs::routers::http::router: src/routers/http/router.rs:1210: Removed worker: http://192.168.5.34:15002
(RolloutManager pid=88529) 2026-05-27 15:01:00  INFO vllm_router_rs::routers::http::router: src/routers/http/router.rs:1225: Removed worker from cache-aware tree: http://192.168.5.34:15002
(RolloutManager pid=88529) 2026-05-27 15:01:00  INFO vllm_router_rs::routers::http::router: src/routers/http/router.rs:1210: Removed worker: http://192.168.5.34:15004
(RolloutManager pid=88529) 2026-05-27 15:01:00  INFO vllm_router_rs::routers::http::router: src/routers/http/router.rs:1210: Removed worker: http://192.168.5.34:15006
(RolloutManager pid=88529) 2026-05-27 15:01:00  INFO vllm_router_rs::routers::http::router: src/routers/http/router.rs:1225: Removed worker from cache-aware tree: http://192.168.5.34:15004
(RolloutManager pid=88529) 2026-05-27 15:01:00  INFO vllm_router_rs::routers::http::router: src/routers/http/router.rs:1225: Removed worker from cache-aware tree: http://192.168.5.34:15006
(RolloutManager pid=88529) 2026-05-27 15:01:00  INFO vllm_router_rs::routers::http::router: src/routers/http/router.rs:1210: Removed worker: http://192.168.5.34:15000
(RolloutManager pid=88529) 2026-05-27 15:01:00  INFO vllm_router_rs::policies::registry: src/policies/registry.rs:124: Removed policy cache_aware for model unknown (last worker removed)
(VLLMEngine pid=89186) (EngineCore pid=90354) INFO 05-27 15:01:00 [abstract.py:349] It took 0.606197 seconds to wake up tags ['kv_cache'].
(VLLMEngine pid=89186) (APIServer pid=89709) INFO:     192.168.5.34:40488 - "POST /wake_up?tags=kv_cache HTTP/1.1" 200 OK
(VLLMEngine pid=89190) (APIServer pid=89711) INFO 05-27 15:00:56 [api_router.py:39] wake up the engine with tags: ['weights'] [repeated 3x across cluster]
(VLLMEngine pid=89190) (EngineCore pid=90362) INFO 05-27 15:00:56 [abstract.py:349] It took 0.484674 seconds to wake up tags ['weights']. [repeated 3x across cluster]
(VLLMEngine pid=89190) (APIServer pid=89711) INFO:     192.168.5.34:43052 - "POST /wake_up?tags=weights HTTP/1.1" 200 OK [repeated 3x across cluster]
(VLLMEngine pid=89190) (APIServer pid=89711) INFO 05-27 15:00:56 [api_router.py:39] Resetting prefix cache... [repeated 3x across cluster]
(VLLMEngine pid=89190) (EngineCore pid=90362) INFO 05-27 15:00:56 [block_pool.py:482] Successfully reset prefix cache [repeated 3x across cluster]
(VLLMEngine pid=89190) (APIServer pid=89711) INFO:     192.168.5.34:43058 - "POST /reset_prefix_cache?reset_running_requests=False&reset_external=False HTTP/1.1" 200 OK [repeated 3x across cluster]
(VLLMEngine pid=89190) (APIServer pid=89711) INFO:     192.168.5.34:43064 - "POST /sleep?level=0 HTTP/1.1" 200 OK [repeated 3x across cluster]
(VLLMEngine pid=89190) (APIServer pid=89711) INFO:     192.168.5.34:43076 - "POST /start_weight_update HTTP/1.1" 200 OK [repeated 3x across cluster]
(VLLMEngine pid=89190) (APIServer pid=89711) INFO:     192.168.5.34:43328 - "POST /update_weights HTTP/1.1" 200 OK [repeated 107x across cluster]
(VLLMEngine pid=89190) (Worker_TP0 pid=90630) WARNING 05-27 15:00:59 [layerwise.py:253] RotaryEmbedding: Failed to load weights [repeated 6x across cluster]
(VLLMEngine pid=89190) (APIServer pid=89711) INFO:     192.168.5.34:43340 - "POST /finish_weight_update HTTP/1.1" 200 OK [repeated 3x across cluster]
(VLLMEngine pid=89190) (APIServer pid=89711) INFO 05-27 15:00:59 [api_router.py:39] wake up the engine with tags: ['weights', 'kv_cache'] [repeated 3x across cluster]
(VLLMEngine pid=89190) (EngineCore pid=90362) WARNING 05-27 15:00:59 [abstract.py:342] Tag weights is not in sleeping tags {'kv_cache'} [repeated 3x across cluster]
(VLLMEngine pid=89190) (APIServer pid=89711) INFO:     192.168.5.34:43348 - "POST /wake_up?tags=weights&tags=kv_cache HTTP/1.1" 200 OK [repeated 3x across cluster]
(VLLMEngine pid=89190) (APIServer pid=89711) INFO 05-27 15:00:59 [api_router.py:39] wake up the engine with tags: ['kv_cache'] [repeated 3x across cluster]
(VLLMEngine pid=89190) (EngineCore pid=90362) INFO 05-27 15:01:00 [abstract.py:349] It took 0.587400 seconds to wake up tags ['kv_cache']. [repeated 3x across cluster]
(VLLMEngine pid=89190) (APIServer pid=89711) INFO:     192.168.5.34:43352 - "POST /wake_up?tags=kv_cache HTTP/1.1" 200 OK [repeated 3x across cluster]
(MegatronTrainRayActor pid=94257) [2026-05-27 15:00:56] memory_utils.py:47 - [Rank 5] Memory-Usage after offload model: {'gpu': '5', 'total_GB': 79.18, 'free_GB': 72.85, 'used_GB': 6.33, 'allocated_GB': 33.71, 'reserved_GB': 33.97, 'host_total_GB': 2015.51, 'host_available_GB': 1367.81, 'host_used_GB': 647.69, 'host_free_GB': 455.25} [repeated 7x across cluster]
(MegatronTrainRayActor pid=94259) [2026-05-27 15:00:56] reloadable_process_group.py:166 - Reloading 33 process groups in pid 94259 [repeated 7x across cluster]
(MegatronTrainRayActor pid=94256) [2026-05-27 15:00:56] memory_utils.py:47 - [Rank 7] Memory-Usage before update_weights: {'gpu': '7', 'total_GB': 79.18, 'free_GB': 65.93, 'used_GB': 13.25, 'allocated_GB': 33.71, 'reserved_GB': 33.92, 'host_total_GB': 2015.51, 'host_available_GB': 1367.78, 'host_used_GB': 647.73, 'host_free_GB': 455.21} [repeated 7x across cluster]
(MegatronTrainRayActor pid=94259) /usr/local/lib/python3.12/dist-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning. [repeated 3x across cluster]
(MegatronTrainRayActor pid=94259)   return func(*args, **kwargs) [repeated 3x across cluster]
(MegatronTrainRayActor pid=94259) [2026-05-27 15:00:59] memory_utils.py:47 - [Rank 6] Memory-Usage after update_weights: {'gpu': '6', 'total_GB': 79.18, 'free_GB': 57.95, 'used_GB': 21.23, 'allocated_GB': 33.71, 'reserved_GB': 40.4, 'host_total_GB': 2015.51, 'host_available_GB': 1367.34, 'host_used_GB': 648.17, 'host_free_GB': 454.77} [repeated 7x across cluster]

------------------------------------------
Job 'raysubmit_kVuxbaKEJ3ww66U5' succeeded
------------------------------------------
```