### PR TITLE
[BugFix]:Stabilize vLLM engine control-plane helpers

### DIFF
--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -589,13 +589,18 @@ class VLLMEngine(RayActor):
         Caller must invoke ``start_weight_update`` / ``finish_weight_update`` around a batch of
         ``/update_weights`` calls (see ``UpdateWeightFromTensor`` / ``UpdateWeightFromDistributed``).
         """
-        response = self._post_json(
-            "update_weights",
-            {"update_info": update_info},
-            timeout=self._weight_transfer_http_timeout(),
+        timeout_s = float(
+            os.environ.get(
+                "SLIME_VLLM_WEIGHT_TRANSFER_UPDATE_TIMEOUT_SEC",
+                os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"),
+            )
         )
+        response = self._post_json("update_weights", {"update_info": update_info}, timeout=timeout_s)
         response.raise_for_status()
-        return _response_json_or_fallback(response)
+        try:
+            return response.json()
+        except Exception:
+            return {"ok": True, "raw": response.text}
 
     def _run_vllm_weight_update(self, update_info: dict, *, is_checkpoint_format: bool = False):
         """Backward-compatible alias for non-NCCL ``update_info`` shapes (e.g. tensor/IPC path)."""
@@ -790,13 +795,16 @@ class VLLMEngine(RayActor):
         For IPC mode the payload is ``{"init_info": {}}``; for NCCL use
         ``init_weights_update_group`` which constructs the payload from typed args.
         """
-        init_timeout_s = self._weight_transfer_http_timeout()
+        init_timeout_s = float(os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"))
         last_error = None
         for attempt in range(1, 4):
             try:
                 response = self._post_json("init_weight_transfer_engine", payload, timeout=init_timeout_s)
                 response.raise_for_status()
-                return _response_json_or_fallback(response)
+                try:
+                    return response.json()
+                except Exception:
+                    return {"ok": True, "raw": response.text}
             except Exception as e:
                 last_error = e
                 if attempt < 3:
@@ -820,7 +828,10 @@ class VLLMEngine(RayActor):
             timeout=self._weight_transfer_http_timeout(),
         )
         response.raise_for_status()
-        return _response_json_or_fallback(response)
+        try:
+            return response.json()
+        except Exception:
+            return {"ok": True, "raw": response.text}
 
     def finish_weight_update(self, weight_version: str | None = None) -> dict:
         """``POST /finish_weight_update`` — signals vLLM to exit IPC weight-update mode.
@@ -845,7 +856,10 @@ class VLLMEngine(RayActor):
         # ``update_weights`` and the ci_test check below it would not run.)
         if weight_version is not None:
             self._weight_version = str(weight_version)
-        return _response_json_or_fallback(response)
+        try:
+            return response.json()
+        except Exception:
+            return {"ok": True, "raw": response.text}
 
     def check_weights(self, action: str):
         """No vLLM ``weights_checker`` route; return a placeholder (SGLang posts to ``/weights_checker``)."""

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -70,6 +70,22 @@ def _format_v6_uri(addr: str | None) -> str | None:
     return addr
 
 
+def _response_json_or_fallback(response: requests.Response) -> dict:
+    """Return a dict body for vLLM control-plane responses.
+
+    vLLM control endpoints generally return JSON objects, but some versions may
+    return a non-JSON or non-object body for successful lightweight endpoints.
+    Normalize those cases so callers can still log/use a structured result.
+    """
+    try:
+        data = response.json()
+    except Exception:
+        return {"ok": False, "error": "Invalid JSON response", "raw": response.text}
+    if not isinstance(data, dict):
+        return {"ok": False, "error": "Response is not a dictionary", "data": data}
+    return data
+
+
 def _exec_vllm_cmd(cmd: list[str], env: dict[str, str]) -> None:
     """Entry point for multiprocessing child process."""
     os.execvpe(cmd[0], cmd, env)
@@ -451,6 +467,8 @@ class VLLMEngine(RayActor):
         self.node_rank = 0
 
     def _http_base(self) -> str:
+        if not hasattr(self, "server_host") or not hasattr(self, "server_port"):
+            raise RuntimeError("VLLMEngine.init() must be called before using the HTTP control plane.")
         return f"http://{self.server_host}:{self.server_port}"
 
     def init(
@@ -571,18 +589,13 @@ class VLLMEngine(RayActor):
         Caller must invoke ``start_weight_update`` / ``finish_weight_update`` around a batch of
         ``/update_weights`` calls (see ``UpdateWeightFromTensor`` / ``UpdateWeightFromDistributed``).
         """
