### PR TITLE
test(plugin-contracts): sync rollout_data_postprocess hook to 3-arg signature

### DIFF
--- a/tests/plugin_contracts/test_plugin_runtime_hook_contracts.py
+++ b/tests/plugin_contracts/test_plugin_runtime_hook_contracts.py
@@ -69,7 +69,7 @@ def reference_convert_samples_to_train_data(args, samples):
     }
 
 
-def reference_rollout_data_postprocess(args) -> None:
+def reference_rollout_data_postprocess(args, rollout_id, rollout_data) -> None:
     args.rollout_data_postprocess_called = True
 
 
@@ -124,7 +124,7 @@ def invoke_convert_samples_to_train_data(fn):
 
 def invoke_rollout_data_postprocess(fn):
     args = type("Args", (), {})()
-    assert fn(args) is None
+    assert fn(args, 0, {}) is None
     assert args.rollout_data_postprocess_called is True
 
 
@@ -170,8 +170,8 @@ HOOK_CASES = [
         "ROLLOUT_DATA_POSTPROCESS_PATH",
         "plugin_contracts.test_plugin_runtime_hook_contracts.reference_rollout_data_postprocess",
         "slime/backends/megatron_utils/actor.py",
-        "self.rollout_data_postprocess(self.args)",
-        ("args",),
+        "self.rollout_data_postprocess(self.args, rollout_id, rollout_data)",
+        ("args", "rollout_id", "rollout_data"),
         invoke_rollout_data_postprocess,
     ),
 ]


### PR DESCRIPTION
## Problem
`test_plugin_runtime_hook_contracts.py::test_runtime_hook_callsite_is_stable[rollout_data_postprocess]` fails on `main`.

The hook is invoked in [actor.py:491](slime/backends/megatron_utils/actor.py#L491) as 3-arg:
```python
self.rollout_data_postprocess(self.args, rollout_id, rollout_data)
```
but the contract test still encoded the stale **1-arg** form (`self.rollout_data_postprocess(self.args)`), so the callsite-marker assertion no longer matched.

## Fix
Sync the `rollout_data_postprocess` `HookCase` to the real 3-arg `(args, rollout_id, rollout_data)` contract:
- `runtime_marker` → `self.rollout_data_postprocess(self.args, rollout_id, rollout_data)`
- `expected_params` → `("args", "rollout_id", "rollout_data")`
- reference function + `invoke_rollout_data_postprocess` updated to 3 params.

Pure test fix — no runtime/behavior change.

## Verification
```
pytest tests/plugin_contracts/test_plugin_runtime_hook_contracts.py -q
# 10 passed (was 9 passed, 1 failed)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)