### PR TITLE
fix(vllm-rollout): map no_stop_trim to vLLM include_stop_str_in_output

### DIFF
--- a/slime/rollout/vllm_rollout.py
+++ b/slime/rollout/vllm_rollout.py
@@ -337,6 +337,13 @@ def _build_inference_sampling_params(sampling_params: dict[str, Any]) -> dict[st
         sp["top_k"] = tk
     if sampling_params.get("stop"):
         sp["stop"] = sampling_params["stop"]
+        # SGLang's ``no_stop_trim=True`` means "keep the matched stop string in the output".
+        # vLLM's equivalent is ``include_stop_str_in_output`` (default False == trim the stop
+        # string). Without this mapping, the vLLM and SGLang rollout paths return different
+        # response token sequences whenever a string ``stop`` is configured, breaking
+        # reproducibility and train/inference token alignment.
+        if sampling_params.get("no_stop_trim"):
+            sp["include_stop_str_in_output"] = True
     if sampling_params.get("stop_token_ids"):
         sp["stop_token_ids"] = sampling_params["stop_token_ids"]
     if sampling_params.get("seed") is not None:


### PR DESCRIPTION
## What
The rollout `sampling_params` carry SGLang's `no_stop_trim=True` (keep the matched stop string in the output), but `_build_inference_sampling_params` never forwarded it to vLLM.

## Why
vLLM's default is `include_stop_str_in_output=False` (trim the stop string). So with a string `--rollout-stop` configured, the vLLM and SGLang rollout paths returned **different response token sequences**, breaking reproducibility and train/inference token alignment. Only triggers when a string stop is used (default `rollout_stop=None`).

## Change
Forward `include_stop_str_in_output=True` when `no_stop_trim` is set and a string `stop` is present, matching the SGLang semantics.

Found while auditing vime's vLLM adaptation against SkyRL. Part of a small series (P2/P3/F1/F2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)