### PR TITLE
fix(tests): use bare --router-request-timeout-secs in glm4.7 mooncake test

### DIFF
--- a/tests/test_glm4.7_30B_A3B_pd_mooncake.py
+++ b/tests/test_glm4.7_30B_A3B_pd_mooncake.py
@@ -114,7 +114,7 @@ def execute():
         "--vllm-max-num-seqs 16 "
         "--vllm-max-cudagraph-capture-size 8 "
         "--vllm-speculative-config '{\"method\":\"mtp\",\"num_speculative_tokens\":3}' "
-        "--vllm-router-request-timeout-secs 1200 "
+        "--router-request-timeout-secs 1200 "
         f"--vllm-config {vllm_config} "
     )
     misc_args = (


### PR DESCRIPTION
## What

One-line fix: [tests/test_glm4.7_30B_A3B_pd_mooncake.py](../blob/main/tests/test_glm4.7_30B_A3B_pd_mooncake.py) passed the pre-hybrid flag `--vllm-router-request-timeout-secs 1200`. Renamed to bare `--router-request-timeout-secs 1200`.

## Why

The hybrid router-arg convention settled in #18 / #40:

- **Endpoint-locating flags keep the `vllm_` prefix:** `--vllm-router-ip`, `--vllm-router-port` (vime owns where the router lives; RouterArgs excludes host/port).
- **Every other vllm-router knob is bare `--router-*`** (dest `router_*`), e.g. `--router-request-timeout-secs`, `--router-policy`.

This GPU-only integration test still used the old `--vllm-router-request-timeout-secs`, which is **no longer a registered flag**. The 1200s timeout therefore never reached `router_args.request_timeout_secs` ([slime/ray/rollout.py:978](../blob/main/slime/ray/rollout.py#L978) reads bare `args.router_request_timeout_secs`). Because the test is outside the unit suite, #40's rename sweep missed it.

## Scope

- Single-line change in one GPU integration test.
- Verified no other stale `--vllm-router-*` non-ip/port flags remain in `tests/`.
- Unit suite (`tests/unit/backends/vllm_utils/`) stays green: 66 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)