### PR TITLE
feat(vllm-rollout): forward min_p / repetition / presence / frequency penalties

### DIFF
--- a/slime/rollout/vllm_rollout.py
+++ b/slime/rollout/vllm_rollout.py
@@ -273,6 +273,10 @@ class GenerateState(metaclass=SingletonMeta):
             temperature=args.rollout_temperature,
             top_p=args.rollout_top_p,
             top_k=args.rollout_top_k,
+            min_p=getattr(args, "rollout_min_p", 0.0),
+            repetition_penalty=getattr(args, "rollout_repetition_penalty", 1.0),
+            presence_penalty=getattr(args, "rollout_presence_penalty", 0.0),
+            frequency_penalty=getattr(args, "rollout_frequency_penalty", 0.0),
             max_new_tokens=args.rollout_max_response_len,
             stop=args.rollout_stop,
             stop_token_ids=args.rollout_stop_token_ids,
@@ -335,6 +339,20 @@ def _build_inference_sampling_params(sampling_params: dict[str, Any]) -> dict[st
     tk = sampling_params.get("top_k")
     if tk is not None and tk > 0:
         sp["top_k"] = tk
+    # Forward optional sampling params only when they differ from vLLM's disabled-defaults,
+    # so existing runs that never set them keep byte-identical request bodies.
+    mp = sampling_params.get("min_p")
+    if mp:
+        sp["min_p"] = float(mp)
+    rp = sampling_params.get("repetition_penalty")
+    if rp is not None and rp != 1.0:
+        sp["repetition_penalty"] = float(rp)
+    pp = sampling_params.get("presence_penalty")
+    if pp:
+        sp["presence_penalty"] = float(pp)
+    fp = sampling_params.get("frequency_penalty")
+    if fp:
+        sp["frequency_penalty"] = float(fp)
     if sampling_params.get("stop"):
         sp["stop"] = sampling_params["stop"]
     if sampling_params.get("stop_token_ids"):
@@ -801,6 +819,10 @@ async def eval_rollout_single_dataset(
         temperature=dataset_cfg.temperature,
         top_p=dataset_cfg.top_p,
         top_k=dataset_cfg.top_k,
+        min_p=getattr(args, "rollout_min_p", 0.0),
+        repetition_penalty=getattr(args, "rollout_repetition_penalty", 1.0),
+        presence_penalty=getattr(args, "rollout_presence_penalty", 0.0),
+        frequency_penalty=getattr(args, "rollout_frequency_penalty", 0.0),
         max_new_tokens=dataset_cfg.max_response_len,
         stop=args.rollout_stop,
         stop_token_ids=args.rollout_stop_token_ids,

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -254,6 +254,30 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 "--rollout-top-k", type=int, default=-1, help="the top-k for the inference engine during rollout."
             )
             parser.add_argument(
+                "--rollout-min-p",
+                type=float,
+                default=0.0,
+                help="the min-p for the inference engine during rollout (vLLM default 0.0 == disabled).",
+            )
+            parser.add_argument(
+                "--rollout-repetition-penalty",
+                type=float,
+                default=1.0,
+                help="the repetition penalty for the inference engine during rollout (vLLM default 1.0 == disabled).",
+            )
+            parser.add_argument(
+                "--rollout-presence-penalty",
+                type=float,
+                default=0.0,
+                help="the presence penalty for the inference engine during rollout (vLLM default 0.0 == disabled).",
+            )
+            parser.add_argument(
+                "--rollout-frequency-penalty",
+                type=float,
+                default=0.0,
+                help="the frequency penalty for the inference engine during rollout (vLLM default 0.0 == disabled).",
+            )
+            parser.add_argument(
                 "--rollout-max-context-len",
                 type=int,
                 default=None,


### PR DESCRIPTION
## What
`_build_inference_sampling_params` only whitelisted `temperature/top_p/top_k/stop/...`, silently dropping `min_p` and the repetition/presence/frequency penalties even if a user wanted them. (SkyRL forwards the full sampling-params dict.)

## Change
- Add `--rollout-min-p`, `--rollout-repetition-penalty`, `--rollout-presence-penalty`, `--rollout-frequency-penalty` (defaults == vLLM's disabled values: 0.0 / 1.0 / 0.0 / 0.0).
- Wire them into both the train and eval `sampling_params`.
- Forward each to vLLM **only when it differs from the disabled default**, so existing runs that never set them send byte-identical request bodies.

Found while auditing vime's vLLM adaptation against SkyRL. Part of a small series (P2/P3/F1/F2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)