### PR TITLE
fix(vllm-rollout): warn instead of silently padding mismatched logprobs

### DIFF
--- a/slime/rollout/vllm_rollout.py
+++ b/slime/rollout/vllm_rollout.py
@@ -251,7 +251,24 @@ def _align_engine_tokens_and_logprobs(
     if m == n:
         return new_response_tokens, [float(x) for x in new_response_log_probs]
     if m > n:
+        logger.warning(
+            "vLLM rollout returned more logprobs (%d) than response tokens (%d); truncating. "
+            "This is unexpected for /inference/v1/generate (one logprob per generated token).",
+            m,
+            n,
+        )
         return new_response_tokens, [float(x) for x in new_response_log_probs[:n]]
+    # Padding with 0.0 means "this token had probability 1.0" — a non-physical value that
+    # silently distorts importance-sampling / TIS ratios (exp(train_logprob - 0.0)) when
+    # --use-rollout-logprobs or --use-tis is enabled. Surface it loudly instead of hiding it.
+    logger.warning(
+        "vLLM rollout returned fewer logprobs (%d) than response tokens (%d); padding %d "
+        "missing entries with 0.0 (== logprob of prob 1.0). If --use-rollout-logprobs / "
+        "--use-tis is on, these padded tokens will bias the policy gradient.",
+        m,
+        n,
+        n - m,
+    )
     return new_response_tokens, [float(x) for x in new_response_log_probs] + [0.0] * (n - m)
 
 


### PR DESCRIPTION
## What
`_align_engine_tokens_and_logprobs` pads missing rollout logprobs with `0.0` — i.e. `log(prob=1.0)` — and truncates extras, **silently**.

## Why
When `--use-rollout-logprobs` or `--use-tis` is enabled, these logprobs feed the training objective (TIS weight = `exp(train_logprob - rollout_logprob)`). A `0.0` fill is non-physical and biases the policy gradient for the affected tokens. vLLM's `/inference/v1/generate` returns exactly one logprob per generated token, so any length mismatch indicates a real problem that should not be hidden.

## Change
Keep the defensive pad/truncate (no behavior change) but emit a `logger.warning` with counts on both the over- and under-length branches, so the corruption is visible.

Found while auditing vime's vLLM adaptation against SkyRL (SkyRL fills missing logprobs with the `-9999.0` sentinel and zips 1:1, never silently). Part of a small series (P2/P3/F1/F2); related to #64/#69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)