### PR TITLE
test: drop stale _apply_monkey_patch_torch_reductions patch context

### DIFF
--- a/tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py
+++ b/tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py
@@ -174,8 +174,7 @@ def _run_update(obj, *, chunks=None, ipc_engine_cls=None, ipc_args_cls=None) -> 
         with patch("torch.distributed.get_rank", return_value=0), patch(
             "torch.distributed.barrier", side_effect=counting_barrier
         ):
-            with patch(f"{MODULE_PATH}._apply_monkey_patch_torch_reductions"):
-                obj.update_weights()
+            obj.update_weights()
     return barrier_calls["n"]
 
 


### PR DESCRIPTION
## Summary

Tiny follow-up to PR #40: drop the `with patch(f"{MODULE_PATH}._apply_monkey_patch_torch_reductions"):` context inside `_run_update`. This patch wraps a helper that is being deleted in PR #48 (commit [`39bf899`](https://github.com/vllm-project/vime/commit/39bf899) on `aoshen/align-ipc-rpc-with-slime`). Once that lands, `unittest.mock.patch` will raise `AttributeError: ... does not have the attribute '_apply_monkey_patch_torch_reductions'` on every run; this PR removes the line so PR #40's test suite survives PR #48 merge.

Targeting `gcl/pr18-tests-ci` (PR #40's branch) so the cleanup ships with PR #40.

## What stays

`sglang_mod.monkey_patch_torch_reductions = MagicMock()` (line 57) is intentionally left in place. On PR #40's current view of `main`, both `update_weight_from_tensor._apply_monkey_patch_torch_reductions` and `hf_weight_iterator_direct.py` still do `from ..sglang import monkey_patch_torch_reductions`. Removing the stub here would break the test on PR #40 alone. It can be removed in a follow-up once PR #48 finishes deleting every import site.

## Test plan

- `python -m pytest tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py -x -q`
- All 6 tests pass on `gcl/pr18-tests-ci` HEAD (95b8bc7) with this change applied.

## Cross-references

- PR #48 (`aoshen/align-ipc-rpc-with-slime`) [`39bf899`](https://github.com/vllm-project/vime/commit/39bf899) — deletion of `_apply_monkey_patch_torch_reductions` from `update_weight_from_tensor.py`
- [#59](https://github.com/vllm-project/vime/issues/59) — umbrella for OPD/sweep follow-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