-        timeout_s = float(
-            os.environ.get(
-                "SLIME_VLLM_WEIGHT_TRANSFER_UPDATE_TIMEOUT_SEC",
-                os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"),
-            )
+        response = self._post_json(
+            "update_weights",
+            {"update_info": update_info},
+            timeout=self._weight_transfer_http_timeout(),
         )
-        response = self._post_json("update_weights", {"update_info": update_info}, timeout=timeout_s)
         response.raise_for_status()
-        try:
-            return response.json()
-        except Exception:
-            return {"ok": True, "raw": response.text}
+        return _response_json_or_fallback(response)
 
     def _run_vllm_weight_update(self, update_info: dict, *, is_checkpoint_format: bool = False):
         """Backward-compatible alias for non-NCCL ``update_info`` shapes (e.g. tensor/IPC path)."""
@@ -777,16 +790,13 @@ class VLLMEngine(RayActor):
         For IPC mode the payload is ``{"init_info": {}}``; for NCCL use
         ``init_weights_update_group`` which constructs the payload from typed args.
         """
-        init_timeout_s = float(os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"))
+        init_timeout_s = self._weight_transfer_http_timeout()
         last_error = None
         for attempt in range(1, 4):
             try:
                 response = self._post_json("init_weight_transfer_engine", payload, timeout=init_timeout_s)
                 response.raise_for_status()
-                try:
-                    return response.json()
-                except Exception:
-                    return {"ok": True, "raw": response.text}
+                return _response_json_or_fallback(response)
             except Exception as e:
                 last_error = e
                 if attempt < 3:
@@ -794,19 +804,23 @@ class VLLMEngine(RayActor):
                     time.sleep(2 * attempt)
         raise RuntimeError(f"vLLM init_weight_transfer_engine failed: {last_error}") from last_error
 
+    def _weight_transfer_http_timeout(self) -> float:
+        return float(
+            os.environ.get(
+                "SLIME_VLLM_WEIGHT_TRANSFER_UPDATE_TIMEOUT_SEC",
+                os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"),
+            )
+        )
+
     def start_weight_update(self, is_checkpoint_format: bool = False) -> dict:
         """``POST /start_weight_update`` — signals vLLM to enter IPC weight-update mode."""
-        update_timeout_s = float(os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"))
         response = self._post_json(
             "start_weight_update",
             {"is_checkpoint_format": is_checkpoint_format},
-            timeout=update_timeout_s,
+            timeout=self._weight_transfer_http_timeout(),
         )
         response.raise_for_status()
-        try:
-            return response.json()
-        except Exception:
-            return {"ok": True, "raw": response.text}
+        return _response_json_or_fallback(response)
 
     def finish_weight_update(self, weight_version: str | None = None) -> dict:
         """``POST /finish_weight_update`` — signals vLLM to exit IPC weight-update mode.
@@ -822,8 +836,7 @@ class VLLMEngine(RayActor):
         (e.g. ``/root/models/Qwen2.5-0.5B-Instruct``), never matching the
         updater's integer version (``"1"``, ``"2"``, …).
         """
-        update_timeout_s = float(os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"))
-        response = self._post_json("finish_weight_update", {}, timeout=update_timeout_s)
+        response = self._post_json("finish_weight_update", {}, timeout=self._weight_transfer_http_timeout())
         response.raise_for_status()
         # Record the new version only after the POST succeeded — if the engine
         # never actually exited weight-update mode, ``_weight_version`` must not
@@ -832,10 +845,7 @@ class VLLMEngine(RayActor):
         # ``update_weights`` and the ci_test check below it would not run.)
         if weight_version is not None:
             self._weight_version = str(weight_version)
-        try:
-            return response.json()
-        except Exception:
-            return {"ok": True, "raw": response.text}
+        return _response_json_or_fallback(response)
 
     def check_weights(self, action: str):
         """No vLLM ``weights_checker`` route; return a placeholder (SGLang posts to ``/weights_checker``)."""

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -822,10 +822,11 @@ class VLLMEngine(RayActor):
 
     def start_weight_update(self, is_checkpoint_format: bool = False) -> dict:
         """``POST /start_weight_update`` — signals vLLM to enter IPC weight-update mode."""
+        update_timeout_s = float(os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"))
         response = self._post_json(
             "start_weight_update",
             {"is_checkpoint_format": is_checkpoint_format},
-            timeout=self._weight_transfer_http_timeout(),
+            timeout=update_timeout_s,
         )
         response.raise_for_status()
         try:
@@ -847,7 +848,8 @@ class VLLMEngine(RayActor):
         (e.g. ``/root/models/Qwen2.5-0.5B-Instruct``), never matching the
         updater's integer version (``"1"``, ``"2"``, …).
         """
-        response = self._post_json("finish_weight_update", {}, timeout=self._weight_transfer_http_timeout())
+        update_timeout_s = float(os.environ.get("SLIME_VLLM_WEIGHT_TRANSFER_HTTP_TIMEOUT_SEC", "900"))
+        response = self._post_json("finish_weight_update", {}, timeout=update_timeout_s)
         response.raise_for_status()
         # Record the new version only after the POST succeeded — if the engine
         # never actually exited weight-update mode, ``_weight_version`` must not


### PR DESCRIPTION
## Purpose
Related: https://github.com/vllm-project/vime/issues/60
The bug was caused by missing and inconsistent vLLM control-plane helpers: timeout handling, JSON response parsing, and pre-init HTTP access were implemented ad hoc or not at all.

The fix adds shared timeout and response-normalization helpers, makes _http_base() fail clearly before initialization, and routes the vLLM weight-update endpoints through the unified helpers.

## Test Plan

```
python -m pytest -m unit --tb=short -ra tests/unit/backends/vllm_utils/test_vllm_engine.py
```

### Previous:
```
========================== test session starts ===========================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /proj-tango-pvc/users/zhipeng.wang/workspace/vime
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 27 items                                                       

tests/unit/backends/vllm_utils/test_vllm_engine.py::test_normalize_vllm_wake_tags_drops_unsupported PASSED [  3%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_normalize_vllm_wake_tags_empty_becomes_none PASSED [  7%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_format_v6_uri_wraps_ipv6 PASSED [ 11%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_format_v6_uri_ipv4_unchanged PASSED [ 14%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_to_local_gpu_id_without_cvd PASSED [ 18%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_to_local_gpu_id_maps_physical_id PASSED [ 22%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_get_base_gpu_id_colocate PASSED [ 25%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_start_weight_update_posts_four_phase_endpoint FAILED [ 29%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_finish_weight_update_posts_empty_body FAILED [ 33%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_finish_weight_update_records_weight_version_after_success PASSED [ 37%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_update_weights_from_distributed_posts_update_weights_without_checkpoint_flag PASSED [ 40%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_post_vllm_update_weights_http_wraps_update_info PASSED [ 44%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_weight_transfer_http_timeout_reads_env FAILED [ 48%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_weight_transfer_http_timeout_fallback_to_legacy_env FAILED [ 51%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_response_json_or_fallback_parses_dict FAILED [ 55%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_response_json_or_fallback_non_dict_wrapped FAILED [ 59%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_response_json_or_fallback_invalid_json FAILED [ 62%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_http_base_requires_init FAILED [ 66%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_http_base_ipv6_host PASSED [ 70%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_redact_cmd_for_log_masks_hf_token PASSED [ 74%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_serialize_for_cli_primitives PASSED [ 77%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_serialize_for_cli_dataclass PASSED [ 81%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_get_base_gpu_id_with_critic_offset PASSED [ 85%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_resume_memory_occupation_wake_tags_query PASSED [ 88%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_resume_memory_occupation_skips_when_sleep_disabled PASSED [ 92%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_init_weights_update_group_retries_then_succeeds PASSED [ 96%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_init_weights_update_group_raises_after_three_failures PASSED [100%]

================================ FAILURES ================================
___________ test_start_weight_update_posts_four_phase_endpoint ___________
tests/unit/backends/vllm_utils/test_vllm_engine.py:86: in test_start_weight_update_posts_four_phase_endpoint
    assert calls[0][2] == vllm_engine._weight_transfer_http_timeout()
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   AttributeError: 'VLLMEngine' object has no attribute '_weight_transfer_http_timeout'
_______________ test_finish_weight_update_posts_empty_body _______________
tests/unit/backends/vllm_utils/test_vllm_engine.py:102: in test_finish_weight_update_posts_empty_body
    assert calls == [("finish_weight_update", {}, vllm_engine._weight_transfer_http_timeout())]
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   AttributeError: 'VLLMEngine' object has no attribute '_weight_transfer_http_timeout'
______________ test_weight_transfer_http_timeout_reads_env _______________
tests/unit/backends/vllm_utils/test_vllm_engine.py:171: in test_weight_transfer_http_timeout_reads_env
    assert vllm_engine._weight_transfer_http_timeout() == 123.5
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   AttributeError: 'VLLMEngine' object has no attribute '_weight_transfer_http_timeout'
________ test_weight_transfer_http_timeout_fallback_to_legacy_env ________
tests/unit/backends/vllm_utils/test_vllm_engine.py:178: in test_weight_transfer_http_timeout_fallback_to_legacy_env
    assert vllm_engine._weight_transfer_http_timeout() == 42.0
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   AttributeError: 'VLLMEngine' object has no attribute '_weight_transfer_http_timeout'
_______________ test_response_json_or_fallback_parses_dict _______________
tests/unit/backends/vllm_utils/test_vllm_engine.py:184: in test_response_json_or_fallback_parses_dict
    assert mod._response_json_or_fallback(response) == {"status": "ready"}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   AttributeError: module 'slime.backends.vllm_utils.vllm_engine' has no attribute '_response_json_or_fallback'
____________ test_response_json_or_fallback_non_dict_wrapped _____________
tests/unit/backends/vllm_utils/test_vllm_engine.py:191: in test_response_json_or_fallback_non_dict_wrapped
    assert mod._response_json_or_fallback(response) == {
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   AttributeError: module 'slime.backends.vllm_utils.vllm_engine' has no attribute '_response_json_or_fallback'
______________ test_response_json_or_fallback_invalid_json _______________
tests/unit/backends/vllm_utils/test_vllm_engine.py:202: in test_response_json_or_fallback_invalid_json
    assert mod._response_json_or_fallback(response) == {
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   AttributeError: module 'slime.backends.vllm_utils.vllm_engine' has no attribute '_response_json_or_fallback'
______________________ test_http_base_requires_init ______________________
tests/unit/backends/vllm_utils/test_vllm_engine.py:215: in test_http_base_requires_init
    engine._http_base()
slime/backends/vllm_utils/vllm_engine.py:454: in _http_base
    return f"http://{self.server_host}:{self.server_port}"
                     ^^^^^^^^^^^^^^^^
E   AttributeError: 'VLLMEngine' object has no attribute 'server_host'
=========================== slowest durations ============================

(81 durations < 0.005s hidden.  Use -vv to show these durations.)
======================== short test summary info =========================
FAILED tests/unit/backends/vllm_utils/test_vllm_engine.py::test_start_weight_update_posts_four_phase_endpoint - AttributeError: 'VLLMEngine' object has no attribute '_weight_transfe...
FAILED tests/unit/backends/vllm_utils/test_vllm_engine.py::test_finish_weight_update_posts_empty_body - AttributeError: 'VLLMEngine' object has no attribute '_weight_transfe...
FAILED tests/unit/backends/vllm_utils/test_vllm_engine.py::test_weight_transfer_http_timeout_reads_env - AttributeError: 'VLLMEngine' object has no attribute '_weight_transfe...
FAILED tests/unit/backends/vllm_utils/test_vllm_engine.py::test_weight_transfer_http_timeout_fallback_to_legacy_env - AttributeError: 'VLLMEngine' object has no attribute '_weight_transfe...
FAILED tests/unit/backends/vllm_utils/test_vllm_engine.py::test_response_json_or_fallback_parses_dict - AttributeError: module 'slime.backends.vllm_utils.vllm_engine' has no...
FAILED tests/unit/backends/vllm_utils/test_vllm_engine.py::test_response_json_or_fallback_non_dict_wrapped - AttributeError: module 'slime.backends.vllm_utils.vllm_engine' has no...
FAILED tests/unit/backends/vllm_utils/test_vllm_engine.py::test_response_json_or_fallback_invalid_json - AttributeError: module 'slime.backends.vllm_utils.vllm_engine' has no...
FAILED tests/unit/backends/vllm_utils/test_vllm_engine.py::test_http_base_requires_init - AttributeError: 'VLLMEngine' object has no attribute 'server_host'
====================== 8 failed, 19 passed in 2.56s ======================

```

### After:
```
========================== test session starts ===========================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /proj-tango-pvc/users/zhipeng.wang/workspace/vime
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 27 items                                                       

tests/unit/backends/vllm_utils/test_vllm_engine.py::test_normalize_vllm_wake_tags_drops_unsupported PASSED [  3%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_normalize_vllm_wake_tags_empty_becomes_none PASSED [  7%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_format_v6_uri_wraps_ipv6 PASSED [ 11%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_format_v6_uri_ipv4_unchanged PASSED [ 14%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_to_local_gpu_id_without_cvd PASSED [ 18%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_to_local_gpu_id_maps_physical_id PASSED [ 22%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_get_base_gpu_id_colocate PASSED [ 25%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_start_weight_update_posts_four_phase_endpoint PASSED [ 29%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_finish_weight_update_posts_empty_body PASSED [ 33%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_finish_weight_update_records_weight_version_after_success PASSED [ 37%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_update_weights_from_distributed_posts_update_weights_without_checkpoint_flag PASSED [ 40%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_post_vllm_update_weights_http_wraps_update_info PASSED [ 44%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_weight_transfer_http_timeout_reads_env PASSED [ 48%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_weight_transfer_http_timeout_fallback_to_legacy_env PASSED [ 51%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_response_json_or_fallback_parses_dict PASSED [ 55%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_response_json_or_fallback_non_dict_wrapped PASSED [ 59%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_response_json_or_fallback_invalid_json PASSED [ 62%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_http_base_requires_init PASSED [ 66%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_http_base_ipv6_host PASSED [ 70%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_redact_cmd_for_log_masks_hf_token PASSED [ 74%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_serialize_for_cli_primitives PASSED [ 77%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_serialize_for_cli_dataclass PASSED [ 81%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_get_base_gpu_id_with_critic_offset PASSED [ 85%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_resume_memory_occupation_wake_tags_query PASSED [ 88%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_resume_memory_occupation_skips_when_sleep_disabled PASSED [ 92%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_init_weights_update_group_retries_then_succeeds PASSED [ 96%]
tests/unit/backends/vllm_utils/test_vllm_engine.py::test_init_weights_update_group_raises_after_three_failures PASSED [100%]

=========================== slowest durations ============================

(81 durations < 0.005s hidden.  Use -vv to show these durations.)
=========================== 27 passed in 2.38s ===========================

```