### PR TITLE
[Feature]vLLM multi-node rollout engine topology

### DIFF
--- a/slime/backends/vllm_utils/arguments.py
+++ b/slime/backends/vllm_utils/arguments.py
@@ -279,10 +279,10 @@ def add_vllm_arguments(parser):
     parser.add_argument = old_parser_add_argument
     parser.add_argument_group = old_parser_add_argument_group
 
-    # NOTE: we deliberately do NOT call ``parser.set_defaults(vllm_gpu_memory_utilization=...)``
-    # here, because argparse.set_defaults also mutates ``action.default`` — which would
-    # then make ``_forward_vllm_cli_args`` think the user accepted the vllm-side default
-    # and skip forwarding. vime-preferred defaults (e.g. gpu_memory_utilization=0.55,
+    # NOTE: we deliberately do NOT call ``parser.set_defaults`` for vllm flags here, because
+    # argparse.set_defaults also mutates ``action.default`` — which would make
+    # ``_forward_vllm_cli_args`` think the user accepted the vllm-side default and skip
+    # forwarding. vime-preferred defaults that genuinely differ from vllm (e.g.
     # weight_transfer_config based on colocate) are applied explicitly in
     # ``vllm_engine.launch_server_process``.
 
@@ -316,15 +316,11 @@ def validate_args(args):
     args.vllm_dp_size = args.vllm_data_parallel_size
     args.vllm_pp_size = args.vllm_pipeline_parallel_size
 
-    # Compute effective TP size considering PP size
-    if args.vllm_pp_size > 1:
-        assert args.rollout_num_gpus_per_engine % args.vllm_pp_size == 0, (
-            f"rollout_num_gpus_per_engine ({args.rollout_num_gpus_per_engine}) must be divisible by "
-            f"vllm_pipeline_parallel_size ({args.vllm_pp_size})"
-        )
-        args.vllm_tp_size = args.rollout_num_gpus_per_engine // args.vllm_pp_size
-    else:
-        args.vllm_tp_size = args.rollout_num_gpus_per_engine
+    # NOTE: TP is intentionally NOT precomputed here. A global ``vllm_tp_size`` derived from the
+    # *global* rollout_num_gpus_per_engine would shadow the per-engine value and break
+    # heterogeneous per-group engines (different num_gpus_per_engine). TP is resolved per engine
+    # in ``vllm_engine._resolve_vllm_parallel_sizes`` (tp = gpus_per_engine // pp), mirroring
+    # upstream slime's sglang_engine. (pp divisibility is validated there, per engine.)
 
     if getattr(args, "vllm_router_ip", None):
         args.vllm_router_ip = _wrap_ipv6(args.vllm_router_ip)

