### PR TITLE
[Bugfix][Rollout] Record prefix_cache_hit_rate from vLLM usage

### DIFF
--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -338,6 +338,11 @@ def launch_server_process(
         cmd += ["--max-model-len", str(args.rollout_max_context_len)]
     if getattr(args, "use_rollout_routing_replay", False):
         cmd += ["--enable-return-routed-experts"]
+    # Prefix-cache accounting: vLLM only emits usage.prompt_tokens_details.cached_tokens
+    # (the numerator behind rollout/prefix_cache_hit_rate) when the OpenAI frontend is
+    # started with this flag. It lives on FrontendArgs, not AsyncEngineArgs, so it is NOT
+    # reachable via --vllm-* auto-forwarding and must be set explicitly here.
+    cmd += ["--enable-prompt-tokens-details"]
 
     # vime-preferred defaults — must be explicitly forwarded because the vllm-side
     # default would otherwise apply (the generic forwarder skips values that equal

--- a/slime/rollout/vllm_rollout.py
+++ b/slime/rollout/vllm_rollout.py
@@ -157,6 +157,11 @@ def _vllm_meta_from_generate_choice(args: Namespace, choice: dict, usage: dict |
     if usage:
         meta["prompt_tokens"] = usage.get("prompt_tokens", 0)
         meta["completion_tokens"] = usage.get("completion_tokens", 0)
+        # vLLM reports the prefix-cache hit count nested under prompt_tokens_details
+        # (only populated when the server runs with --enable-prompt-tokens-details).
+        # Surface it so Sample.PrefixCacheInfo.add can populate prefix_cache_hit_rate;
+        # without this the numerator is pinned to 0 and the metric always reads 0.
+        meta["cached_tokens"] = (usage.get("prompt_tokens_details") or {}).get("cached_tokens", 0)
     return meta
 
 


### PR DESCRIPTION
## Problem

`rollout/prefix_cache_hit_rate` always reports **0** on the vLLM path, even on workloads where prefix caching is clearly active (the slime/SGLang arm of the same A/B run reports 0.17–0.23 on identical data). This is a **recording/plumbing bug, not preemption** — preemption events were zero and would not zero out the accounting anyway.

Two compounding gaps:

### 1. Parser never reads the cached-token count
`_vllm_meta_from_generate_choice` (`slime/rollout/vllm_rollout.py`) copied `prompt_tokens` and `completion_tokens` out of `usage`, but never the cached-token count. So `Sample.PrefixCacheInfo.add` always saw `cached_tokens=0`:

```python
# slime/utils/types.py
def add(self, meta_info: dict):
    self.cached_tokens += meta_info.get("cached_tokens", 0)   # always 0
    self.total_prompt_tokens += meta_info.get("prompt_tokens", 0)  # populated
```

The hit-rate **numerator was structurally pinned to 0** while the denominator was fine. vLLM reports the count nested as `usage.prompt_tokens_details.cached_tokens`, so we now read it from there.

### 2. Server never enabled the nested usage detail
vLLM only emits `usage.prompt_tokens_details` when the OpenAI frontend is started with `--enable-prompt-tokens-details` (default off). That flag lives on `FrontendArgs`, **not** `AsyncEngineArgs`, so it is **not** reachable through vime's `--vllm-*` auto-forwarder (which is built solely from `AsyncEngineArgs.add_cli_args`). It has to be added explicitly to the `vllm serve` command in `launch_server_process`.

Both changes are required — fixing either alone still yields 0.

## Changes
- `slime/rollout/vllm_rollout.py`: read `meta["cached_tokens"]` from `usage.prompt_tokens_details.cached_tokens`.
- `slime/backends/vllm_utils/vllm_engine.py`: pass `--enable-prompt-tokens-details` when launching the vLLM server.

## Impact
Cosmetic metric only. Does **not** affect training, weight transfer, or the `train_rollout_logprob_abs_diff` (#64) consistency metric.

## Testing
- `python -c "import ast; ast.parse(...)"` on both edited files — OK.
- Flag string `--enable-prompt-tokens-details` verified against the reference vLLM tree (`vllm/entrypoints/openai/cli_args.py:135`, `FrontendArgs.enable_prompt_tokens_details`; used in vLLM's own `tests/entrypoints/openai/completion/test_completion.py`).
- Disagg server path that vime uses guards the field on the same flag (`vllm/entrypoints/serve/disagg/serving.py`: `if self.enable_prompt_tokens_details and final_res.num_cached_tokens:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)