### PR TITLE
ci: restore runnable pre-commit gate

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -10,7 +10,7 @@ on:
   #   branches: [main]
   pull_request:
     branches: [main]
-    types: [synchronize, labeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
   workflow_dispatch:
     inputs:
       infinite_run:
@@ -27,7 +27,8 @@ jobs:
 
   pre-commit:
     name: Run pre-commit (gate)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -91,7 +91,7 @@ on:
   #   branches: [main]
   pull_request:
     branches: [main]
-    types: [synchronize, labeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
   workflow_dispatch:
     inputs:
       infinite_run:
@@ -108,7 +108,8 @@ jobs:
 
   pre-commit:
     name: Run pre-commit (gate)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,8 @@ permissions:
 jobs:
   run-pre-commit:
     name: Run pre-commit
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -38,4 +39,3 @@ jobs:
 
       - name: Run pre-commit on all files
         run: pre-commit run --all-files --show-diff-on-failure --color=always
-

--- a/slime/backends/megatron_utils/fp8_helpers.py
+++ b/slime/backends/megatron_utils/fp8_helpers.py
@@ -12,6 +12,7 @@ import torch
 try:
     import deep_gemm.utils.layout as _deep_gemm_layout
     from vllm.utils.deep_gemm import get_tma_aligned_size as _get_tma_aligned_size
+
     _HAS_DEEP_GEMM = True
 except ImportError:
     _deep_gemm_layout = None

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -1052,7 +1052,9 @@ def start_rollout_servers(args, pg) -> dict[str, RolloutServer]:
         model_cfg.resolve(args)
 
         has_pd = model_cfg.has_pd_disaggregation
-        router_ip, router_port, prom_port = _start_router(args, has_pd_disaggregation=has_pd, force_new=(model_idx > 0))
+        router_ip, router_port, prom_port = _start_router(
+            args, has_pd_disaggregation=has_pd, force_new=(model_idx > 0)
+        )
 
         # Write back so downstream readers (vllm_rollout, vllm_engine) see the
         # router we just started (only relevant for first model in multi-model setups).

--- a/slime/rollout/vllm_rollout.py
+++ b/slime/rollout/vllm_rollout.py
@@ -460,9 +460,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
             "token_ids": token_ids,
             "sampling_params": inference_sampling_params,
         }
-        with trace_span(
-            sample, "vllm_inference_generate", attrs={"max_new_tokens": params["max_new_tokens"]}
-        ) as span:
+        with trace_span(sample, "vllm_inference_generate", attrs={"max_new_tokens": params["max_new_tokens"]}) as span:
             output = await post(url, payload, headers=headers)
             # Enrich the span with response meta (finish reason + token usage), mirroring
             # SGLang's build_sglang_meta_trace_attrs. trace_span yields the raw target when

--- a/tests/test_glm4.7_30B_A3B_pd_mooncake.py
+++ b/tests/test_glm4.7_30B_A3B_pd_mooncake.py
@@ -113,7 +113,7 @@ def execute():
         "--vllm-gpu-memory-utilization 0.45 "
         "--vllm-max-num-seqs 16 "
         "--vllm-max-cudagraph-capture-size 8 "
-        "--vllm-speculative-config '{\"method\":\"mtp\",\"num_speculative_tokens\":3}' "
+        '--vllm-speculative-config \'{"method":"mtp","num_speculative_tokens":3}\' '
         "--vllm-router-request-timeout-secs 1200 "
         f"--vllm-config {vllm_config} "
     )

--- a/tests/test_mimo_7B_mtp_only_grad.py
+++ b/tests/test_mimo_7B_mtp_only_grad.py
@@ -92,7 +92,7 @@ def execute():
         "--rollout-num-gpus 8 "
         "--vllm-gpu-memory-utilization 0.8 "
         "--vllm-max-cudagraph-capture-size 8 "
-        "--vllm-speculative-config '{\"method\":\"mtp\",\"num_speculative_tokens\":2}' "
+        '--vllm-speculative-config \'{"method":"mtp","num_speculative_tokens":2}\' '
     )
 
     # Enable MTP training with loss scaling

--- a/tests/test_qwen3.6_35B_A3B_pd_mooncake.py
+++ b/tests/test_qwen3.6_35B_A3B_pd_mooncake.py
@@ -99,7 +99,7 @@ def execute():
         "--vllm-enable-expert-parallel "
         "--vllm-max-num-seqs 512 "
         "--vllm-cudagraph-capture-sizes 1 2 4 8 16 24 32 "
-        "--vllm-speculative-config '{\"method\":\"mtp\",\"num_speculative_tokens\":3}' "
+        '--vllm-speculative-config \'{"method":"mtp","num_speculative_tokens":3}\' '
         "--prefill-num-servers 1 "
     )
 

--- a/tests/test_qwen3_4B_ckpt.py
+++ b/tests/test_qwen3_4B_ckpt.py
@@ -99,7 +99,9 @@ def execute(mode: str = ""):
         "--dist-ckpt-optim-fully-reshardable "
     )
 
-    vllm_args = "--rollout-num-gpus-per-engine 2 --vllm-gpu-memory-utilization 0.8 --vllm-max-cudagraph-capture-size 32 "
+    vllm_args = (
+        "--rollout-num-gpus-per-engine 2 --vllm-gpu-memory-utilization 0.8 --vllm-max-cudagraph-capture-size 32 "
+    )
 
     ci_args = "--ci-test "
 

--- a/tests/test_vllm_config_mixed_offload_ft.py
+++ b/tests/test_vllm_config_mixed_offload_ft.py
@@ -46,9 +46,7 @@ def prepare():
 
 
 def execute():
-    config_file = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".yaml", prefix="vllm_mixed_offload_ft_", delete=False
-    )
+    config_file = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", prefix="vllm_mixed_offload_ft_", delete=False)
     config_file.write(VLLM_CONFIG_YAML)
     config_file.flush()
     config_path = config_file.name


### PR DESCRIPTION
## Summary
- apply the current Black/pre-commit formatting drift on main
- run the PR Test pre-commit gate when PRs are opened, reopened, and marked ready for review
- move pre-commit jobs to self-hosted runners so they do not fail before starting when GitHub-hosted minutes/billing are unavailable

## Testing
- `pre-commit run --all-files --show-diff-on-failure --color=never`

## Follow-up outside this PR
- mark `Run pre-commit` and/or `Run pre-commit (gate)` as required checks in repo branch protection/rulesets once available