### PR TITLE
fix(vllm): tolerate empty 200 body in _response_json (/sleep, /wake_up)

### DIFF
--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -38,6 +38,13 @@ def _response_json(response: requests.Response) -> dict:
     except requests.exceptions.HTTPError as e:
         e.add_note(f"{response.text=}")
         raise
+    # Some vLLM control-plane endpoints (e.g. POST /sleep, /wake_up) return an
+    # HTTP 200 with an EMPTY body. response.json() would then raise
+    # JSONDecodeError("Expecting value: line 1 column 1 (char 0)") and break
+    # colocate memory offload (release_memory_occupation / resume_memory_occupation).
+    # Treat an empty body as an empty result.
+    if not response.content or not response.text.strip():
+        return {}
     return response.json()
 
 

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -13,10 +13,25 @@ from slime.backends.vllm_utils import vllm_engine as mod
 
 
 class _MockResponse:
-    def __init__(self, *, json_data: dict | None = None, text: str = "", status_code: int = 200):
+    def __init__(
+        self,
+        *,
+        json_data: dict | None = None,
+        text: str = "",
+        status_code: int = 200,
+        content: bytes | None = None,
+    ):
         self._json_data = json_data
-        self.text = text
+        self.text = text if text or json_data is None else "{}"
         self.status_code = status_code
+        if content is not None:
+            self.content = content
+        elif text:
+            self.content = text.encode()
+        elif json_data is not None:
+            self.content = self.text.encode()
+        else:
+            self.content = b""
 
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
@@ -275,6 +290,12 @@ def test_init_weights_update_group_uses_config_timeout(vllm_engine, monkeypatch)
 def test_response_json_parses_dict():
     response = _MockResponse(json_data={"status": "ready"})
     assert mod._response_json(response) == {"status": "ready"}
+
+
+@pytest.mark.unit
+def test_response_json_empty_body_returns_empty_dict():
+    response = _MockResponse()
+    assert mod._response_json(response) == {}
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Problem

`VLLMEngine.release_memory_occupation()` (colocate memory offload, via `RolloutManager.offload()`) does `POST /sleep` and then `_response_json(response)`. vLLM's `/sleep` (and `/wake_up`) return **HTTP 200 with an empty body**, but `_response_json` unconditionally calls `response.json()`:

```python
def _response_json(response: requests.Response) -> dict:
    response.raise_for_status()      # 200 OK
    return response.json()           # 💥 empty body -> JSONDecodeError
```

So colocate offload crashes on the **first** offload (before rollout #1):

```
ray::VLLMEngine.release_memory_occupation()
  File ".../slime/backends/vllm_utils/vllm_engine.py", line 749, in release_memory_occupation
    return _response_json(response)
  File ".../slime/backends/vllm_utils/vllm_engine.py", line 41, in _response_json
    return response.json()
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

### Fix

Treat an empty 200 body as an empty result (`{}`). This covers `/sleep` and `/wake_up`, which carry no JSON payload.

### How it was found

A colocate **Qwen3-4B GRPO** run (DP4 / TP1, `--colocate`) on the vLLM **R3** image (`vllm 0.21.1rc1.dev38`), as part of a slime(SGLang)-vs-vime(vLLM) convergence A/B. The vime arm crashed at the first `release_memory_occupation`; the slime arm was unaffected.

### Notes / follow-up

- `resume_memory_occupation()` (`/wake_up`) hits the same code path and is fixed by the same change.
- Behavior for endpoints that *do* return JSON is unchanged.
- Follow-up: a unit test for `_response_json` (empty body → `{}`, non-empty → parsed, non-200 → raises with `response.text` note) would lock this in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)