### PR TITLE
fix(examples/opd): drop fictional --enable-prompt-logprobs flag from teacher launch

### DIFF
--- a/examples/on_policy_distillation/run-qwen3-8B-opd.sh
+++ b/examples/on_policy_distillation/run-qwen3-8B-opd.sh
@@ -11,15 +11,16 @@ TEACHER_PORT=13141
 LOG_FILE="/tmp/vllm_teacher_$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 6).log"
 
 ## Launch the teacher model server in the background.
-## --enable-prompt-logprobs is required so /v1/completions returns the
-## choices[0].prompt_logprobs that slime/rollout/on_policy_distillation.py
-## consumes (with echo=True + prompt_logprobs=1 on each request).
+## OPD teacher uses /v1/completions with echo=True + prompt_logprobs=1 set
+## per-request (see slime/rollout/on_policy_distillation.py reward_func).
+## prompt_logprobs is a per-request SamplingParams field in vLLM; no
+## server-side flag gates it. --max-logprobs defaults to 20, which is
+## plenty for prompt_logprobs=1.
 CUDA_VISIBLE_DEVICES=7 vllm serve /root/Qwen3-32B \
     --host 0.0.0.0 \
     --port $TEACHER_PORT \
     --tensor-parallel-size 1 \
     --gpu-memory-utilization 0.6 \
-    --enable-prompt-logprobs \
     --max-num-batched-tokens 4096 \
     > "$LOG_FILE" 2>&1 &
 


### PR DESCRIPTION
## Summary

`examples/on_policy_distillation/run-qwen3-8B-opd.sh` launches the OPD teacher with `vllm serve ... --enable-prompt-logprobs ...`. That CLI flag does not exist in vllm at any version — `vllm serve` rejects it with `argparse: error: unrecognized arguments: --enable-prompt-logprobs` and the teacher never comes up, so the readiness `until` loop spins indefinitely (matches upstream miles/slime behavior, kept as-is here).

`prompt_logprobs` in vllm is a **per-request** `SamplingParams` field on `/v1/completions`. The OPD `reward_func` in `slime/rollout/on_policy_distillation.py` already sets `prompt_logprobs=1` and `echo=True` per request, which is the correct and only mechanism. No server-side gate.

## Verification (vllm source)

| Where | What |
|---|---|
| `vllm/entrypoints/openai/completion/protocol.py:91` | `prompt_logprobs: int \| None = None` — request-side field |
| `vllm/entrypoints/openai/completion/protocol.py:271-274` | request-side `to_sampling_params()` plumbs it into `SamplingParams` |
| `vllm/engine/arg_utils.py`, `vllm/config/model.py` | only related server-side knob is `--max-logprobs` (default 20); no `--enable-prompt-logprobs` |
| `grep -rn "enable_prompt_logprobs\|enable-prompt-logprobs" vllm/` | zero hits |

The "required" comment block above the flag claimed the flag gated the response, which was wrong (the comment was added during the recent sglang→vllm rename pass and never verified against vllm source). Rewrite it to reflect the per-request mechanism and point at `--max-logprobs` as the only relevant server-side cap.

## Scope

- Single file, single concept fix
- Targets `main` (not PR #18) so it lands independently of the larger sglang runtime cleanup
- Found during PR #18 + PR #48 verification sweep on the r3 image (see [#59](https://github.com/vllm-project/vime/issues/59))

## Test plan

- `vllm serve --help` does not list `--enable-prompt-logprobs` — already verified against the reference vllm checkout (post-PR #37476 nightly)
- OPD teacher launches end-to-end on a host with Qwen3-32B available; readiness loop exits when the first health check succeeds
- `slime/rollout/on_policy_distillation.py reward_func` already issues `prompt_logprobs=1 echo=True` per request — unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
