### PR TITLE
[Docker] arm64 (sbsa) + CUDA 13 build portability fixes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,9 +46,29 @@ RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f
 RUN pip install flash-linear-attention==0.4.1
 RUN pip install tilelang -f https://tile-ai.github.io/whl/nightly/cu128/
 
-# TE does not have wheel on cuda 13 yet, thus need to install from source
+# cublas + (cu13) cuda dev headers. The arm64 (sbsa) vllm/vllm-openai base ships
+# the cublas runtime .so but not the dev header (cublas_v2.h) / unversioned .so
+# symlink that the x86 base has; TE needs the header and its CMake only creates
+# the CUDA::cublas target when both exist. The dev pkg must match the toolkit
+# CUDA major. For cu13 the top apt block's -12-9 dev set is the wrong major, so
+# also install the -13-0 nvrtc/nvtx/etc. headers TE's nvcc build needs. Placed
+# after the slow flash-attn layers so their cache is preserved; before TE.
+RUN apt-get update && \
+    if [ "${ENABLE_CUDA_13}" = "1" ]; then \
+      apt-get install -y libcublas-dev-13-0 \
+        cuda-nvrtc-dev-13-0 cuda-nvtx-13-0 cuda-nvml-dev-13-0 cuda-profiler-api-13-0 \
+        libcusparse-dev-13-0 libcusolver-dev-13-0 libcufft-dev-13-0 libcurand-dev-13-0; \
+    else apt-get install -y libcublas-dev-12-9; fi && \
+    rm -rf /var/lib/apt/lists/*
+
+# TE does not have wheel on cuda 13 yet, thus need to install from source.
+# TE is built with --no-build-isolation, so its build deps must be pre-installed;
+# install the set TE's release_v2.10 CI uses (wheel packaging ninja pybind11).
+# nvidia-mathdx is left unpinned (as in TE CI): 26.6.0 is x86-only, arm64 (sbsa)
+# max is 25.6.0, and TE release_v2.10 does not pin or reference it (it links plain
+# CUDA::cublas), so the resolver picking the per-arch latest is safe.
 RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
-      pip install nvidia-mathdx==26.6.0 && \
+      pip install nvidia-mathdx pybind11 ninja wheel packaging && \
       pip -v install --no-build-isolation git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.10; \
     else \
       pip -v install --no-build-isolation "transformer_engine[pytorch]==2.10.0"; \


### PR DESCRIPTION
## What

Makes `docker/Dockerfile` build on the **arm64 (sbsa)** `vllm/vllm-openai` base — and fixes the **CUDA 13** (`ENABLE_CUDA_13=1`) source-build path, which builds TransformerEngine from source. Validated by building both images on a GB200 (Grace+Blackwell, aarch64/sm100) host:

- `cu129-arm64` — 72.3 GB
- `cu13-arm64` — 90.3 GB

Both pass the existing build-time smoke (`vllm 0.22.0`, `flashinfer 0.6.11.post2`, `VLLMEngine import ok`).

## Why

The sbsa base diverges from the x86 base, which currently breaks the TE build:

1. **cublas dev** — the sbsa base ships the cublas runtime `.so` but not the dev header (`cublas_v2.h`) nor the unversioned `.so` symlink the x86 base has. TE needs the header, and its CMake `FindCUDAToolkit` only creates the `CUDA::cublas` target when both exist → otherwise `target_link_libraries ... CUDA::cublas but the target was not found`. The dev package must match the toolkit CUDA major (`-13-0` for cu13, `-12-9` otherwise).
2. **cu13 dev headers** — the top apt block installs the `-12-9` dev set, the wrong major for the cu13 toolkit 13.0; TE's nvcc build then fails on `nvrtc.h` / `nvtx3/nvToolsExt.h`. Install the `-13-0` nvrtc/nvtx/math dev set for cu13.
3. **TE build deps** — TE is built with `--no-build-isolation`, so build deps must be pre-present. Only `nvidia-mathdx` was installed, so the source build died with `ModuleNotFoundError: pybind11`. Install the set TE `release_v2.10` CI uses: `wheel packaging ninja pybind11`.
4. **nvidia-mathdx pin** — `26.6.0` is x86-only; arm64 max is `25.6.0`. TE `release_v2.10` does not pin or reference mathdx (it links plain `CUDA::cublas`), so unpin it (as TE CI does) and let the resolver pick the per-arch latest.

## Impact on the x86 default

x86 `cu129` (the default `ENABLE_CUDA_13=0`) only additionally installs an **idempotent** `libcublas-dev-12-9`; every other change is gated on `ENABLE_CUDA_13`. The new apt layer sits **after** the slow flash-attn layers so their build cache is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)