--- a/slime/backends/vllm_utils/arguments.py
+++ b/slime/backends/vllm_utils/arguments.py
@@ -97,6 +97,13 @@ SKIPPED_DESTS = [
     # data_parallel_size remain user-controllable and auto-forward to the vllm
     # subprocess when set.
     "tensor_parallel_size",
+    # multi-node logical engine (orchestrator-owned)
+    "nnodes",
+    "node_rank",
+    "master_addr",
+    "master_port",
+    "data_parallel_backend",
+    "distributed_executor_backend",
     # network: engine launcher decides per-engine port/host
     "port",
     "host",

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -50,8 +50,6 @@ class VllmEngineTopology:
     local_num_gpus: int
     tensor_parallel_size: int
     pipeline_parallel_size: int
-    master_host: str | None = None
-    master_port: int | None = None
 
     @property
     def headless(self) -> bool:
@@ -123,11 +121,26 @@ def _get_vllm_dp_size(args) -> int:
 
 
 def _resolve_vllm_parallel_sizes(args, *, gpus_per_engine: int) -> tuple[int, int]:
+    # Derive TP per-engine from THIS engine's GPU count (matches upstream slime's
+    # sglang_engine: tp = _gpus_per_engine // pp). Deliberately does NOT consult a global
+    # ``args.vllm_tp_size``: validate_args used to set that from the *global*
+    # rollout_num_gpus_per_engine, which shadowed this per-engine value and made a
+    # heterogeneous per-group engine (e.g. a tp=2 group) launch with the global TP —
+    # desyncing the weight-transfer rendezvous (the 300s "3/4 clients joined" hang).
     pp = _get_vllm_pp_size(args)
-    if getattr(args, "vllm_tp_size", None) is not None:
-        tp = int(args.vllm_tp_size)
-    else:
-        tp = gpus_per_engine // pp
+    dp = _get_vllm_dp_size(args)
+    if dp != 1:
+        raise NotImplementedError(
+            "vLLM data parallelism (vllm_data_parallel_size>1) is not wired in this base: TP is "
+            "computed as gpus_per_engine // pp (no DP term) and --data-parallel-size is not "
+            "forwarded. DP/EP support lands in a follow-up PR."
+        )
+    if gpus_per_engine % pp != 0:
+        raise ValueError(
+            f"num_gpus_per_engine ({gpus_per_engine}) must be divisible by "
+            f"vllm_pipeline_parallel_size ({pp})"
+        )
+    tp = gpus_per_engine // pp
     return tp, pp
 
 
@@ -193,9 +206,6 @@ def append_vllm_distributed_launch_flags(
         cmd += ["--distributed-executor-backend", "mp"]
     if topology.headless:
         cmd.append("--headless")
-
-
-_append_vllm_distributed_launch_flags = append_vllm_distributed_launch_flags
 
 
 def _user_overrode(args, dest: str) -> bool:
@@ -303,9 +313,6 @@ def redact_cmd_for_log(cmd: list[str]) -> str:
     return " ".join(parts)
 
 
-_redact_cmd_for_log = redact_cmd_for_log
-
-
 def build_vllm_subprocess_env(server_args: dict[str, Any]) -> dict[str, str]:
     """Child-process environment for ``vllm serve``."""
     args = server_args["args"]
@@ -358,9 +365,6 @@ def serialize_for_cli(value) -> str | None:
             logger.debug("JSON serialization failed for %r: %s", type(value).__name__, exc)
             return None
     return None
-
-
-_serialize_for_cli = serialize_for_cli
 
 
 def _serialize_weight_transfer_config(value) -> str:
@@ -479,11 +483,9 @@ def build_vllm_cmd_and_env(server_args: dict[str, Any]) -> tuple[list[str], dict
     if getattr(args, "use_rollout_routing_replay", False):
         cmd += ["--enable-return-routed-experts"]
 
-    if _user_overrode(args, "vllm_gpu_memory_utilization"):
-        gpu_mem = args.vllm_gpu_memory_utilization
-    else:
-        gpu_mem = 0.55
-    cmd += ["--gpu-memory-utilization", str(gpu_mem)]
+    # gpu_memory_utilization: no vime-forced default. In colocate, training and rollout do not
+    # occupy the GPU simultaneously (sleep/offload cycles), so vLLM's own default is fine. A user
+    # value passed via --vllm-gpu-memory-utilization is auto-forwarded by _forward_vllm_cli_args.
 
     # 2) logprobs_mode: vllm's raw_logprobs are pre-temperature, while Megatron
     #    replay compares against rollout-temperature-scaled logprobs.
@@ -636,8 +638,10 @@ class VLLMEngine(RayActor):
         self._topology = self._server_args["topology"]
         self.node_rank = self._topology.node_rank
 
-        self.router_ip = router_ip if router_ip is not None else self.args.vllm_router_ip
-        self.router_port = router_port if router_port is not None else self.args.vllm_router_port
+        # rollout always passes the resolved router (engine.init(router_ip=self.router_ip, ...))
+        # and _start_router always returns a real address, so no fallback to args is needed.
+        self.router_ip = router_ip
+        self.router_port = router_port
         self.server_host = self._server_args["host"]
         self.server_port = port
 
@@ -648,7 +652,18 @@ class VLLMEngine(RayActor):
             )
 
         if self.args.rollout_external:
-            self._init_external()
+            # Only the HTTP-owning head node (node_rank 0) can hit /health and
+            # /server_info. Headless workers (node_rank>0) expose no HTTP endpoint,
+            # so skip the check for them — mirrors the head/worker split in _init_normal.
+            if self.node_rank == 0:
+                self._init_external()
+            else:
+                logger.info(
+                    "External vLLM headless worker (rank=%s node_rank=%s): skip HTTP health/config "
+                    "check (only node_rank 0 owns HTTP).",
+                    self.rank,
+                    self.node_rank,
+                )
         else:
             self._init_normal()
 
@@ -687,29 +702,45 @@ class VLLMEngine(RayActor):
 
     def _init_external(self) -> None:
         logger.info("Use external vLLM engine (rank=%s) at %s:%s", self.rank, self.server_host, self.server_port)
-        base = self._http_base()
-        _wait_server_healthy(base, process=None)
-        self._wait_external_config_ready()
+        _wait_server_healthy(self._http_base(), process=None)
+        self._sanity_check_external_server_args()
 
-    def _wait_external_config_ready(self) -> None:
-        """External engine: best-effort ``GET /server_info`` TP check (non-fatal)."""
-        try:
-            actual = requests.get(f"{self._http_base()}/server_info", params={"config_format": "json"}, timeout=30)
-            actual.raise_for_status()
-            body = actual.json()
-        except requests.RequestException as e:
-            logger.warning("External vLLM: could not GET /server_info (non-fatal): %s", e)
-            return
+    def _sanity_check_external_server_args(self) -> None:
+        """Strictly verify an external engine's parallel config matches what we expect; raise on mismatch.
 
-        expect_tp = self.args.rollout_num_gpus_per_engine
+        Replaces the previous warn-only check, which (a) compared against the *global*
+        ``rollout_num_gpus_per_engine`` — wrong for heterogeneous / multi-node groups — and
+        (b) only logged a warning, so a misconfigured external engine sailed through and then
+        hung the weight-sync rendezvous ~300s later with no clear error.
+
+        We now compare every field in ``EXTERNAL_ENGINE_CHECK_FIELDS`` against the per-engine
+        expectation in ``self._server_args`` and raise immediately on mismatch. A field that the
+        engine's ``/server_info`` does not report (``actual is None``) is skipped rather than
+        treated as a mismatch (e.g. vLLM ``parallel_config`` may not surface ``nnodes``), so the
+        check stays strict for reported fields without false-failing on unreported ones.
+        """
+        response = requests.get(f"{self._http_base()}/server_info", params={"config_format": "json"}, timeout=30)
+        body = _response_json(response)
         parallel_cfg = body.get("vllm_config", {}).get("parallel_config", {})
-        actual_tp = parallel_cfg.get("tensor_parallel_size")
-        if actual_tp is not None and actual_tp != expect_tp:
-            logger.warning(
-                "External vLLM server_info TP mismatch: expect=%s actual=%s (weak check)",
-                expect_tp,
-                actual_tp,
-            )
+        if not parallel_cfg:
+            raise RuntimeError(f"External vLLM /server_info missing vllm_config.parallel_config: {body}")
+        actual = {
+            "tp_size": parallel_cfg.get("tensor_parallel_size"),
+            "pp_size": parallel_cfg.get("pipeline_parallel_size"),
+            "dp_size": parallel_cfg.get("data_parallel_size"),
+            "nnodes": parallel_cfg.get("nnodes"),
+        }
+        expect = {name: self._server_args.get(name) for name in EXTERNAL_ENGINE_CHECK_FIELDS}
+        for name in EXTERNAL_ENGINE_CHECK_FIELDS:
+            actual_value = actual.get(name)
+            if actual_value is None:
+                logger.debug("External vLLM /server_info did not report %s; skipping that check.", name)
+                continue
+            if actual_value != expect.get(name):
+                raise AssertionError(
+                    f"External vLLM server arg mismatch: {name}: expect={expect.get(name)} "
+                    f"actual={actual_value} (full expect={expect} actual={actual})"
+                )
 
     def _init_normal(self) -> None:
         topology = self._topology
@@ -728,9 +759,17 @@ class VLLMEngine(RayActor):
         else:
             _wait_worker_process_alive(self.process)
 
-    def _post_json(self, endpoint: str, payload: dict, timeout: float) -> requests.Response:
+    def _make_request(self, endpoint: str, payload: dict | None = None, *, timeout: float) -> dict | None:
+        """Control-plane POST returning parsed JSON (mirrors SGLang's ``_make_request``).
+
+        The single choke point for control-plane POSTs: headless workers (node_rank>0) own no
+        HTTP server, so they no-op to None; otherwise POST and parse via the shared
+        ``_response_json`` (also reused by the query-param endpoints /sleep, /wake_up, ...).
+        """
+        if self.node_rank != 0:
+            return None
         url = f"{self._http_base()}/{endpoint.lstrip('/')}"
-        return requests.post(url, json=payload, timeout=timeout)
+        return _response_json(requests.post(url, json=payload or {}, timeout=timeout))
 
     def _post_vllm_update_weights_http(self, update_info: dict) -> dict:
         """POST ``/update_weights`` with ``{"update_info": ...}`` (vLLM RLHF control plane).
@@ -738,12 +777,11 @@ class VLLMEngine(RayActor):
         Caller must invoke ``start_weight_update`` / ``finish_weight_update`` around a batch of
         ``/update_weights`` calls (see ``UpdateWeightFromTensor`` / ``UpdateWeightFromDistributed``).
         """
-        response = self._post_json(
+        return self._make_request(
             "update_weights",
             {"update_info": update_info},
             timeout=self._weight_transfer_http_timeout(),
         )
-        return _response_json(response)
 
     def health_generate(self, timeout: float = 5.0) -> bool:
         """Return True if ``GET /health`` succeeds."""
@@ -861,6 +899,8 @@ class VLLMEngine(RayActor):
         level=0 releases both KV cache and model weights (required before IPC tensor injection).
         Returns a no-op dict when ``--vllm-enable-sleep-mode`` was not set.
         """
+        if self.node_rank != 0:  # /sleep bypasses _make_request (query params, not JSON body); guard explicitly.
+            return None
         self.flush_cache()
         if not getattr(self.args, "vllm_enable_sleep_mode", False):
             return {"ok": True, "sleep_mode": False, "note": "vLLM sleep mode disabled; no /sleep call."}
@@ -875,6 +915,8 @@ class VLLMEngine(RayActor):
 
     def resume_memory_occupation(self, tags: list[str] | None = None):
         """``POST /wake_up`` when sleep mode is on; else a no-op placeholder dict."""
+        if self.node_rank != 0:  # /wake_up bypasses _make_request (query params, not JSON body); guard explicitly.
+            return None
         if not getattr(self.args, "vllm_enable_sleep_mode", False):
             return {"ok": True, "sleep_mode": False}
         tags = _normalize_vllm_wake_tags(tags)
@@ -898,8 +940,7 @@ class VLLMEngine(RayActor):
         last_error = None
         for attempt in range(1, 4):
             try:
-                response = self._post_json("init_weight_transfer_engine", payload, timeout=init_timeout_s)
-                return _response_json(response)
+                return self._make_request("init_weight_transfer_engine", payload, timeout=init_timeout_s)
             except Exception as e:
                 last_error = e
                 if attempt < 3:
@@ -909,12 +950,11 @@ class VLLMEngine(RayActor):
 
     def start_weight_update(self, is_checkpoint_format: bool = False) -> dict:
         """``POST /start_weight_update`` — signals vLLM to enter IPC weight-update mode."""
-        response = self._post_json(
+        return self._make_request(
             "start_weight_update",
             {"is_checkpoint_format": is_checkpoint_format},
             timeout=self._weight_transfer_http_timeout(),
         )
-        return _response_json(response)
 
     def finish_weight_update(self) -> dict:
         """``POST /finish_weight_update`` — signals vLLM to exit IPC weight-update mode.
@@ -923,8 +963,7 @@ class VLLMEngine(RayActor):
         ``update_weights_from_tensor`` (the IPC data-carrying RPC), matching slime's
         single-RPC version-with-data semantics.
         """
-        response = self._post_json("finish_weight_update", {}, timeout=self._weight_transfer_http_timeout())
-        return _response_json(response)
+        return self._make_request("finish_weight_update", {}, timeout=self._weight_transfer_http_timeout())
 
     def check_weights(self, action: str):
         """No vLLM ``weights_checker`` route; return a placeholder dict."""
@@ -950,8 +989,7 @@ class VLLMEngine(RayActor):
         last_error = None
         for attempt in range(1, 4):
             try:
-                response = self._post_json("init_weight_transfer_engine", payload, timeout=init_timeout_s)
-                return _response_json(response)
+                return self._make_request("init_weight_transfer_engine", payload, timeout=init_timeout_s)
             except Exception as e:
                 last_error = e
                 if attempt < 3:

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -1,16 +1,28 @@
+"""Ray actor and launch helpers for vLLM OpenAI HTTP rollout.
+
+Per-Ray-actor ``server_args`` dict is built via :func:`compute_server_args`,
+then :func:`build_vllm_cmd_and_env` turns it into ``vllm serve`` CLI + subprocess env.
+:class:`VLLMEngine` manages the runtime HTTP control plane.
+User-facing vLLM knobs remain on ``train.py`` as ``--vllm-*`` (see ``arguments.py``).
+"""
+
 from __future__ import annotations
 
 import base64
+import dataclasses
 import ipaddress
 import logging
 import multiprocessing
 import os
 import time
+from argparse import BooleanOptionalAction
+from typing import Any
 from urllib.parse import quote
 
 import cloudpickle
 import requests
 
+from slime.backends.vllm_utils.arguments import SKIPPED_DESTS, get_vllm_cli_action_table
 from slime.ray.ray_actor import RayActor
 from slime.utils.http_utils import get_host_info
 
@@ -18,18 +30,47 @@ logger = logging.getLogger(__name__)
 
 _spawn_ctx = multiprocessing.get_context("spawn")
 
-# vLLM sleep/wake only supports these tags.
+# Fields checked against external ``GET /server_info``.
+EXTERNAL_ENGINE_CHECK_FIELDS = ("tp_size", "pp_size", "dp_size", "nnodes")
+
+_REDACTED_FLAGS = frozenset({"--hf-token"})
+
+# vLLM sleep/wake only supports these tags (``cuda_graph`` is not supported).
 _VLLM_WAKE_TAGS = frozenset({"weights", "kv_cache"})
 
+_PRIMITIVE_TYPES = (str, int, float, bool)
 
-def _normalize_vllm_wake_tags(tags: list[str] | None) -> list[str] | None:
-    if not tags:
-        return tags
-    normalized = [t for t in tags if t in _VLLM_WAKE_TAGS]
-    dropped = set(tags) - set(normalized)
-    if dropped:
-        logger.debug("vLLM wake_up: dropped tags not supported by vLLM: %s", sorted(dropped))
-    return normalized or None
+
+@dataclasses.dataclass(frozen=True)
+class VllmEngineTopology:
+    """Per-Ray-actor placement for one slice of a logical rollout engine."""
+
+    nnodes: int
+    node_rank: int
+    local_num_gpus: int
+    tensor_parallel_size: int
+    pipeline_parallel_size: int
+    master_host: str | None = None
+    master_port: int | None = None
+
+    @property
+    def headless(self) -> bool:
+        return self.node_rank != 0
+
+    @property
+    def multi_node(self) -> bool:
+        return self.nnodes > 1
+
+
+def _format_v6_uri(addr: str | None) -> str | None:
+    if not addr or addr.startswith("["):
+        return addr
+    try:
+        if ipaddress.ip_address(addr).version == 6:
+            return f"[{addr}]"
+    except ValueError:
+        pass
+    return addr
 
 
 def _response_json(response: requests.Response) -> dict:
@@ -38,6 +79,9 @@ def _response_json(response: requests.Response) -> dict:
     except requests.exceptions.HTTPError as e:
         e.add_note(f"{response.text=}")
         raise
+    # vLLM sleep/wake endpoints may return 200 with an empty body.
+    if not response.content or not response.content.strip():
+        return {"ok": True}
     return response.json()
 
 
@@ -70,130 +114,220 @@ def _to_local_gpu_id(physical_gpu_id: int) -> int:
     )
 
 
-def _format_v6_uri(addr: str | None) -> str | None:
-    if not addr or addr.startswith("["):
-        return addr
-    try:
-        if ipaddress.ip_address(addr).version == 6:
-            return f"[{addr}]"
-    except ValueError:
-        pass
-    return addr
+def _get_vllm_pp_size(args) -> int:
+    return int(getattr(args, "vllm_pipeline_parallel_size", 1) or 1)
 
 
-def _exec_vllm_cmd(cmd: list[str], env: dict[str, str]) -> None:
-    """Entry point for multiprocessing child process."""
-    os.execvpe(cmd[0], cmd, env)
+def _get_vllm_dp_size(args) -> int:
+    return int(getattr(args, "vllm_dp_size", None) or getattr(args, "vllm_data_parallel_size", 1) or 1)
 
 
-# Types we can safely round-trip through ``str(...)`` back to a CLI argument.
-# We branch on the PARSED VALUE, not ``action.type`` — vllm uses helper parsers
-# (e.g. ``optional_type(int)``) that look custom but produce plain primitives;
-# only when the parsed object itself is non-primitive (e.g. a dataclass like
-# ``WeightTransferConfig``) do we need to skip and let vime handle it explicitly.
-_PRIMITIVE_TYPES = (str, int, float, bool)
+def _resolve_vllm_parallel_sizes(args, *, gpus_per_engine: int) -> tuple[int, int]:
+    pp = _get_vllm_pp_size(args)
+    if getattr(args, "vllm_tp_size", None) is not None:
+        tp = int(args.vllm_tp_size)
+    else:
+        tp = gpus_per_engine // pp
+    return tp, pp
 
 
-def _forward_vllm_cli_args(args, cmd: list[str]) -> None:
-    """Walk ``args.vllm_*`` and append each non-default value to ``cmd`` as a vllm CLI flag.
-
-    Uses the action table from ``slime.backends.vllm_utils.arguments.get_vllm_cli_action_table``
-    so any new flag in vllm's ``AsyncEngineArgs`` becomes user-controllable through
-    ``--vllm-<flag>`` without changes here.
-
-    Flags whose parsed value is a non-primitive Python object (e.g. a dataclass)
-    are skipped — ``str(value)`` would produce a Python repr instead of the
-    JSON/string the subprocess expects. vime handles those explicitly in
-    ``launch_server_process``.
-    """
-    from argparse import BooleanOptionalAction
-
-    from slime.backends.vllm_utils.arguments import get_vllm_cli_action_table
-
-    fixed = {flag for flag in cmd if isinstance(flag, str) and flag.startswith("--")}
-    raw_values: dict[str, str] = getattr(args, "_vllm_raw_values", {})
-
-    for vime_dest, (vllm_flag, action) in get_vllm_cli_action_table().items():
-        if vllm_flag in fixed:
-            continue  # already set by the orchestrator (e.g., --tensor-parallel-size)
-        if not hasattr(args, vime_dest):
-            continue
-        value = getattr(args, vime_dest)
-        default = action.default
-        if value == default or value is None:
-            continue
-
-        if isinstance(action, BooleanOptionalAction):
-            # vllm registers BooleanOptionalAction so --xxx and --no-xxx both flip the same dest.
-            cmd.append(vllm_flag if value else f"--no-{vllm_flag[2:]}")
-            continue
-        # store_true / store_false (nargs=0): emit bare flag.
-        # NOTE: do not collapse this into a generic ``const is True/False`` check —
-        # that would mis-handle ``nargs='?'`` flags like ``--hf-token <token>``
-        # whose ``const`` is True but whose user-supplied value is the actual token.
-        if action.nargs == 0:
-            cmd.append(vllm_flag)
-            continue
-        # nargs='?' with a const: only emit a bare flag when the user passed the
-        # option WITHOUT a value (parsed value == const). Otherwise fall through
-        # and forward the value.
-        if action.nargs == "?" and action.const is not None and value == action.const:
-            cmd.append(vllm_flag)
-            continue
-        # Value-taking lists (when argparse expects multiple positional values):
-        # forward each item separately as ``--flag v1 v2 ...``.
-        if action.nargs in ("+", "*") or (action.nargs not in (None, "?") and isinstance(value, (list, tuple))):
-            # Normalize scalar values from --custom-config-path YAML (which bypasses
-            # argparse) to a single-element list. Without this, an int like
-            # ``cudagraph_capture_sizes: 1024`` would raise on iteration, and a
-            # string like ``allowed_media_domains: example.com`` would be exploded
-            # into one CLI argument per character.
-            if not isinstance(value, (list, tuple)):
-                value = [value]
-            if not value:
-                continue  # avoid emitting a bare `--flag` with no values
-            if not all(isinstance(v, _PRIMITIVE_TYPES) for v in value):
-                logger.debug("Skipping %s: list contains non-primitive items (%r)", vllm_flag, value)
-                continue
-            cmd.append(vllm_flag)
-            cmd.extend(str(v) for v in value)
-            continue
-        # Single value — forward primitives directly. For non-primitive values
-        # (dict, dataclass, list), prefer the user's original CLI/YAML string when
-        # available (``_vllm_raw_values``): vllm's parsers turn JSON into runtime
-        # objects whose ``asdict()`` snapshot contains normalized/internal fields
-        # the subprocess parser may reject (e.g. ``AttentionConfig.backend`` becomes
-        # a fully-qualified class name). Falling back to ``_serialize_for_cli`` covers
-        # cases where the raw string isn't available (e.g. ``args.<x>`` was set
-        # programmatically without going through ``--custom-config-path`` or argv).
-        if not isinstance(value, _PRIMITIVE_TYPES):
-            raw = raw_values.get(vime_dest)
-            if raw is not None:
-                cmd.extend([vllm_flag, raw])
-                continue
-        serialized = _serialize_for_cli(value)
-        if serialized is None:
-            logger.debug(
-                "Skipping forward of %s: parsed value %r (%s) cannot be serialized; " "needs vime-side handling.",
-                vllm_flag,
-                value,
-                type(value).__name__,
+def compute_vllm_engine_topology(
+    args,
+    global_rank: int,
+    *,
+    num_gpus_per_engine: int | None = None,
+) -> VllmEngineTopology:
+    """Compute nnodes / node_rank / local GPU slice for one Ray actor."""
+    gpus_per_engine = num_gpus_per_engine if num_gpus_per_engine is not None else args.rollout_num_gpus_per_engine
+    nnodes = max(1, gpus_per_engine // args.num_gpus_per_node)
+    node_rank = global_rank % nnodes
+    if nnodes == 1:
+        local_num_gpus = min(args.num_gpus_per_node, gpus_per_engine)
+    else:
+        if gpus_per_engine % nnodes != 0:
+            raise ValueError(
+                f"rollout_num_gpus_per_engine ({gpus_per_engine}) must be divisible by the number of "
+                f"nodes per engine ({nnodes})"
             )
+        local_num_gpus = gpus_per_engine // nnodes
+    tp, pp = _resolve_vllm_parallel_sizes(args, gpus_per_engine=gpus_per_engine)
+    return VllmEngineTopology(
+        nnodes=nnodes,
+        node_rank=node_rank,
+        local_num_gpus=local_num_gpus,
+        tensor_parallel_size=tp,
+        pipeline_parallel_size=pp,
+    )
+
+
+def parse_dist_init_addr(dist_init_addr: str) -> tuple[str, int]:
+    """Split ``host:port`` (IPv6-safe) into master host and port."""
+    ip_part, port_part = dist_init_addr.rsplit(":", 1)
+    host = _format_v6_uri(ip_part) or ip_part
+    return host.strip("[]"), int(port_part)
+
+
+def append_vllm_distributed_launch_flags(
+    cmd: list[str],
+    topology: VllmEngineTopology,
+    master: tuple[str, int],
+    args,
+) -> None:
+    """Append vLLM multi-node flags when ``topology.multi_node`` (no-op for single-node)."""
+    if not topology.multi_node:
+        return
+    master_host, master_port = master
+    cmd += [
+        "--nnodes",
+        str(topology.nnodes),
+        "--node-rank",
+        str(topology.node_rank),
+        "--master-addr",
+        master_host,
+        "--master-port",
+        str(master_port),
+    ]
+    if not _user_overrode(args, "vllm_data_parallel_backend"):
+        cmd += ["--data-parallel-backend", "mp"]
+    if not _user_overrode(args, "vllm_distributed_executor_backend"):
+        cmd += ["--distributed-executor-backend", "mp"]
+    if topology.headless:
+        cmd.append("--headless")
+
+
+_append_vllm_distributed_launch_flags = append_vllm_distributed_launch_flags
+
+
+def _user_overrode(args, dest: str) -> bool:
+    user_provided: set[str] = getattr(args, "_vllm_user_provided", set())
+    if dest in user_provided:
+        return True
+    entry = get_vllm_cli_action_table().get(dest)
+    if entry is None:
+        return False
+    _, action = entry
+    return getattr(args, dest, action.default) != action.default
+
+
+def _apply_vllm_overrides(args, server_args: dict[str, Any], vllm_overrides: dict | None, rank: int) -> None:
+    """Merge per-group ``overrides`` from rollout YAML into ``args`` / ``server_args``."""
+    if not vllm_overrides:
+        return
+    for key, value in vllm_overrides.items():
+        normalized = key.replace("-", "_")
+        if normalized == "model_path":
+            server_args["model_path"] = value
             continue
-        cmd.extend([vllm_flag, serialized])
+        if normalized.startswith("disaggregation"):
+            logger.debug("vllm_overrides: skipping unsupported key %s (rank=%s)", key, rank)
+            continue
+        dest = normalized if normalized.startswith("vllm_") else f"vllm_{normalized}"
+        if hasattr(args, dest):
+            logger.info("vllm_overrides: %s=%r (rank=%s)", dest, value, rank)
+            setattr(args, dest, value)
+            continue
+        if normalized in server_args:
+            server_args[normalized] = value
+            continue
+        logger.debug("vllm_overrides: unrecognized key %s (rank=%s)", key, rank)
+
+
+def compute_server_args(
+    args,
+    rank,
+    dist_init_addr,
+    host,
+    port,
+    *,
+    worker_type: str = "regular",
+    base_gpu_id: int | None = None,
+    model_path: str | None = None,
+    vllm_overrides: dict | None = None,
+    num_gpus_per_engine: int | None = None,
+) -> dict[str, Any]:
+    """Build per-actor launch config for ``launch_server_process``."""
+    gpus_per_engine = num_gpus_per_engine or args.rollout_num_gpus_per_engine
+    if gpus_per_engine > args.num_gpus_per_node and gpus_per_engine % args.num_gpus_per_node != 0:
+        raise ValueError(
+            "vLLM multi-node rollout requires rollout_num_gpus_per_engine to be divisible by "
+            f"num_gpus_per_node, got rollout_num_gpus_per_engine={gpus_per_engine} "
+            f"num_gpus_per_node={args.num_gpus_per_node}."
+        )
+
+    topology = compute_vllm_engine_topology(args, rank, num_gpus_per_engine=gpus_per_engine)
+    base = base_gpu_id if base_gpu_id is not None else get_base_gpu_id(args, rank)
+    base = _to_local_gpu_id(base)
+
+    master_addr: str | None = None
+    master_port: int | None = None
+    if topology.multi_node:
+        if not dist_init_addr:
+            raise ValueError("dist_init_addr is required when launching a multi-node vLLM engine")
+        master_addr, master_port = parse_dist_init_addr(dist_init_addr)
+
+    server_args = {
+        "args": args,
+        "rank": rank,
+        "worker_type": worker_type,
+        "model_path": model_path or args.hf_checkpoint,
+        "host": _format_v6_uri(host),
+        "port": port,
+        "master_addr": master_addr,
+        "master_port": master_port,
+        "dist_init_addr": dist_init_addr,
+        "nnodes": topology.nnodes,
+        "node_rank": topology.node_rank,
+        "topology": topology,
+        "visible_devices": ",".join(str(base + i) for i in range(topology.local_num_gpus)),
+        "tp_size": topology.tensor_parallel_size,
+        "pp_size": topology.pipeline_parallel_size,
+        "dp_size": _get_vllm_dp_size(args),
+        "seed": getattr(args, "seed", 1234) + rank,
+    }
+    _apply_vllm_overrides(args, server_args, vllm_overrides, rank)
+    return server_args
+
+
+def redact_cmd_for_log(cmd: list[str]) -> str:
+    """Stringify ``cmd`` for logging, redacting credential flags."""
+    parts: list[str] = []
+    redact_next = False
+    for token in cmd:
+        if redact_next:
+            parts.append("***")
+            redact_next = False
+            continue
+        parts.append(token)
+        if isinstance(token, str) and token in _REDACTED_FLAGS:
+            redact_next = True
+    return " ".join(parts)
+
+
+_redact_cmd_for_log = redact_cmd_for_log
+
+
+def build_vllm_subprocess_env(server_args: dict[str, Any]) -> dict[str, str]:
+    """Child-process environment for ``vllm serve``."""
+    args = server_args["args"]
+    env = os.environ.copy()
+    env.pop("PYTORCH_CUDA_ALLOC_CONF", None)
+    env.setdefault("NCCL_CUMEM_ENABLE", "0")
+    env["CUDA_VISIBLE_DEVICES"] = server_args["visible_devices"]
+    env.setdefault("VLLM_SERVER_DEV_MODE", "1")
+    if getattr(args, "colocate", False):
+        import slime
+
+        vime_root = os.path.dirname(os.path.dirname(os.path.abspath(slime.__file__)))
+        existing_pp = env.get("PYTHONPATH", "")
+        if vime_root not in {p for p in existing_pp.split(os.pathsep) if p}:
+            env["PYTHONPATH"] = os.pathsep.join(filter(None, [vime_root, existing_pp]))
+        env.setdefault("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+    return env
 
 
 class _RobustJsonEncoder:
-    """JSON-encode dataclasses and the non-JSON types vllm's parsed configs may contain.
-
-    vllm's ``CompilationConfig``, ``EPLBConfig``, etc. contain fields of type ``set``,
-    ``frozenset``, ``Enum``, ``Path``, ``bytes``, and nested dataclasses. ``json.dumps``
-    can't serialize those by default; this encoder converts them to JSON-friendly forms.
-    """
-
     @staticmethod
     def default(obj):
-        import dataclasses
         import enum
         from pathlib import Path
 
@@ -210,18 +344,7 @@ class _RobustJsonEncoder:
         raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
-def _serialize_for_cli(value) -> str | None:
-    """Serialize a parsed vllm-arg value back to a CLI-safe string.
-
-    Handles the common cases vllm's CLI parsers produce:
-      - primitives (str/int/float/bool) → ``str(value)``
-      - dataclasses (e.g. ``WeightTransferConfig``, ``CompilationConfig`` with sets/enums)
-        → JSON via a robust encoder that handles set/enum/Path/bytes
-      - dicts (e.g. ``--hf-overrides``) → JSON
-      - lists/tuples of JSON-serializable items → JSON
-      - anything else → ``None`` (caller should skip / handle specially)
-    """
-    import dataclasses
+def serialize_for_cli(value) -> str | None:
     import json
 
     if isinstance(value, str):
@@ -237,143 +360,134 @@ def _serialize_for_cli(value) -> str | None:
     return None
 
 
+_serialize_for_cli = serialize_for_cli
+
+
 def _serialize_weight_transfer_config(value) -> str:
-    """Backwards-compat wrapper that always returns a JSON string for the
-    ``--weight-transfer-config`` flag (which the vllm subprocess parses as JSON).
-    """
-    serialized = _serialize_for_cli(value)
+    serialized = serialize_for_cli(value)
     if serialized is None:
-        # Last resort: assume the value's str() form names the backend.
         import json
 
         return json.dumps({"backend": str(value)})
     return serialized
 
 
-def launch_server_process(
-    *,
-    bind_host: str,
-    server_port: int,
-    args,
-    rank: int,
-    visible_devices: str,
-    model_path: str,
-    num_gpus_per_engine: int | None = None,
-) -> multiprocessing.Process:
-    """Spawn ``vllm serve`` (OpenAI API server) in a subprocess.
+def _forward_vllm_cli_args(args, cmd: list[str]) -> None:
+    """Append user ``--vllm-*`` overrides not already set by the orchestrator."""
+    fixed = {flag for flag in cmd if isinstance(flag, str) and flag.startswith("--")}
+    raw_values: dict[str, str] = getattr(args, "_vllm_raw_values", {})
 
-    Fixed flags (model identity, distributed topology, port/host, seed) are set by the
-    orchestrator. Every other ``vllm serve`` flag is reachable via ``--vllm-<flag>`` and
-    auto-forwarded by ``_forward_vllm_cli_args`` when the user overrides the vllm default.
-    """
-    env = os.environ.copy()
-    env.pop("PYTORCH_CUDA_ALLOC_CONF", None)
-    env.setdefault("NCCL_CUMEM_ENABLE", "0")
-    env["CUDA_VISIBLE_DEVICES"] = visible_devices
-    env.setdefault("VLLM_SERVER_DEV_MODE", "1")
-    # DeepGEMM fp8 kernels: vLLM enables them by default; set explicitly so the
-    # rollout engine is pinned regardless of the base image's defaults (replaces
-    # SGLang's SGLANG_JIT_DEEPGEMM_PRECOMPILE / _FAST_WARMUP). WARMUP="relax" JITs
-    # the required kernels before serving (no hot-path JIT) without the longer
-    # "full" sweep. Both overridable via the environment.
-    env.setdefault("VLLM_USE_DEEP_GEMM", "1")
-    env.setdefault("VLLM_DEEP_GEMM_WARMUP", "relax")
-    # Deterministic inference: VLLM_BATCH_INVARIANT=1 makes attention / comm /
-    # MM kernels pick batch-invariant variants so the same token sequence yields
-    # the same logits regardless of batch composition. Per-sample seed alone (see
-    # GenerateState / eval_rollout_single_dataset in vllm_rollout.py) is necessary
-    # but not sufficient for determinism.
-    if getattr(args, "vllm_enable_deterministic_inference", False):
-        env["VLLM_BATCH_INVARIANT"] = "1"
-    # Colocate loads --worker-extension-cls from slime; vLLM subprocess must see the
-    # same tree as the trainer (editable vime), not an older site-packages slime.
-    if getattr(args, "colocate", False):
-        import slime
+    for vime_dest, (vllm_flag, action) in get_vllm_cli_action_table().items():
+        if vime_dest in SKIPPED_DESTS:
+            continue
+        if vllm_flag in fixed:
+            continue
+        if not hasattr(args, vime_dest):
+            continue
+        value = getattr(args, vime_dest)
+        default = action.default
+        if value == default or value is None:
+            continue
 
-        vime_root = os.path.dirname(os.path.dirname(os.path.abspath(slime.__file__)))
-        existing_pp = env.get("PYTHONPATH", "")
-        if vime_root not in {p for p in existing_pp.split(os.pathsep) if p}:
-            env["PYTHONPATH"] = os.pathsep.join(filter(None, [vime_root, existing_pp]))
-    # Colocated (IPC) mode: the server must be able to deserialize pickled IPC handles
-    # sent by VLLMEngine.update_weights via the /update_weights HTTP endpoint.
-    if getattr(args, "colocate", False):
-        env.setdefault("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+        if isinstance(action, BooleanOptionalAction):
+            cmd.append(vllm_flag if value else f"--no-{vllm_flag[2:]}")
+            continue
+        if action.nargs == 0:
+            cmd.append(vllm_flag)
+            continue
+        if action.nargs == "?" and action.const is not None and value == action.const:
+            cmd.append(vllm_flag)
+            continue
+        if action.nargs in ("+", "*") or (action.nargs not in (None, "?") and isinstance(value, (list, tuple))):
+            if not isinstance(value, (list, tuple)):
+                value = [value]
+            if not value:
+                continue
+            if not all(isinstance(v, _PRIMITIVE_TYPES) for v in value):
+                logger.debug("Skipping %s: list contains non-primitive items (%r)", vllm_flag, value)
+                continue
+            cmd.append(vllm_flag)
+            cmd.extend(str(v) for v in value)
+            continue
+        if not isinstance(value, _PRIMITIVE_TYPES):
+            raw = raw_values.get(vime_dest)
+            if raw is not None:
+                cmd.extend([vllm_flag, raw])
+                continue
+        serialized = serialize_for_cli(value)
+        if serialized is None:
+            logger.debug(
+                "Skipping forward of %s: parsed value %r (%s) cannot be serialized",
+                vllm_flag,
+                value,
+                type(value).__name__,
+            )
+            continue
+        cmd.extend([vllm_flag, serialized])
 
-    host_for_subprocess = bind_host.strip("[]")
-    model = model_path
-    # Per-engine TP: honor this engine's ServerGroup num_gpus_per_engine so a group
-    # configured with tp>1 launches tp>1, matching the weight-sync world_size
-    # accounting in update_weight_from_distributed (engine_gpu_counts). Falls back
-    # to the global flag for single-GPU-per-engine groups.
-    tp = num_gpus_per_engine or args.rollout_num_gpus_per_engine
-    seed = getattr(args, "seed", 1234) + rank
 
-    # Orchestrator-owned flags (correspond to SKIPPED_DESTS in vllm_utils/arguments.py).
+def build_vllm_cmd_and_env(server_args: dict[str, Any]) -> tuple[list[str], dict[str, str]]:
+    """Translate ``server_args`` to ``vllm serve`` argv and subprocess environment."""
+    args = server_args["args"]
+    topology: VllmEngineTopology = server_args["topology"]
+    env = build_vllm_subprocess_env(server_args)
+    host_for_subprocess = (server_args["host"] or "127.0.0.1").strip("[]")
+
     cmd = [
         "vllm",
         "serve",
-        str(model),
+        str(server_args["model_path"]),
         "--tensor-parallel-size",
-        str(tp),
+        str(server_args["tp_size"]),
         "--port",
-        str(server_port),
+        str(server_args["port"]),
         "--host",
         host_for_subprocess,
         "--seed",
-        str(seed),
+        str(server_args["seed"]),
         "--trust-remote-code",
     ]
+
+    if server_args["pp_size"] > 1:
+        cmd += ["--pipeline-parallel-size", str(server_args["pp_size"])]
+
+    if topology.multi_node:
+        if server_args["master_addr"] is None or server_args["master_port"] is None:
+            raise ValueError("master_addr/master_port required for multi-node vLLM engine")
+        append_vllm_distributed_launch_flags(
+            cmd,
+            topology,
+            (server_args["master_addr"], server_args["master_port"]),
+            args,
+        )
+
     if getattr(args, "fp16", False):
         cmd += ["--dtype", "float16"]
-    # Colocated IPC weight sync releases model weights via POST /sleep?level=0.
-    # offload_rollout also needs sleep/wake for memory handoff.
+
     if (getattr(args, "offload_rollout", False) or getattr(args, "colocate", False)) and not getattr(
         args, "vllm_enable_sleep_mode", False
     ):
         cmd += ["--enable-sleep-mode"]
         args.vllm_enable_sleep_mode = True
-    # rollout_max_context_len (vime top-level flag) maps to --max-model-len when set,
-    # unless the user already passed --vllm-max-model-len explicitly.
-    if args.rollout_max_context_len is not None and getattr(args, "vllm_max_model_len", None) is None:
+
+    if (
+        getattr(args, "rollout_max_context_len", None) is not None
+        and getattr(args, "vllm_max_model_len", None) is None
+    ):
         cmd += ["--max-model-len", str(args.rollout_max_context_len)]
+
     if getattr(args, "use_rollout_routing_replay", False):
         cmd += ["--enable-return-routed-experts"]
 
-    # vime-preferred defaults — must be explicitly forwarded because the vllm-side
-    # default would otherwise apply (the generic forwarder skips values that equal
-    # action.default).
-    #
-    # We treat a value as "user-supplied" if EITHER:
-    #   (a) the user named the flag on argv (tracked in ``args._vllm_user_provided``),
-    #       which lets ``--vllm-gpu-memory-utilization 0.92`` (= vllm-side default)
-    #       still be honored as an explicit override, OR
-    #   (b) the parsed value differs from the vllm-side default — this catches
-    #       overrides loaded later from ``--custom-config-path`` YAML or set
-    #       programmatically on the namespace.
-    from slime.backends.vllm_utils.arguments import get_vllm_cli_action_table
-
-    user_provided: set[str] = getattr(args, "_vllm_user_provided", set())
-    _vllm_action_table = get_vllm_cli_action_table()
-
-    def _user_overrode(dest: str) -> bool:
-        if dest in user_provided:
-            return True
-        entry = _vllm_action_table.get(dest)
-        if entry is None:
-            return False
-        _, action = entry
-        return getattr(args, dest, action.default) != action.default
-
-    # 1) gpu_memory_utilization: vllm default 0.92 OOMs in colocate training; vime ships 0.55.
-    if _user_overrode("vllm_gpu_memory_utilization"):
+    if _user_overrode(args, "vllm_gpu_memory_utilization"):
         gpu_mem = args.vllm_gpu_memory_utilization
     else:
-        gpu_mem = 0.55  # vime preferred
+        gpu_mem = 0.55
     cmd += ["--gpu-memory-utilization", str(gpu_mem)]
 
     # 2) logprobs_mode: vllm's raw_logprobs are pre-temperature, while Megatron
     #    replay compares against rollout-temperature-scaled logprobs.
-    if not _user_overrode("vllm_logprobs_mode"):
+    if not _user_overrode(args, "vllm_logprobs_mode"):
         cmd += ["--logprobs-mode", "processed_logprobs"]
 
     # 3) weight_transfer_config: vllm default None disables /init_weight_transfer_engine,
@@ -386,7 +500,7 @@ def launch_server_process(
     #      init_weight_transfer_engine to succeed (with NCCL the caller must supply
     #      master_address, master_port, rank_offset, and world_size separately).
     #    Users who pass ``--vllm-weight-transfer-config`` explicitly are honored.
-    if _user_overrode("vllm_weight_transfer_config"):
+    if _user_overrode(args, "vllm_weight_transfer_config"):
         cmd += [
             "--weight-transfer-config",
             _serialize_weight_transfer_config(args.vllm_weight_transfer_config),
@@ -396,46 +510,48 @@ def launch_server_process(
     else:
         cmd += ["--weight-transfer-config", '{"backend":"nccl"}']
 
-    # Colocated (IPC) mode: inject the worker extension so the IPC engine patch
-    # is applied inside every vLLM worker process automatically.
     if getattr(args, "colocate", False) and "--worker-extension-cls" not in cmd:
         cmd += [
             "--worker-extension-cls",
             "slime.backends.megatron_utils.update_weight.update_weight_from_tensor.vLLMColocateWorkerExtension",
         ]
 
-    # Auto-forward all other args.vllm_* that differ from their vllm-side default.
     _forward_vllm_cli_args(args, cmd)
+    logger.info("Launching vLLM server: %s", redact_cmd_for_log(cmd))
+    return cmd, env
 
-    logger.info("Launching vLLM server: %s", _redact_cmd_for_log(cmd))
 
+def _normalize_vllm_wake_tags(tags: list[str] | None) -> list[str] | None:
+    if not tags:
+        return tags
+    normalized = [t for t in tags if t in _VLLM_WAKE_TAGS]
+    dropped = set(tags) - set(normalized)
+    if dropped:
+        logger.debug("vLLM wake_up: dropped tags not supported by vLLM: %s", sorted(dropped))
+    return normalized or None
+
+
+def _exec_vllm_cmd(cmd: list[str], env: dict[str, str]) -> None:
+    """Entry point for multiprocessing child process."""
+    os.execvpe(cmd[0], cmd, env)
+
+
+def _wait_worker_process_alive(process: multiprocessing.Process, timeout_s: float = 300.0) -> None:
+    """Non-head nodes have no HTTP health endpoint; ensure the subprocess stays up."""
+    start = time.time()
+    while process.is_alive():
+        if time.time() - start > timeout_s:
+            return
+        time.sleep(2)
+    raise RuntimeError(f"vLLM worker process exited unexpectedly with code {process.exitcode}")
+
+
+def launch_server_process(server_args: dict) -> multiprocessing.Process:
+    """Spawn ``vllm serve`` from a :func:`compute_server_args` dict."""
+    cmd, env = build_vllm_cmd_and_env(server_args)
     p = _spawn_ctx.Process(target=_exec_vllm_cmd, args=(cmd, env))
     p.start()
     return p
-
-
-# Flags whose value is a credential and must never appear in logs.
-_REDACTED_FLAGS = frozenset({"--hf-token"})
-
-
-def _redact_cmd_for_log(cmd: list[str]) -> str:
-    """Stringify ``cmd`` for logging, replacing values of sensitive flags with '***'.
-
-    vllm ``--hf-token`` accepts the token as its argument (``nargs='?'``), so we
-    redact the immediately-following token whenever the previous element is in
-    ``_REDACTED_FLAGS``.
-    """
-    parts: list[str] = []
-    redact_next = False
-    for token in cmd:
-        if redact_next:
-            parts.append("***")
-            redact_next = False
-            continue
-        parts.append(token)
-        if isinstance(token, str) and token in _REDACTED_FLAGS:
-            redact_next = True
-    return " ".join(parts)
 
 
 def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None, timeout_s: float = 300.0) -> None:
@@ -474,13 +590,13 @@ class VLLMEngine(RayActor):
         self.worker_type = worker_type
         self.base_gpu_id = base_gpu_id
         self.model_path = model_path or args.hf_checkpoint
-        # Uniform Ray ``start_engines`` kwargs; unused when launching vLLM over HTTP.
         self.vllm_overrides = vllm_overrides or {}
         self.num_gpus_per_engine = num_gpus_per_engine
         self.process: multiprocessing.Process | None = None
         self._weight_version: str | None = None
-        # Slime runs one vLLM HTTP process per logical engine; multi-node worker rank is not used.
         self.node_rank = 0
+        self._topology: VllmEngineTopology | None = None
+        self._server_args: dict | None = None
 
     def _http_base(self) -> str:
         return f"http://{self.server_host}:{self.server_port}"
@@ -498,13 +614,31 @@ class VLLMEngine(RayActor):
         router_ip=None,
         router_port=None,
     ):
-        del dist_init_addr, nccl_port, disaggregation_bootstrap_port
+        # ``nccl_port`` / ``disaggregation_bootstrap_port`` are allocated by rollout
+        # port allocation but not consumed by vLLM (rendezvous uses ``dist_init_addr``).
+        del nccl_port, disaggregation_bootstrap_port
+
+        gpus_per_engine = self.num_gpus_per_engine or self.args.rollout_num_gpus_per_engine
+        host = host or get_host_info()[1]
+
+        self._server_args = compute_server_args(
+            self.args,
+            self.rank,
+            dist_init_addr,
+            host,
+            port,
+            worker_type=self.worker_type,
+            base_gpu_id=self.base_gpu_id,
+            model_path=self.model_path,
+            vllm_overrides=self.vllm_overrides,
+            num_gpus_per_engine=gpus_per_engine,
+        )
+        self._topology = self._server_args["topology"]
+        self.node_rank = self._topology.node_rank
 
         self.router_ip = router_ip if router_ip is not None else self.args.vllm_router_ip
         self.router_port = router_port if router_port is not None else self.args.vllm_router_port
-
-        host = host or get_host_info()[1]
-        self.server_host = _format_v6_uri(host)
+        self.server_host = self._server_args["host"]
         self.server_port = port
 
         if self.worker_type != "regular":
@@ -578,24 +712,21 @@ class VLLMEngine(RayActor):
             )
 
     def _init_normal(self) -> None:
-        logger.info("Launch vLLM OpenAI api_server at: %s:%s", self.server_host, self.server_port)
-        gpus_per_engine = self.num_gpus_per_engine or self.args.rollout_num_gpus_per_engine
-        num_gpus = min(self.args.num_gpus_per_node, gpus_per_engine)
-        base = self.base_gpu_id if self.base_gpu_id is not None else get_base_gpu_id(self.args, self.rank)
-        base = _to_local_gpu_id(base)
-        visible_devices = ",".join(str(base + i) for i in range(num_gpus))
-
-        bind_host = self.server_host
-        self.process = launch_server_process(
-            bind_host=bind_host,
-            server_port=self.server_port,
-            args=self.args,
-            rank=self.rank,
-            visible_devices=visible_devices,
-            model_path=self.model_path,
-            num_gpus_per_engine=gpus_per_engine,
+        topology = self._topology
+        assert topology is not None and self._server_args is not None
+        logger.info(
+            "Launch vLLM OpenAI api_server at: %s:%s (rank=%s node_rank=%s/%s)",
+            self.server_host,
+            self.server_port,
+            self.rank,
+            topology.node_rank,
+            topology.nnodes,
         )
-        _wait_server_healthy(self._http_base(), process=self.process)
+        self.process = launch_server_process(self._server_args)
+        if topology.node_rank == 0:
+            _wait_server_healthy(self._http_base(), process=self.process)
+        else:
+            _wait_worker_process_alive(self.process)
 
     def _post_json(self, endpoint: str, payload: dict, timeout: float) -> requests.Response:
         url = f"{self._http_base()}/{endpoint.lstrip('/')}"
@@ -743,7 +874,7 @@ class VLLMEngine(RayActor):
         return _response_json(response)
 
     def resume_memory_occupation(self, tags: list[str] | None = None):
-        """``POST /wake_up`` when sleep mode is on; else a small placeholder dict."""
+        """``POST /wake_up`` when sleep mode is on; else a no-op placeholder dict."""
         if not getattr(self.args, "vllm_enable_sleep_mode", False):
             return {"ok": True, "sleep_mode": False}
         tags = _normalize_vllm_wake_tags(tags)
@@ -796,7 +927,7 @@ class VLLMEngine(RayActor):
         return _response_json(response)
 
     def check_weights(self, action: str):
-        """No vLLM ``weights_checker`` route; return a placeholder."""
+        """No vLLM ``weights_checker`` route; return a placeholder dict."""
         del action
         return {"ok": True, "supported": False, "note": "vLLM has no weights_checker endpoint."}
 
@@ -843,7 +974,7 @@ class VLLMEngine(RayActor):
         weight_version: str | None = None,
         packed: bool = True,
     ):
-        """NCCL path: POST ``/update_weights``.
+        """NCCL path: ``POST /update_weights`` with packed tensor metadata.
 
         Payload matches vLLM NCCL weight transfer (see upstream rlhf_http_nccl example).
         """
@@ -890,7 +1021,7 @@ class VLLMEngine(RayActor):
         return response
 
     def continue_generation(self):
-        """``POST /resume``."""
+        """``POST /resume`` to continue generation after pause."""
         if self.node_rank != 0:
             return None
         response = requests.post(f"{self._http_base()}/resume", json={}, timeout=120)
@@ -902,7 +1033,7 @@ class VLLMEngine(RayActor):
         restore_weights_before_load: bool = False,
         post_process_quantization: bool = False,
     ):
-        """No vLLM HTTP hook; return a noop placeholder dict."""
+        """No vLLM HTTP hook for post-load processing; return a noop placeholder dict."""
         del restore_weights_before_load, post_process_quantization
         return {"ok": True, "noop": True, "note": "vLLM post_process is internal to load; no HTTP API."}
 

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -41,25 +41,6 @@ _VLLM_WAKE_TAGS = frozenset({"weights", "kv_cache"})
 _PRIMITIVE_TYPES = (str, int, float, bool)
 
 
-@dataclasses.dataclass(frozen=True)
-class VllmEngineTopology:
-    """Per-Ray-actor placement for one slice of a logical rollout engine."""
-
-    nnodes: int
-    node_rank: int
-    local_num_gpus: int
-    tensor_parallel_size: int
-    pipeline_parallel_size: int
-
-    @property
-    def headless(self) -> bool:
-        return self.node_rank != 0
-
-    @property
-    def multi_node(self) -> bool:
-        return self.nnodes > 1
-
-
 def _format_v6_uri(addr: str | None) -> str | None:
     if not addr or addr.startswith("["):
         return addr
@@ -110,6 +91,25 @@ def _to_local_gpu_id(physical_gpu_id: int) -> int:
         f"GPU id {physical_gpu_id} is not valid under CUDA_VISIBLE_DEVICES={cvd}. "
         f"Expected one of {visible} (physical) or 0..{len(visible)-1} (local)."
     )
+
+
+@dataclasses.dataclass(frozen=True)
+class VllmEngineTopology:
+    """Per-Ray-actor placement for one slice of a logical rollout engine."""
+
+    nnodes: int
+    node_rank: int
+    local_num_gpus: int
+    tensor_parallel_size: int
+    pipeline_parallel_size: int
+
+    @property
+    def headless(self) -> bool:
+        return self.node_rank != 0
+
+    @property
+    def multi_node(self) -> bool:
+        return self.nnodes > 1
 
 
 def _get_vllm_pp_size(args) -> int:
@@ -298,40 +298,6 @@ def compute_server_args(
     return server_args
 
 
-def redact_cmd_for_log(cmd: list[str]) -> str:
-    """Stringify ``cmd`` for logging, redacting credential flags."""
-    parts: list[str] = []
-    redact_next = False
-    for token in cmd:
-        if redact_next:
-            parts.append("***")
-            redact_next = False
-            continue
-        parts.append(token)
-        if isinstance(token, str) and token in _REDACTED_FLAGS:
-            redact_next = True
-    return " ".join(parts)
-
-
-def build_vllm_subprocess_env(server_args: dict[str, Any]) -> dict[str, str]:
-    """Child-process environment for ``vllm serve``."""
-    args = server_args["args"]
-    env = os.environ.copy()
-    env.pop("PYTORCH_CUDA_ALLOC_CONF", None)
-    env.setdefault("NCCL_CUMEM_ENABLE", "0")
-    env["CUDA_VISIBLE_DEVICES"] = server_args["visible_devices"]
-    env.setdefault("VLLM_SERVER_DEV_MODE", "1")
-    if getattr(args, "colocate", False):
-        import slime
-
-        vime_root = os.path.dirname(os.path.dirname(os.path.abspath(slime.__file__)))
-        existing_pp = env.get("PYTHONPATH", "")
-        if vime_root not in {p for p in existing_pp.split(os.pathsep) if p}:
-            env["PYTHONPATH"] = os.pathsep.join(filter(None, [vime_root, existing_pp]))
-        env.setdefault("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
-    return env
-
-
 class _RobustJsonEncoder:
     @staticmethod
     def default(obj):
@@ -430,6 +396,40 @@ def _forward_vllm_cli_args(args, cmd: list[str]) -> None:
         cmd.extend([vllm_flag, serialized])
 
 
+def redact_cmd_for_log(cmd: list[str]) -> str:
+    """Stringify ``cmd`` for logging, redacting credential flags."""
+    parts: list[str] = []
+    redact_next = False
+    for token in cmd:
+        if redact_next:
+            parts.append("***")
+            redact_next = False
+            continue
+        parts.append(token)
+        if isinstance(token, str) and token in _REDACTED_FLAGS:
+            redact_next = True
+    return " ".join(parts)
+
+
+def build_vllm_subprocess_env(server_args: dict[str, Any]) -> dict[str, str]:
+    """Child-process environment for ``vllm serve``."""
+    args = server_args["args"]
+    env = os.environ.copy()
+    env.pop("PYTORCH_CUDA_ALLOC_CONF", None)
+    env.setdefault("NCCL_CUMEM_ENABLE", "0")
+    env["CUDA_VISIBLE_DEVICES"] = server_args["visible_devices"]
+    env.setdefault("VLLM_SERVER_DEV_MODE", "1")
+    if getattr(args, "colocate", False):
+        import slime
+
+        vime_root = os.path.dirname(os.path.dirname(os.path.abspath(slime.__file__)))
+        existing_pp = env.get("PYTHONPATH", "")
+        if vime_root not in {p for p in existing_pp.split(os.pathsep) if p}:
+            env["PYTHONPATH"] = os.pathsep.join(filter(None, [vime_root, existing_pp]))
+        env.setdefault("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+    return env
+
+
 def build_vllm_cmd_and_env(server_args: dict[str, Any]) -> tuple[list[str], dict[str, str]]:
     """Translate ``server_args`` to ``vllm serve`` argv and subprocess environment."""
     args = server_args["args"]
@@ -523,16 +523,6 @@ def build_vllm_cmd_and_env(server_args: dict[str, Any]) -> tuple[list[str], dict
     return cmd, env
 
 
-def _normalize_vllm_wake_tags(tags: list[str] | None) -> list[str] | None:
-    if not tags:
-        return tags
-    normalized = [t for t in tags if t in _VLLM_WAKE_TAGS]
-    dropped = set(tags) - set(normalized)
-    if dropped:
-        logger.debug("vLLM wake_up: dropped tags not supported by vLLM: %s", sorted(dropped))
-    return normalized or None
-
-
 def _exec_vllm_cmd(cmd: list[str], env: dict[str, str]) -> None:
     """Entry point for multiprocessing child process."""
     os.execvpe(cmd[0], cmd, env)
@@ -546,14 +536,6 @@ def _wait_worker_process_alive(process: multiprocessing.Process, timeout_s: floa
             return
         time.sleep(2)
     raise RuntimeError(f"vLLM worker process exited unexpectedly with code {process.exitcode}")
-
-
-def launch_server_process(server_args: dict) -> multiprocessing.Process:
-    """Spawn ``vllm serve`` from a :func:`compute_server_args` dict."""
-    cmd, env = build_vllm_cmd_and_env(server_args)
-    p = _spawn_ctx.Process(target=_exec_vllm_cmd, args=(cmd, env))
-    p.start()
-    return p
 
 
 def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None, timeout_s: float = 300.0) -> None:
@@ -572,6 +554,24 @@ def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None,
         if time.time() - start > timeout_s:
             raise TimeoutError(f"Timeout waiting for vLLM server healthy: {base_url}")
         time.sleep(2)
+
+
+def launch_server_process(server_args: dict) -> multiprocessing.Process:
+    """Spawn ``vllm serve`` from a :func:`compute_server_args` dict."""
+    cmd, env = build_vllm_cmd_and_env(server_args)
+    p = _spawn_ctx.Process(target=_exec_vllm_cmd, args=(cmd, env))
+    p.start()
+    return p
+
+
+def _normalize_vllm_wake_tags(tags: list[str] | None) -> list[str] | None:
+    if not tags:
+        return tags
+    normalized = [t for t in tags if t in _VLLM_WAKE_TAGS]
+    dropped = set(tags) - set(normalized)
+    if dropped:
+        logger.debug("vLLM wake_up: dropped tags not supported by vLLM: %s", sorted(dropped))
+    return normalized or None
 
 
 class VLLMEngine(RayActor):

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -538,9 +538,17 @@ def _wait_worker_process_alive(process: multiprocessing.Process, timeout_s: floa
     raise RuntimeError(f"vLLM worker process exited unexpectedly with code {process.exitcode}")
 
 
-def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None, timeout_s: float = 300.0) -> None:
-    """Wait until the vLLM server responds on ``GET /health``."""
-    start = time.time()
+def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None) -> None:
+    """Wait until the vLLM server responds on ``GET /health`` (no time limit, SGLang-style).
+
+    Loops until /health returns 200, or — for a managed subprocess — until it dies (fail fast via
+    ``process.is_alive()``). There is no overall deadline, so a slow-but-healthy startup (a large
+    MoE / DP engine loading + compiling + capturing CUDA graphs across replicas) is never
+    spuriously timed out. The per-probe ``timeout=3`` bounds each individual request so a single
+    stuck socket cannot wedge the loop. In external mode (``process is None``) there is no liveness
+    signal, so a permanently unreachable URL loops indefinitely by design (the external engine is
+    caller-managed). Mirrors slime's SGLang backend _wait_server_healthy.
+    """
     while True:
         try:
             response = requests.get(f"{base_url}/health", timeout=3)
@@ -551,8 +559,6 @@ def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None,
 
         if process is not None and not process.is_alive():
             raise RuntimeError(f"vLLM server exited unexpectedly with code {process.exitcode}")
-        if time.time() - start > timeout_s:
-            raise TimeoutError(f"Timeout waiting for vLLM server healthy: {base_url}")
         time.sleep(2)
 
 

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -982,10 +982,11 @@ def _start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool 
             router_args.vllm_pd_disaggregation = True
         if hasattr(router_args, "disable_circuit_breaker"):
             router_args.disable_circuit_breaker = True
-
-    # MiniLB is PD-only in vllm-router; non-PD rollout needs the Rust Router (omit SLIME_VLLM_ROUTER_USE_RUST).
-    if has_pd_disaggregation and os.environ.get("SLIME_VLLM_ROUTER_USE_RUST", "") != "1":
-        router_args.mini_lb = True
+        # PD uses the full Rust router: it accepts dynamic /workers registration (engines register
+        # after the router is up), matching slime's launch-router-then-register flow. vllm-router's
+        # MiniLB is a debug-only load balancer that requires STATIC prefill/decode URLs at
+        # construction, which slime never provides, so it can never work here. MiniLB stays off
+        # (RouterArgs defaults mini_lb=False); the old SLIME_VLLM_ROUTER_USE_RUST gate is removed.
 
     if any(f.name == "disable_health_check" for f in dataclasses.fields(type(router_args))):
         router_args.disable_health_check = True
@@ -1002,8 +1003,8 @@ def _start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool 
     if not process.is_alive():
         raise RuntimeError(
             f"Router subprocess exited (exitcode={process.exitcode}). "
-            "For vllm-router non-PD mode, install the Rust router (pip wheel with Router); "
-            "MiniLB is only valid with PD disaggregation. See slime.utils.http_utils run_router logs."
+            "Ensure the vllm-router (Rust) wheel is installed; both PD and non-PD rollout use it. "
+            "See slime.utils.http_utils run_router logs."
         )
     logger.info(f"Router launched at {router_ip}:{router_port}, Prometheus port: {router_args.prometheus_port}")
     return router_ip, router_port, router_args.prometheus_port

--- a/tests/test_vllm_generate_endpoint.py
+++ b/tests/test_vllm_generate_endpoint.py
@@ -133,7 +133,7 @@ def _execute_case(case: VLLMGenerateCase):
     )
 
     try:
-        _wait_server_healthy(f"http://127.0.0.1:{server_port}", process, timeout_s=case.timeout_s)
+        _wait_server_healthy(f"http://127.0.0.1:{server_port}", process)
 
         rollout_args = Namespace(
             ci_test=False,

--- a/tests/unit/backends/vllm_utils/test_arguments.py
+++ b/tests/unit/backends/vllm_utils/test_arguments.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``slime.backends.vllm_utils.arguments``."""
+﻿"""Unit tests for ``slime.backends.vllm_utils.arguments``."""
 
 from __future__ import annotations
 
@@ -79,10 +79,17 @@ def test_wrapper_skips_dest_listed_in_SKIPPED_DESTS(args_mod):
 
 
 @pytest.mark.unit
-def test_SKIPPED_DESTS_only_tp(args_mod):
+def test_SKIPPED_DESTS_orchestrator_parallel_dims(args_mod):
+    """TP/multi-node dims are orchestrator-owned; PP/DP remain CLI-forwardable."""
     assert "tensor_parallel_size" in args_mod.SKIPPED_DESTS
     assert "pipeline_parallel_size" not in args_mod.SKIPPED_DESTS
     assert "data_parallel_size" not in args_mod.SKIPPED_DESTS
+    assert "nnodes" in args_mod.SKIPPED_DESTS
+    assert "node_rank" in args_mod.SKIPPED_DESTS
+    assert "master_addr" in args_mod.SKIPPED_DESTS
+    assert "master_port" in args_mod.SKIPPED_DESTS
+    assert "data_parallel_backend" in args_mod.SKIPPED_DESTS
+    assert "distributed_executor_backend" in args_mod.SKIPPED_DESTS
 
 
 @pytest.mark.unit

--- a/tests/unit/backends/vllm_utils/test_arguments.py
+++ b/tests/unit/backends/vllm_utils/test_arguments.py
@@ -164,23 +164,33 @@ def test_validate_args_pp1(args_mod):
     args_mod.validate_args(ns)
     assert ns.vllm_pp_size == 1
     assert ns.vllm_dp_size == 1
-    assert ns.vllm_tp_size == 4
+    # validate_args intentionally does NOT set a global ``vllm_tp_size`` anymore: a global TP
+    # (derived from the *global* rollout_num_gpus_per_engine) shadowed the per-engine value and
+    # broke heterogeneous per-group engines (the 300s "3/4 clients joined" rendezvous hang). TP is
+    # now derived per engine in vllm_engine._resolve_vllm_parallel_sizes (covered in
+    # test_vllm_engine.py::test_resolve_parallel_sizes_is_per_engine_not_global).
+    assert not hasattr(ns, "vllm_tp_size")
 
 
 @pytest.mark.unit
-def test_validate_args_pp2_dp2_derives_tp(args_mod):
+def test_validate_args_records_pp_dp_but_no_global_tp(args_mod):
+    # validate_args records pp/dp on the namespace but must not precompute a global TP, even when
+    # pp>1 and dp>1. Per-engine TP = gpus_per_engine // (pp * dp) is resolved at launch time.
     ns = _ns(vllm_pipeline_parallel_size=2, vllm_data_parallel_size=2)
     args_mod.validate_args(ns)
     assert ns.vllm_pp_size == 2
     assert ns.vllm_dp_size == 2
-    assert ns.vllm_tp_size == 2
+    assert not hasattr(ns, "vllm_tp_size")
 
 
 @pytest.mark.unit
-def test_validate_args_pp_indivisible_asserts(args_mod):
+def test_validate_args_no_longer_raises_on_pp_indivisible(args_mod):
+    # The pp-divisibility check moved out of validate_args and into the per-engine resolver
+    # (vllm_engine._resolve_vllm_parallel_sizes / compute_vllm_engine_topology), so validate_args
+    # itself is now agnostic to it. The enforcement is covered in test_vllm_engine.py.
     ns = _ns(vllm_pipeline_parallel_size=3, rollout_num_gpus_per_engine=4)
-    with pytest.raises(AssertionError, match="divisible"):
-        args_mod.validate_args(ns)
+    args_mod.validate_args(ns)  # must not raise
+    assert ns.vllm_pp_size == 3
 
 
 @pytest.mark.unit

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -62,6 +62,90 @@ def test_to_local_gpu_id_maps_physical_id(monkeypatch):
 
 
 @pytest.mark.unit
+def test_compute_vllm_engine_topology_single_node(vllm_args):
+    vllm_args.num_gpus_per_node = 8
+    vllm_args.rollout_num_gpus_per_engine = 4
+    vllm_args.vllm_pipeline_parallel_size = 1
+    vllm_args.vllm_tp_size = 4
+    topo = mod.compute_vllm_engine_topology(vllm_args, global_rank=0)
+    assert topo.nnodes == 1
+    assert topo.node_rank == 0
+    assert topo.local_num_gpus == 4
+    assert not topo.multi_node
+    assert not topo.headless
+
+
+@pytest.mark.unit
+def test_compute_vllm_engine_topology_multi_node_ranks(vllm_args):
+    vllm_args.num_gpus_per_node = 8
+    vllm_args.rollout_num_gpus_per_engine = 16
+    vllm_args.vllm_pipeline_parallel_size = 2
+    vllm_args.vllm_tp_size = 8
+    topo0 = mod.compute_vllm_engine_topology(vllm_args, global_rank=0)
+    topo1 = mod.compute_vllm_engine_topology(vllm_args, global_rank=1)
+    assert topo0.nnodes == 2
+    assert topo0.node_rank == 0
+    assert topo1.node_rank == 1
+    assert topo0.local_num_gpus == 8
+    assert topo0.headless is False
+    assert topo1.headless is True
+
+
+@pytest.mark.unit
+def test_append_distributed_flags_only_when_multi_node(vllm_args):
+    cmd: list[str] = ["vllm", "serve"]
+    single = mod.VllmEngineTopology(
+        nnodes=1,
+        node_rank=0,
+        local_num_gpus=4,
+        tensor_parallel_size=4,
+        pipeline_parallel_size=1,
+    )
+    mod._append_vllm_distributed_launch_flags(cmd, single, ("10.0.0.1", 15000), vllm_args)
+    assert cmd == ["vllm", "serve"]
+
+    cmd_multi: list[str] = ["vllm", "serve"]
+    multi = mod.VllmEngineTopology(
+        nnodes=2,
+        node_rank=1,
+        local_num_gpus=8,
+        tensor_parallel_size=8,
+        pipeline_parallel_size=2,
+    )
+    mod._append_vllm_distributed_launch_flags(cmd_multi, multi, ("10.0.0.2", 16000), vllm_args)
+    assert "--nnodes" in cmd_multi
+    assert "--node-rank" in cmd_multi
+    assert "1" in cmd_multi
+    assert "--headless" in cmd_multi
+    assert "--master-addr" in cmd_multi
+    assert "10.0.0.2" in cmd_multi
+    assert cmd_multi[cmd_multi.index("--data-parallel-backend") + 1] == "mp"
+    assert cmd_multi[cmd_multi.index("--distributed-executor-backend") + 1] == "mp"
+
+
+@pytest.mark.unit
+def test_parse_dist_init_addr_ipv6():
+    host, port = mod.parse_dist_init_addr("[2001:db8::1]:15000")
+    assert host == "2001:db8::1"
+    assert port == 15000
+
+
+@pytest.mark.unit
+def test_build_vllm_subprocess_env_colocate(vllm_args, monkeypatch):
+    vllm_args.colocate = True
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    env = mod.build_vllm_subprocess_env(
+        {
+            "args": vllm_args,
+            "visible_devices": "0,1",
+        }
+    )
+    assert "VLLM_ALLOW_INSECURE_SERIALIZATION" in env
+    assert env["VLLM_ALLOW_INSECURE_SERIALIZATION"] == "1"
+    assert "PYTHONPATH" in env
+
+
+@pytest.mark.unit
 def test_get_base_gpu_id_colocate(vllm_args):
     vllm_args.colocate = True
     vllm_args.num_gpus_per_node = 8
@@ -275,6 +359,12 @@ def test_init_weights_update_group_uses_config_timeout(vllm_engine, monkeypatch)
 def test_response_json_parses_dict():
     response = _MockResponse(json_data={"status": "ready"})
     assert mod._response_json(response) == {"status": "ready"}
+
+
+@pytest.mark.unit
+def test_response_json_empty_body_returns_ok():
+    response = _MockResponse(text="")
+    assert mod._response_json(response) == {"ok": True}
 
 
 @pytest.mark.unit

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -17,6 +17,10 @@ class _MockResponse:
         self._json_data = json_data
         self.text = text
         self.status_code = status_code
+        # Model requests.Response.content (raw body bytes) so _response_json's empty-body
+        # handling (empty 200 -> {"ok": True}) is actually exercised. A JSON body is non-empty;
+        # text-only/empty bodies use the given text (b"" when empty).
+        self.content = json.dumps(json_data).encode() if json_data is not None else text.encode()
 
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
@@ -101,7 +105,7 @@ def test_append_distributed_flags_only_when_multi_node(vllm_args):
         tensor_parallel_size=4,
         pipeline_parallel_size=1,
     )
-    mod._append_vllm_distributed_launch_flags(cmd, single, ("10.0.0.1", 15000), vllm_args)
+    mod.append_vllm_distributed_launch_flags(cmd, single, ("10.0.0.1", 15000), vllm_args)
     assert cmd == ["vllm", "serve"]
 
     cmd_multi: list[str] = ["vllm", "serve"]
@@ -112,7 +116,7 @@ def test_append_distributed_flags_only_when_multi_node(vllm_args):
         tensor_parallel_size=8,
         pipeline_parallel_size=2,
     )
-    mod._append_vllm_distributed_launch_flags(cmd_multi, multi, ("10.0.0.2", 16000), vllm_args)
+    mod.append_vllm_distributed_launch_flags(cmd_multi, multi, ("10.0.0.2", 16000), vllm_args)
     assert "--nnodes" in cmd_multi
     assert "--node-rank" in cmd_multi
     assert "1" in cmd_multi
@@ -159,9 +163,9 @@ def test_start_weight_update_posts_four_phase_endpoint(vllm_engine, monkeypatch)
 
     def fake_post(endpoint: str, payload: dict, timeout: float):
         calls.append((endpoint, payload, timeout))
-        return _MockResponse(json_data={"ok": True})
+        return {"ok": True}
 
-    monkeypatch.setattr(vllm_engine, "_post_json", fake_post)
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
 
     result = vllm_engine.start_weight_update(is_checkpoint_format=True)
 
@@ -178,9 +182,9 @@ def test_finish_weight_update_posts_empty_body(vllm_engine, monkeypatch):
 
     def fake_post(endpoint: str, payload: dict, timeout: float):
         calls.append((endpoint, payload, timeout))
-        return _MockResponse(json_data={"done": True})
+        return {"done": True}
 
-    monkeypatch.setattr(vllm_engine, "_post_json", fake_post)
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
 
     result = vllm_engine.finish_weight_update()
 
@@ -295,9 +299,9 @@ def test_post_vllm_update_weights_http_wraps_update_info(vllm_engine, monkeypatc
 
     def fake_post(endpoint: str, payload: dict, timeout: float):
         seen.append((endpoint, payload, timeout))
-        return _MockResponse(json_data={"status": "ok"})
+        return {"status": "ok"}
 
-    monkeypatch.setattr(vllm_engine, "_post_json", fake_post)
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
 
     result = vllm_engine._post_vllm_update_weights_http({"names": ["w"], "packed": False})
 
@@ -325,9 +329,9 @@ def test_start_weight_update_uses_config_timeout(vllm_engine, monkeypatch):
 
     def fake_post(endpoint: str, payload: dict, timeout: float):
         calls.append((endpoint, payload, timeout))
-        return _MockResponse(json_data={"ok": True})
+        return {"ok": True}
 
-    monkeypatch.setattr(vllm_engine, "_post_json", fake_post)
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
 
     vllm_engine.start_weight_update()
     assert calls[0][2] == 123.5
@@ -340,9 +344,9 @@ def test_init_weights_update_group_uses_config_timeout(vllm_engine, monkeypatch)
 
     def fake_post(endpoint: str, payload: dict, timeout: float):
         calls.append((endpoint, payload, timeout))
-        return _MockResponse(json_data={"initialized": True})
+        return {"initialized": True}
 
-    monkeypatch.setattr(vllm_engine, "_post_json", fake_post)
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
 
     vllm_engine.init_weights_update_group(
         "127.0.0.1",
@@ -392,16 +396,16 @@ def test_http_base_ipv6_host(vllm_engine):
 @pytest.mark.unit
 def test_redact_cmd_for_log_masks_hf_token():
     cmd = ["vllm", "serve", "model", "--hf-token", "secret-token", "--port", "8000"]
-    logged = mod._redact_cmd_for_log(cmd)
+    logged = mod.redact_cmd_for_log(cmd)
     assert "secret-token" not in logged
     assert "***" in logged
 
 
 @pytest.mark.unit
 def test_serialize_for_cli_primitives():
-    assert mod._serialize_for_cli(42) == "42"
-    assert mod._serialize_for_cli(True) == "True"
-    assert mod._serialize_for_cli({"backend": "nccl"}) == json.dumps({"backend": "nccl"})
+    assert mod.serialize_for_cli(42) == "42"
+    assert mod.serialize_for_cli(True) == "True"
+    assert mod.serialize_for_cli({"backend": "nccl"}) == json.dumps({"backend": "nccl"})
 
 
 @pytest.mark.unit
@@ -410,7 +414,7 @@ def test_serialize_for_cli_dataclass():
     class _Cfg:
         backend: str = "nccl"
 
-    out = mod._serialize_for_cli(_Cfg())
+    out = mod.serialize_for_cli(_Cfg())
     assert json.loads(out) == {"backend": "nccl"}
 
 
@@ -461,9 +465,9 @@ def test_init_weights_update_group_retries_then_succeeds(vllm_engine, monkeypatc
         attempts["n"] += 1
         if attempts["n"] < 2:
             raise requests.ConnectionError("transient")
-        return _MockResponse(json_data={"initialized": True})
+        return {"initialized": True}
 
-    monkeypatch.setattr(vllm_engine, "_post_json", fake_post)
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
     monkeypatch.setattr(mod.time, "sleep", lambda *_a, **_k: None)
 
     result = vllm_engine.init_weights_update_group(
@@ -483,7 +487,7 @@ def test_init_weights_update_group_retries_then_succeeds(vllm_engine, monkeypatc
 def test_init_weights_update_group_raises_after_three_failures(vllm_engine, monkeypatch):
     monkeypatch.setattr(
         vllm_engine,
-        "_post_json",
+        "_make_request",
         lambda *a, **k: (_ for _ in ()).throw(requests.ConnectionError("down")),
     )
     monkeypatch.setattr(mod.time, "sleep", lambda *_a, **_k: None)
@@ -497,3 +501,120 @@ def test_init_weights_update_group_raises_after_three_failures(vllm_engine, monk
             group_name="g",
             backend="nccl",
         )
+
+
+def _stub_server_info(monkeypatch, parallel_config: dict) -> None:
+    def fake_get(url, *, params=None, timeout=30):
+        return _MockResponse(json_data={"vllm_config": {"parallel_config": parallel_config}})
+
+    monkeypatch.setattr(mod.requests, "get", fake_get)
+
+
+@pytest.mark.unit
+def test_sanity_check_external_server_args_passes_on_match(vllm_engine, monkeypatch):
+    vllm_engine._server_args = {"tp_size": 2, "pp_size": 1, "dp_size": 1, "nnodes": 1}
+    _stub_server_info(
+        monkeypatch,
+        {"tensor_parallel_size": 2, "pipeline_parallel_size": 1, "data_parallel_size": 1, "nnodes": 1},
+    )
+    # All reported fields match the per-engine expectation → no raise.
+    vllm_engine._sanity_check_external_server_args()
+
+
+@pytest.mark.unit
+def test_sanity_check_external_server_args_raises_on_tp_mismatch(vllm_engine, monkeypatch):
+    # Expect a tp=2 engine but the external server reports tp=1 → fail fast (the bug class
+    # that used to only warn and then hang the weight-sync rendezvous 300s later).
+    vllm_engine._server_args = {"tp_size": 2, "pp_size": 1, "dp_size": 1, "nnodes": 1}
+    _stub_server_info(
+        monkeypatch,
+        {"tensor_parallel_size": 1, "pipeline_parallel_size": 1, "data_parallel_size": 1, "nnodes": 1},
+    )
+    with pytest.raises(AssertionError, match="tp_size"):
+        vllm_engine._sanity_check_external_server_args()
+
+
+@pytest.mark.unit
+def test_sanity_check_external_server_args_skips_unreported_field(vllm_engine, monkeypatch):
+    # vLLM /server_info may not surface ``nnodes``: an unreported (None) field is skipped,
+    # not treated as a mismatch — so a single-node external engine doesn't false-fail.
+    vllm_engine._server_args = {"tp_size": 1, "pp_size": 1, "dp_size": 1, "nnodes": 2}
+    _stub_server_info(
+        monkeypatch,
+        {"tensor_parallel_size": 1, "pipeline_parallel_size": 1, "data_parallel_size": 1},
+    )
+    vllm_engine._sanity_check_external_server_args()
+
+
+@pytest.mark.unit
+def test_sanity_check_external_server_args_raises_when_parallel_config_missing(vllm_engine, monkeypatch):
+    vllm_engine._server_args = {"tp_size": 1, "pp_size": 1, "dp_size": 1, "nnodes": 1}
+    _stub_server_info(monkeypatch, {})
+    with pytest.raises(RuntimeError, match="missing vllm_config.parallel_config"):
+        vllm_engine._sanity_check_external_server_args()
+
+
+@pytest.mark.unit
+def test_resolve_parallel_sizes_is_per_engine_not_global(vllm_args):
+    # The global flag is 1, but THIS engine has 2 GPUs → tp must be 2 (per-engine), not 1.
+    # A stale global vllm_tp_size must NOT shadow the per-engine value.
+    vllm_args.rollout_num_gpus_per_engine = 1
+    vllm_args.vllm_pipeline_parallel_size = 1
+    vllm_args.vllm_tp_size = 1  # stale global; must be ignored now
+    tp, pp = mod._resolve_vllm_parallel_sizes(vllm_args, gpus_per_engine=2)
+    assert (tp, pp) == (2, 1)
+
+
+@pytest.mark.unit
+def test_compute_topology_heterogeneous_per_group_tp(vllm_args):
+    # Reproduces the rendezvous bug's root: global=1 but a per-group engine uses 2 GPUs.
+    vllm_args.num_gpus_per_node = 8
+    vllm_args.rollout_num_gpus_per_engine = 1
+    vllm_args.vllm_pipeline_parallel_size = 1
+    vllm_args.vllm_tp_size = 1  # stale global
+    topo = mod.compute_vllm_engine_topology(vllm_args, global_rank=0, num_gpus_per_engine=2)
+    assert topo.tensor_parallel_size == 2
+    assert topo.nnodes == 1
+
+
+@pytest.mark.unit
+def test_resolve_parallel_sizes_rejects_dp_gt_1(vllm_args):
+    vllm_args.vllm_pipeline_parallel_size = 1
+    vllm_args.vllm_data_parallel_size = 2
+    vllm_args.vllm_dp_size = 2
+    with pytest.raises(NotImplementedError, match="data parallelism"):
+        mod._resolve_vllm_parallel_sizes(vllm_args, gpus_per_engine=4)
+
+
+@pytest.mark.unit
+def test_make_request_short_circuits_on_headless(vllm_engine, monkeypatch):
+    # _make_request is the single control-plane POST choke point; on a headless worker
+    # (node_rank>0) it must no-op to None without issuing any HTTP request.
+    def _boom(*a, **k):
+        raise AssertionError("control-plane HTTP must not be called on a headless worker")
+
+    monkeypatch.setattr(mod.requests, "post", _boom)
+    vllm_engine.node_rank = 1
+    assert vllm_engine._make_request("whatever", {}, timeout=1) is None
+
+
+@pytest.mark.unit
+def test_control_plane_methods_noop_on_headless_worker(vllm_engine, monkeypatch):
+    """node_rank>0 (headless) workers own no HTTP server; every control-plane method must
+    no-op (return None) without issuing an HTTP request."""
+
+    def _boom(*a, **k):
+        raise AssertionError("control-plane HTTP must not be called on a headless worker")
+
+    monkeypatch.setattr(mod.requests, "post", _boom)
+    monkeypatch.setattr(mod.requests, "get", _boom)
+    vllm_engine.node_rank = 1
+    vllm_engine.args.vllm_enable_sleep_mode = True
+
+    assert vllm_engine.init_weight_transfer_engine({"init_info": {}}) is None
+    assert vllm_engine.start_weight_update() is None
+    assert vllm_engine.finish_weight_update() is None
+    assert vllm_engine.init_weights_update_group("addr", 1, 0, 4, "g", "nccl") is None
+    assert vllm_engine.update_weights_from_distributed(["w"], [torch.float32], [[1]], "g") is None
+    assert vllm_engine.release_memory_occupation() is None
+    assert vllm_engine.resume_memory_occupation() is None


### PR DESCRIPTION
## Summary
- Add vLLM multi-node rollout topology: one Ray actor per node-rank, head owns HTTP/router, workers launch with `--headless`.
- Consolidate launch configuration into `vllm_engine.py` (`compute_server_args` → `build_vllm_cmd_and_env` → `launch_server_process`).
- Multi-node CLI: `--nnodes`, `--node-rank`, `--master-*`, `--data-parallel-backend mp`, `--distributed-executor-backend mp`.
- Rename rollout per-group overrides to `vllm_overrides`; remove SGLang references from vllm_utils.

Part of #65 (orchestration layer; multinode integration tests and rollout cleanup in follow-up PRs).

## Test plan

### Completed

- [x] Local: pre-commit on changed files (`ruff`, `black`, `isort`, `autoflake`) — all passed
- [x] A800-server / `vime_v22` container: `pytest -q tests/unit/backends/vllm_utils/` → **60 passed**
  - Topology: single-node (`rollout_num_gpus_per_engine=4`, `num_gpus_per_node=8`, TP=4) and multi-node rank split (`rollout_num_gpus_per_engine=16`, `num_gpus_per_node=8` → `nnodes=2`, TP=8, PP=2)
  - CLI flags: `--nnodes`, `--node-rank`, `--master-addr`, `--master-port`, `--headless` (worker), `--data-parallel-backend mp`, `--distributed-executor-backend mp`
  - Single-node path: no extra distributed flags appended when `nnodes=1`

### Single-node backward compatibility (existing workloads — not re-run in this PR)

These configs should behave identically to pre-PR behavior because `nnodes=1` when `rollout_num_gpus_per_engine <= num_gpus_per_node`; no multi-node CLI flags are injected.

- `tests/test_vllm_generate_endpoint.py` — **Qwen3-0.6B** (1 GPU): `compute_server_args` + `launch_server_process` → `/inference/v1/generate`
- `tests/test_vllm_generate_endpoint.py` — **Qwen3-30B-A3B** (1 GPU): MoE rollout + logprob capture
- `tests/test_vllm_generate_endpoint.py` — **Qwen3-30B-A3B + R3 routing replay** (1 GPU): `rollout_routed_experts` shape check
- Existing single-host training scripts (e.g. **Qwen3-30B-A3B**, 8 GPU colocate, `rollout_num_gpus_per_engine=8`, `nnodes_per_engine=1`) — unchanged code path; head-only HTTP/router/weight-update logic

### Multi-node orchestration (supported by this PR — integration validation deferred to 2/N)

This PR adds the Ray-actor topology and vLLM launch flags; cross-host E2E is planned in follow-up PRs (see PR #66 sweep matrix). Target configs:

| Config | Model | Hosts | `rollout_num_gpus_per_engine` | `num_gpus_per_node` | `nnodes_per_engine` | vLLM TP × PP | What this exercises |
|---|---|---|---|---|---|---|---|
| s3 | **Qwen3-30B-A3B** | 2 × 8 GPU | 16 | 8 | **2** | 16 × 1 | One logical engine spans both hosts; worker `--headless`; `mp` backends |
| s4 | **Qwen3-30B-A3B** | 2 × 8 GPU | 8 | 4 | **2** | 8 × 1 | Multi-engine + `nnodes=2` per engine |
| s9 | **Qwen3-30B-A3B** | 2 × 8 GPU | 16 | 8 | **2** | 8 × 2 | Cross-host vLLM PP=2 × `nnodes=2` (eager; CUDA-graph capture hang is a known vLLM PP issue) |

Planned test artifacts (2/N, aligned with #65 / PR #66):
- `tests/test_qwen3_30B_A3B_pr66_sweep.py` — parametrized 11-config × 2-step sweep
- `tests/multinode/{head,worker,launch_cross_host}.sh` — cross-host Ray + container orchestration

Part of #65
