### PR TITLE
fix(vllm): per-engine TP + strict external config check (harden #68)

### DIFF
--- a/slime/backends/vllm_utils/arguments.py
+++ b/slime/backends/vllm_utils/arguments.py
@@ -279,10 +279,10 @@ def add_vllm_arguments(parser):
     parser.add_argument = old_parser_add_argument
     parser.add_argument_group = old_parser_add_argument_group
 
-    # NOTE: we deliberately do NOT call ``parser.set_defaults(vllm_gpu_memory_utilization=...)``
-    # here, because argparse.set_defaults also mutates ``action.default`` — which would
-    # then make ``_forward_vllm_cli_args`` think the user accepted the vllm-side default
-    # and skip forwarding. vime-preferred defaults (e.g. gpu_memory_utilization=0.55,
+    # NOTE: we deliberately do NOT call ``parser.set_defaults`` for vllm flags here, because
+    # argparse.set_defaults also mutates ``action.default`` — which would make
+    # ``_forward_vllm_cli_args`` think the user accepted the vllm-side default and skip
+    # forwarding. vime-preferred defaults that genuinely differ from vllm (e.g.
     # weight_transfer_config based on colocate) are applied explicitly in
     # ``vllm_engine.launch_server_process``.
 

--- a/slime/backends/vllm_utils/arguments.py
+++ b/slime/backends/vllm_utils/arguments.py
@@ -316,15 +316,11 @@ def validate_args(args):
     args.vllm_dp_size = args.vllm_data_parallel_size
     args.vllm_pp_size = args.vllm_pipeline_parallel_size
 
-    # Compute effective TP size considering PP size
-    if args.vllm_pp_size > 1:
-        assert args.rollout_num_gpus_per_engine % args.vllm_pp_size == 0, (
-            f"rollout_num_gpus_per_engine ({args.rollout_num_gpus_per_engine}) must be divisible by "
-            f"vllm_pipeline_parallel_size ({args.vllm_pp_size})"
-        )
-        args.vllm_tp_size = args.rollout_num_gpus_per_engine // args.vllm_pp_size
-    else:
-        args.vllm_tp_size = args.rollout_num_gpus_per_engine
+    # NOTE: TP is intentionally NOT precomputed here. A global ``vllm_tp_size`` derived from the
+    # *global* rollout_num_gpus_per_engine would shadow the per-engine value and break
+    # heterogeneous per-group engines (different num_gpus_per_engine). TP is resolved per engine
+    # in ``vllm_engine._resolve_vllm_parallel_sizes`` (tp = gpus_per_engine // pp), mirroring
+    # upstream slime's sglang_engine. (pp divisibility is validated there, per engine.)
 
     if getattr(args, "vllm_router_ip", None):
         args.vllm_router_ip = _wrap_ipv6(args.vllm_router_ip)

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -71,7 +71,11 @@ def _format_v6_uri(addr: str | None) -> str | None:
     return addr
 
 
-def _response_json(response: requests.Response) -> dict:
+def _response_json(response: requests.Response | None) -> dict | None:
+    # A headless worker's control-plane POST short-circuits to None (see _post_json);
+    # propagate that no-op cleanly so callers don't each need a node_rank special-case.
+    if response is None:
+        return None
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
@@ -759,7 +763,13 @@ class VLLMEngine(RayActor):
         else:
             _wait_worker_process_alive(self.process)
 
-    def _post_json(self, endpoint: str, payload: dict, timeout: float) -> requests.Response:
+    def _post_json(self, endpoint: str, payload: dict, timeout: float) -> requests.Response | None:
+        # Central control-plane POST choke point (mirrors SGLang's _make_request): the single
+        # place the node_rank guard lives, so every control-plane method that POSTs through here
+        # is guarded by construction. Headless workers (node_rank>0) own no HTTP server, so they
+        # short-circuit to None; _response_json(None) -> None lets that no-op propagate to callers.
+        if self.node_rank != 0:
+            return None
         url = f"{self._http_base()}/{endpoint.lstrip('/')}"
         return requests.post(url, json=payload, timeout=timeout)
 
@@ -892,6 +902,8 @@ class VLLMEngine(RayActor):
         level=0 releases both KV cache and model weights (required before IPC tensor injection).
         Returns a no-op dict when ``--vllm-enable-sleep-mode`` was not set.
         """
+        if self.node_rank != 0:  # /sleep bypasses _post_json (query params); guard explicitly.
+            return None
         self.flush_cache()
         if not getattr(self.args, "vllm_enable_sleep_mode", False):
             return {"ok": True, "sleep_mode": False, "note": "vLLM sleep mode disabled; no /sleep call."}
@@ -906,6 +918,8 @@ class VLLMEngine(RayActor):
 
     def resume_memory_occupation(self, tags: list[str] | None = None):
         """``POST /wake_up`` when sleep mode is on; else a no-op placeholder dict."""
+        if self.node_rank != 0:  # /wake_up bypasses _post_json (query params); guard explicitly.
+            return None
         if not getattr(self.args, "vllm_enable_sleep_mode", False):
             return {"ok": True, "sleep_mode": False}
         tags = _normalize_vllm_wake_tags(tags)

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -50,8 +50,6 @@ class VllmEngineTopology:
     local_num_gpus: int
     tensor_parallel_size: int
     pipeline_parallel_size: int
-    master_host: str | None = None
-    master_port: int | None = None
 
     @property
     def headless(self) -> bool:
@@ -210,9 +208,6 @@ def append_vllm_distributed_launch_flags(
         cmd.append("--headless")
 
 
-_append_vllm_distributed_launch_flags = append_vllm_distributed_launch_flags
-
-
 def _user_overrode(args, dest: str) -> bool:
     user_provided: set[str] = getattr(args, "_vllm_user_provided", set())
     if dest in user_provided:
@@ -318,9 +313,6 @@ def redact_cmd_for_log(cmd: list[str]) -> str:
     return " ".join(parts)
 
 
-_redact_cmd_for_log = redact_cmd_for_log
-
-
 def build_vllm_subprocess_env(server_args: dict[str, Any]) -> dict[str, str]:
     """Child-process environment for ``vllm serve``."""
     args = server_args["args"]
@@ -373,9 +365,6 @@ def serialize_for_cli(value) -> str | None:
             logger.debug("JSON serialization failed for %r: %s", type(value).__name__, exc)
             return None
     return None
-
-
-_serialize_for_cli = serialize_for_cli
 
 
 def _serialize_weight_transfer_config(value) -> str:
@@ -731,8 +720,7 @@ class VLLMEngine(RayActor):
         check stays strict for reported fields without false-failing on unreported ones.
         """
         response = requests.get(f"{self._http_base()}/server_info", params={"config_format": "json"}, timeout=30)
-        response.raise_for_status()
-        body = response.json()
+        body = _response_json(response)
         parallel_cfg = body.get("vllm_config", {}).get("parallel_config", {})
         if not parallel_cfg:
             raise RuntimeError(f"External vLLM /server_info missing vllm_config.parallel_config: {body}")

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -123,11 +123,26 @@ def _get_vllm_dp_size(args) -> int:
 
 
 def _resolve_vllm_parallel_sizes(args, *, gpus_per_engine: int) -> tuple[int, int]:
+    # Derive TP per-engine from THIS engine's GPU count (matches upstream slime's
+    # sglang_engine: tp = _gpus_per_engine // pp). Deliberately does NOT consult a global
+    # ``args.vllm_tp_size``: validate_args used to set that from the *global*
+    # rollout_num_gpus_per_engine, which shadowed this per-engine value and made a
+    # heterogeneous per-group engine (e.g. a tp=2 group) launch with the global TP —
+    # desyncing the weight-transfer rendezvous (the 300s "3/4 clients joined" hang).
     pp = _get_vllm_pp_size(args)
-    if getattr(args, "vllm_tp_size", None) is not None:
-        tp = int(args.vllm_tp_size)
-    else:
-        tp = gpus_per_engine // pp
+    dp = _get_vllm_dp_size(args)
+    if dp != 1:
+        raise NotImplementedError(
+            "vLLM data parallelism (vllm_data_parallel_size>1) is not wired in this base: TP is "
+            "computed as gpus_per_engine // pp (no DP term) and --data-parallel-size is not "
+            "forwarded. DP/EP support lands in a follow-up PR."
+        )
+    if gpus_per_engine % pp != 0:
+        raise ValueError(
+            f"num_gpus_per_engine ({gpus_per_engine}) must be divisible by "
+            f"vllm_pipeline_parallel_size ({pp})"
+        )
+    tp = gpus_per_engine // pp
     return tp, pp
 
 
@@ -648,7 +663,18 @@ class VLLMEngine(RayActor):
             )
 
         if self.args.rollout_external:
-            self._init_external()
+            # Only the HTTP-owning head node (node_rank 0) can hit /health and
+            # /server_info. Headless workers (node_rank>0) expose no HTTP endpoint,
+            # so skip the check for them — mirrors the head/worker split in _init_normal.
+            if self.node_rank == 0:
+                self._init_external()
+            else:
+                logger.info(
+                    "External vLLM headless worker (rank=%s node_rank=%s): skip HTTP health/config "
+                    "check (only node_rank 0 owns HTTP).",
+                    self.rank,
+                    self.node_rank,
+                )
         else:
             self._init_normal()
 
@@ -687,29 +713,46 @@ class VLLMEngine(RayActor):
 
     def _init_external(self) -> None:
         logger.info("Use external vLLM engine (rank=%s) at %s:%s", self.rank, self.server_host, self.server_port)
-        base = self._http_base()
-        _wait_server_healthy(base, process=None)
-        self._wait_external_config_ready()
+        _wait_server_healthy(self._http_base(), process=None)
+        self._sanity_check_external_server_args()
 
-    def _wait_external_config_ready(self) -> None:
-        """External engine: best-effort ``GET /server_info`` TP check (non-fatal)."""
-        try:
-            actual = requests.get(f"{self._http_base()}/server_info", params={"config_format": "json"}, timeout=30)
-            actual.raise_for_status()
-            body = actual.json()
-        except requests.RequestException as e:
-            logger.warning("External vLLM: could not GET /server_info (non-fatal): %s", e)
-            return
+    def _sanity_check_external_server_args(self) -> None:
+        """Strictly verify an external engine's parallel config matches what we expect; raise on mismatch.
 
-        expect_tp = self.args.rollout_num_gpus_per_engine
+        Replaces the previous warn-only check, which (a) compared against the *global*
+        ``rollout_num_gpus_per_engine`` — wrong for heterogeneous / multi-node groups — and
+        (b) only logged a warning, so a misconfigured external engine sailed through and then
+        hung the weight-sync rendezvous ~300s later with no clear error.
+
+        We now compare every field in ``EXTERNAL_ENGINE_CHECK_FIELDS`` against the per-engine
+        expectation in ``self._server_args`` and raise immediately on mismatch. A field that the
+        engine's ``/server_info`` does not report (``actual is None``) is skipped rather than
+        treated as a mismatch (e.g. vLLM ``parallel_config`` may not surface ``nnodes``), so the
+        check stays strict for reported fields without false-failing on unreported ones.
+        """
+        response = requests.get(f"{self._http_base()}/server_info", params={"config_format": "json"}, timeout=30)
+        response.raise_for_status()
+        body = response.json()
         parallel_cfg = body.get("vllm_config", {}).get("parallel_config", {})
-        actual_tp = parallel_cfg.get("tensor_parallel_size")
-        if actual_tp is not None and actual_tp != expect_tp:
-            logger.warning(
-                "External vLLM server_info TP mismatch: expect=%s actual=%s (weak check)",
-                expect_tp,
-                actual_tp,
-            )
+        if not parallel_cfg:
+            raise RuntimeError(f"External vLLM /server_info missing vllm_config.parallel_config: {body}")
+        actual = {
+            "tp_size": parallel_cfg.get("tensor_parallel_size"),
+            "pp_size": parallel_cfg.get("pipeline_parallel_size"),
+            "dp_size": parallel_cfg.get("data_parallel_size"),
+            "nnodes": parallel_cfg.get("nnodes"),
+        }
+        expect = {name: self._server_args.get(name) for name in EXTERNAL_ENGINE_CHECK_FIELDS}
+        for name in EXTERNAL_ENGINE_CHECK_FIELDS:
+            actual_value = actual.get(name)
+            if actual_value is None:
+                logger.debug("External vLLM /server_info did not report %s; skipping that check.", name)
+                continue
+            if actual_value != expect.get(name):
+                raise AssertionError(
+                    f"External vLLM server arg mismatch: {name}: expect={expect.get(name)} "
+                    f"actual={actual_value} (full expect={expect} actual={actual})"
+                )
 
     def _init_normal(self) -> None:
         topology = self._topology

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -773,18 +773,26 @@ class VLLMEngine(RayActor):
         url = f"{self._http_base()}/{endpoint.lstrip('/')}"
         return requests.post(url, json=payload, timeout=timeout)
 
+    def _make_request(self, endpoint: str, payload: dict | None = None, *, timeout: float) -> dict | None:
+        """Control-plane POST returning parsed JSON (SGLang-style ``_make_request``).
+
+        Combines the central guard (``_post_json`` short-circuits a headless worker to None) with
+        JSON parsing (``_response_json``), so control-plane callers are one-liners and a headless
+        worker (node_rank>0) cleanly no-ops to None.
+        """
+        return _response_json(self._post_json(endpoint, payload or {}, timeout))
+
     def _post_vllm_update_weights_http(self, update_info: dict) -> dict:
         """POST ``/update_weights`` with ``{"update_info": ...}`` (vLLM RLHF control plane).
 
         Caller must invoke ``start_weight_update`` / ``finish_weight_update`` around a batch of
         ``/update_weights`` calls (see ``UpdateWeightFromTensor`` / ``UpdateWeightFromDistributed``).
         """
-        response = self._post_json(
+        return self._make_request(
             "update_weights",
             {"update_info": update_info},
             timeout=self._weight_transfer_http_timeout(),
         )
-        return _response_json(response)
 
     def health_generate(self, timeout: float = 5.0) -> bool:
         """Return True if ``GET /health`` succeeds."""
@@ -943,8 +951,7 @@ class VLLMEngine(RayActor):
         last_error = None
         for attempt in range(1, 4):
             try:
-                response = self._post_json("init_weight_transfer_engine", payload, timeout=init_timeout_s)
-                return _response_json(response)
+                return self._make_request("init_weight_transfer_engine", payload, timeout=init_timeout_s)
             except Exception as e:
                 last_error = e
                 if attempt < 3:
@@ -954,12 +961,11 @@ class VLLMEngine(RayActor):
 
     def start_weight_update(self, is_checkpoint_format: bool = False) -> dict:
         """``POST /start_weight_update`` — signals vLLM to enter IPC weight-update mode."""
-        response = self._post_json(
+        return self._make_request(
             "start_weight_update",
             {"is_checkpoint_format": is_checkpoint_format},
             timeout=self._weight_transfer_http_timeout(),
         )
-        return _response_json(response)
 
     def finish_weight_update(self) -> dict:
         """``POST /finish_weight_update`` — signals vLLM to exit IPC weight-update mode.
@@ -968,8 +974,7 @@ class VLLMEngine(RayActor):
         ``update_weights_from_tensor`` (the IPC data-carrying RPC), matching slime's
         single-RPC version-with-data semantics.
         """
-        response = self._post_json("finish_weight_update", {}, timeout=self._weight_transfer_http_timeout())
-        return _response_json(response)
+        return self._make_request("finish_weight_update", {}, timeout=self._weight_transfer_http_timeout())
 
     def check_weights(self, action: str):
         """No vLLM ``weights_checker`` route; return a placeholder dict."""
@@ -995,8 +1000,7 @@ class VLLMEngine(RayActor):
         last_error = None
         for attempt in range(1, 4):
             try:
-                response = self._post_json("init_weight_transfer_engine", payload, timeout=init_timeout_s)
-                return _response_json(response)
+                return self._make_request("init_weight_transfer_engine", payload, timeout=init_timeout_s)
             except Exception as e:
                 last_error = e
                 if attempt < 3:

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -71,11 +71,7 @@ def _format_v6_uri(addr: str | None) -> str | None:
     return addr
 
 
-def _response_json(response: requests.Response | None) -> dict | None:
-    # A headless worker's control-plane POST short-circuits to None (see _post_json);
-    # propagate that no-op cleanly so callers don't each need a node_rank special-case.
-    if response is None:
-        return None
+def _response_json(response: requests.Response) -> dict:
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
@@ -763,24 +759,17 @@ class VLLMEngine(RayActor):
         else:
             _wait_worker_process_alive(self.process)
 
-    def _post_json(self, endpoint: str, payload: dict, timeout: float) -> requests.Response | None:
-        # Central control-plane POST choke point (mirrors SGLang's _make_request): the single
-        # place the node_rank guard lives, so every control-plane method that POSTs through here
-        # is guarded by construction. Headless workers (node_rank>0) own no HTTP server, so they
-        # short-circuit to None; _response_json(None) -> None lets that no-op propagate to callers.
+    def _make_request(self, endpoint: str, payload: dict | None = None, *, timeout: float) -> dict | None:
+        """Control-plane POST returning parsed JSON (mirrors SGLang's ``_make_request``).
+
+        The single choke point for control-plane POSTs: headless workers (node_rank>0) own no
+        HTTP server, so they no-op to None; otherwise POST and parse via the shared
+        ``_response_json`` (also reused by the query-param endpoints /sleep, /wake_up, ...).
+        """
         if self.node_rank != 0:
             return None
         url = f"{self._http_base()}/{endpoint.lstrip('/')}"
-        return requests.post(url, json=payload, timeout=timeout)
-
-    def _make_request(self, endpoint: str, payload: dict | None = None, *, timeout: float) -> dict | None:
-        """Control-plane POST returning parsed JSON (SGLang-style ``_make_request``).
-
-        Combines the central guard (``_post_json`` short-circuits a headless worker to None) with
-        JSON parsing (``_response_json``), so control-plane callers are one-liners and a headless
-        worker (node_rank>0) cleanly no-ops to None.
-        """
-        return _response_json(self._post_json(endpoint, payload or {}, timeout))
+        return _response_json(requests.post(url, json=payload or {}, timeout=timeout))
 
     def _post_vllm_update_weights_http(self, update_info: dict) -> dict:
         """POST ``/update_weights`` with ``{"update_info": ...}`` (vLLM RLHF control plane).
@@ -910,7 +899,7 @@ class VLLMEngine(RayActor):
         level=0 releases both KV cache and model weights (required before IPC tensor injection).
         Returns a no-op dict when ``--vllm-enable-sleep-mode`` was not set.
         """
-        if self.node_rank != 0:  # /sleep bypasses _post_json (query params); guard explicitly.
+        if self.node_rank != 0:  # /sleep bypasses _make_request (query params, not JSON body); guard explicitly.
             return None
         self.flush_cache()
         if not getattr(self.args, "vllm_enable_sleep_mode", False):
@@ -926,7 +915,7 @@ class VLLMEngine(RayActor):
 
     def resume_memory_occupation(self, tags: list[str] | None = None):
         """``POST /wake_up`` when sleep mode is on; else a no-op placeholder dict."""
-        if self.node_rank != 0:  # /wake_up bypasses _post_json (query params); guard explicitly.
+        if self.node_rank != 0:  # /wake_up bypasses _make_request (query params, not JSON body); guard explicitly.
             return None
         if not getattr(self.args, "vllm_enable_sleep_mode", False):
             return {"ok": True, "sleep_mode": False}

--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -494,11 +494,9 @@ def build_vllm_cmd_and_env(server_args: dict[str, Any]) -> tuple[list[str], dict
     if getattr(args, "use_rollout_routing_replay", False):
         cmd += ["--enable-return-routed-experts"]
 
-    if _user_overrode(args, "vllm_gpu_memory_utilization"):
-        gpu_mem = args.vllm_gpu_memory_utilization
-    else:
-        gpu_mem = 0.55
-    cmd += ["--gpu-memory-utilization", str(gpu_mem)]
+    # gpu_memory_utilization: no vime-forced default. In colocate, training and rollout do not
+    # occupy the GPU simultaneously (sleep/offload cycles), so vLLM's own default is fine. A user
+    # value passed via --vllm-gpu-memory-utilization is auto-forwarded by _forward_vllm_cli_args.
 
     # 2) logprobs_mode: vllm's raw_logprobs are pre-temperature, while Megatron
     #    replay compares against rollout-temperature-scaled logprobs.
@@ -651,8 +649,10 @@ class VLLMEngine(RayActor):
         self._topology = self._server_args["topology"]
         self.node_rank = self._topology.node_rank
 
-        self.router_ip = router_ip if router_ip is not None else self.args.vllm_router_ip
-        self.router_port = router_port if router_port is not None else self.args.vllm_router_port
+        # rollout always passes the resolved router (engine.init(router_ip=self.router_ip, ...))
+        # and _start_router always returns a real address, so no fallback to args is needed.
+        self.router_ip = router_ip
+        self.router_port = router_port
         self.server_host = self._server_args["host"]
         self.server_port = port
 

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -101,7 +101,7 @@ def test_append_distributed_flags_only_when_multi_node(vllm_args):
         tensor_parallel_size=4,
         pipeline_parallel_size=1,
     )
-    mod._append_vllm_distributed_launch_flags(cmd, single, ("10.0.0.1", 15000), vllm_args)
+    mod.append_vllm_distributed_launch_flags(cmd, single, ("10.0.0.1", 15000), vllm_args)
     assert cmd == ["vllm", "serve"]
 
     cmd_multi: list[str] = ["vllm", "serve"]
@@ -112,7 +112,7 @@ def test_append_distributed_flags_only_when_multi_node(vllm_args):
         tensor_parallel_size=8,
         pipeline_parallel_size=2,
     )
-    mod._append_vllm_distributed_launch_flags(cmd_multi, multi, ("10.0.0.2", 16000), vllm_args)
+    mod.append_vllm_distributed_launch_flags(cmd_multi, multi, ("10.0.0.2", 16000), vllm_args)
     assert "--nnodes" in cmd_multi
     assert "--node-rank" in cmd_multi
     assert "1" in cmd_multi
@@ -392,16 +392,16 @@ def test_http_base_ipv6_host(vllm_engine):
 @pytest.mark.unit
 def test_redact_cmd_for_log_masks_hf_token():
     cmd = ["vllm", "serve", "model", "--hf-token", "secret-token", "--port", "8000"]
-    logged = mod._redact_cmd_for_log(cmd)
+    logged = mod.redact_cmd_for_log(cmd)
     assert "secret-token" not in logged
     assert "***" in logged
 
 
 @pytest.mark.unit
 def test_serialize_for_cli_primitives():
-    assert mod._serialize_for_cli(42) == "42"
-    assert mod._serialize_for_cli(True) == "True"
-    assert mod._serialize_for_cli({"backend": "nccl"}) == json.dumps({"backend": "nccl"})
+    assert mod.serialize_for_cli(42) == "42"
+    assert mod.serialize_for_cli(True) == "True"
+    assert mod.serialize_for_cli({"backend": "nccl"}) == json.dumps({"backend": "nccl"})
 
 
 @pytest.mark.unit
@@ -410,7 +410,7 @@ def test_serialize_for_cli_dataclass():
     class _Cfg:
         backend: str = "nccl"
 
-    out = mod._serialize_for_cli(_Cfg())
+    out = mod.serialize_for_cli(_Cfg())
     assert json.loads(out) == {"backend": "nccl"}
 
 

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -17,6 +17,10 @@ class _MockResponse:
         self._json_data = json_data
         self.text = text
         self.status_code = status_code
+        # Model requests.Response.content (raw body bytes) so _response_json's empty-body
+        # handling (empty 200 -> {"ok": True}) is actually exercised. A JSON body is non-empty;
+        # text-only/empty bodies use the given text (b"" when empty).
+        self.content = json.dumps(json_data).encode() if json_data is not None else text.encode()
 
     def raise_for_status(self) -> None:
         if self.status_code >= 400:

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -580,3 +580,41 @@ def test_resolve_parallel_sizes_rejects_dp_gt_1(vllm_args):
     vllm_args.vllm_dp_size = 2
     with pytest.raises(NotImplementedError, match="data parallelism"):
         mod._resolve_vllm_parallel_sizes(vllm_args, gpus_per_engine=4)
+
+
+@pytest.mark.unit
+def test_response_json_tolerates_none():
+    # _post_json short-circuits to None on headless workers; _response_json must propagate None.
+    assert mod._response_json(None) is None
+
+
+@pytest.mark.unit
+def test_post_json_short_circuits_on_headless(vllm_engine, monkeypatch):
+    def _boom(*a, **k):
+        raise AssertionError("control-plane HTTP must not be called on a headless worker")
+
+    monkeypatch.setattr(mod.requests, "post", _boom)
+    vllm_engine.node_rank = 1
+    assert vllm_engine._post_json("whatever", {}, timeout=1) is None
+
+
+@pytest.mark.unit
+def test_control_plane_methods_noop_on_headless_worker(vllm_engine, monkeypatch):
+    """node_rank>0 (headless) workers own no HTTP server; every control-plane method must
+    no-op (return None) without issuing an HTTP request."""
+
+    def _boom(*a, **k):
+        raise AssertionError("control-plane HTTP must not be called on a headless worker")
+
+    monkeypatch.setattr(mod.requests, "post", _boom)
+    monkeypatch.setattr(mod.requests, "get", _boom)
+    vllm_engine.node_rank = 1
+    vllm_engine.args.vllm_enable_sleep_mode = True
+
+    assert vllm_engine.init_weight_transfer_engine({"init_info": {}}) is None
+    assert vllm_engine.start_weight_update() is None
+    assert vllm_engine.finish_weight_update() is None
+    assert vllm_engine.init_weights_update_group("addr", 1, 0, 4, "g", "nccl") is None
+    assert vllm_engine.update_weights_from_distributed(["w"], [torch.float32], [[1]], "g") is None
+    assert vllm_engine.release_memory_occupation() is None
+    assert vllm_engine.resume_memory_occupation() is None

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -159,9 +159,9 @@ def test_start_weight_update_posts_four_phase_endpoint(vllm_engine, monkeypatch)
 
     def fake_post(endpoint: str, payload: dict, timeout: float):
         calls.append((endpoint, payload, timeout))
-        return _MockResponse(json_data={"ok": True})
+        return {"ok": True}
 
-    monkeypatch.setattr(vllm_engine, "_post_json", fake_post)
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
 
     result = vllm_engine.start_weight_update(is_checkpoint_format=True)
 
@@ -178,9 +178,9 @@ def test_finish_weight_update_posts_empty_body(vllm_engine, monkeypatch):
 
     def fake_post(endpoint: str, payload: dict, timeout: float):
         calls.append((endpoint, payload, timeout))
-        return _MockResponse(json_data={"done": True})
+        return {"done": True}
 
-    monkeypatch.setattr(vllm_engine, "_post_json", fake_post)
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
 
     result = vllm_engine.finish_weight_update()
 
@@ -295,9 +295,9 @@ def test_post_vllm_update_weights_http_wraps_update_info(vllm_engine, monkeypatc
 
     def fake_post(endpoint: str, payload: dict, timeout: float):
         seen.append((endpoint, payload, timeout))
-        return _MockResponse(json_data={"status": "ok"})
+        return {"status": "ok"}
 
-    monkeypatch.setattr(vllm_engine, "_post_json", fake_post)
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
 
     result = vllm_engine._post_vllm_update_weights_http({"names": ["w"], "packed": False})
 
@@ -325,9 +325,9 @@ def test_start_weight_update_uses_config_timeout(vllm_engine, monkeypatch):
 
     def fake_post(endpoint: str, payload: dict, timeout: float):
         calls.append((endpoint, payload, timeout))
-        return _MockResponse(json_data={"ok": True})
+        return {"ok": True}
 
-    monkeypatch.setattr(vllm_engine, "_post_json", fake_post)
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
 
     vllm_engine.start_weight_update()
     assert calls[0][2] == 123.5
@@ -340,9 +340,9 @@ def test_init_weights_update_group_uses_config_timeout(vllm_engine, monkeypatch)
 
     def fake_post(endpoint: str, payload: dict, timeout: float):
         calls.append((endpoint, payload, timeout))
-        return _MockResponse(json_data={"initialized": True})
+        return {"initialized": True}
 
-    monkeypatch.setattr(vllm_engine, "_post_json", fake_post)
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
 
     vllm_engine.init_weights_update_group(
         "127.0.0.1",
@@ -461,9 +461,9 @@ def test_init_weights_update_group_retries_then_succeeds(vllm_engine, monkeypatc
         attempts["n"] += 1
         if attempts["n"] < 2:
             raise requests.ConnectionError("transient")
-        return _MockResponse(json_data={"initialized": True})
+        return {"initialized": True}
 
-    monkeypatch.setattr(vllm_engine, "_post_json", fake_post)
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
     monkeypatch.setattr(mod.time, "sleep", lambda *_a, **_k: None)
 
     result = vllm_engine.init_weights_update_group(
@@ -483,7 +483,7 @@ def test_init_weights_update_group_retries_then_succeeds(vllm_engine, monkeypatc
 def test_init_weights_update_group_raises_after_three_failures(vllm_engine, monkeypatch):
     monkeypatch.setattr(
         vllm_engine,
-        "_post_json",
+        "_make_request",
         lambda *a, **k: (_ for _ in ()).throw(requests.ConnectionError("down")),
     )
     monkeypatch.setattr(mod.time, "sleep", lambda *_a, **_k: None)
@@ -583,19 +583,15 @@ def test_resolve_parallel_sizes_rejects_dp_gt_1(vllm_args):
 
 
 @pytest.mark.unit
-def test_response_json_tolerates_none():
-    # _post_json short-circuits to None on headless workers; _response_json must propagate None.
-    assert mod._response_json(None) is None
-
-
-@pytest.mark.unit
-def test_post_json_short_circuits_on_headless(vllm_engine, monkeypatch):
+def test_make_request_short_circuits_on_headless(vllm_engine, monkeypatch):
+    # _make_request is the single control-plane POST choke point; on a headless worker
+    # (node_rank>0) it must no-op to None without issuing any HTTP request.
     def _boom(*a, **k):
         raise AssertionError("control-plane HTTP must not be called on a headless worker")
 
     monkeypatch.setattr(mod.requests, "post", _boom)
     vllm_engine.node_rank = 1
-    assert vllm_engine._post_json("whatever", {}, timeout=1) is None
+    assert vllm_engine._make_request("whatever", {}, timeout=1) is None
 
 
 @pytest.mark.unit

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -497,3 +497,86 @@ def test_init_weights_update_group_raises_after_three_failures(vllm_engine, monk
             group_name="g",
             backend="nccl",
         )
+
+
+def _stub_server_info(monkeypatch, parallel_config: dict) -> None:
+    def fake_get(url, *, params=None, timeout=30):
+        return _MockResponse(json_data={"vllm_config": {"parallel_config": parallel_config}})
+
+    monkeypatch.setattr(mod.requests, "get", fake_get)
+
+
+@pytest.mark.unit
+def test_sanity_check_external_server_args_passes_on_match(vllm_engine, monkeypatch):
+    vllm_engine._server_args = {"tp_size": 2, "pp_size": 1, "dp_size": 1, "nnodes": 1}
+    _stub_server_info(
+        monkeypatch,
+        {"tensor_parallel_size": 2, "pipeline_parallel_size": 1, "data_parallel_size": 1, "nnodes": 1},
+    )
+    # All reported fields match the per-engine expectation → no raise.
+    vllm_engine._sanity_check_external_server_args()
+
+
+@pytest.mark.unit
+def test_sanity_check_external_server_args_raises_on_tp_mismatch(vllm_engine, monkeypatch):
+    # Expect a tp=2 engine but the external server reports tp=1 → fail fast (the bug class
+    # that used to only warn and then hang the weight-sync rendezvous 300s later).
+    vllm_engine._server_args = {"tp_size": 2, "pp_size": 1, "dp_size": 1, "nnodes": 1}
+    _stub_server_info(
+        monkeypatch,
+        {"tensor_parallel_size": 1, "pipeline_parallel_size": 1, "data_parallel_size": 1, "nnodes": 1},
+    )
+    with pytest.raises(AssertionError, match="tp_size"):
+        vllm_engine._sanity_check_external_server_args()
+
+
+@pytest.mark.unit
+def test_sanity_check_external_server_args_skips_unreported_field(vllm_engine, monkeypatch):
+    # vLLM /server_info may not surface ``nnodes``: an unreported (None) field is skipped,
+    # not treated as a mismatch — so a single-node external engine doesn't false-fail.
+    vllm_engine._server_args = {"tp_size": 1, "pp_size": 1, "dp_size": 1, "nnodes": 2}
+    _stub_server_info(
+        monkeypatch,
+        {"tensor_parallel_size": 1, "pipeline_parallel_size": 1, "data_parallel_size": 1},
+    )
+    vllm_engine._sanity_check_external_server_args()
+
+
+@pytest.mark.unit
+def test_sanity_check_external_server_args_raises_when_parallel_config_missing(vllm_engine, monkeypatch):
+    vllm_engine._server_args = {"tp_size": 1, "pp_size": 1, "dp_size": 1, "nnodes": 1}
+    _stub_server_info(monkeypatch, {})
+    with pytest.raises(RuntimeError, match="missing vllm_config.parallel_config"):
+        vllm_engine._sanity_check_external_server_args()
+
+
+@pytest.mark.unit
+def test_resolve_parallel_sizes_is_per_engine_not_global(vllm_args):
+    # The global flag is 1, but THIS engine has 2 GPUs → tp must be 2 (per-engine), not 1.
+    # A stale global vllm_tp_size must NOT shadow the per-engine value.
+    vllm_args.rollout_num_gpus_per_engine = 1
+    vllm_args.vllm_pipeline_parallel_size = 1
+    vllm_args.vllm_tp_size = 1  # stale global; must be ignored now
+    tp, pp = mod._resolve_vllm_parallel_sizes(vllm_args, gpus_per_engine=2)
+    assert (tp, pp) == (2, 1)
+
+
+@pytest.mark.unit
+def test_compute_topology_heterogeneous_per_group_tp(vllm_args):
+    # Reproduces the rendezvous bug's root: global=1 but a per-group engine uses 2 GPUs.
+    vllm_args.num_gpus_per_node = 8
+    vllm_args.rollout_num_gpus_per_engine = 1
+    vllm_args.vllm_pipeline_parallel_size = 1
+    vllm_args.vllm_tp_size = 1  # stale global
+    topo = mod.compute_vllm_engine_topology(vllm_args, global_rank=0, num_gpus_per_engine=2)
+    assert topo.tensor_parallel_size == 2
+    assert topo.nnodes == 1
+
+
+@pytest.mark.unit
+def test_resolve_parallel_sizes_rejects_dp_gt_1(vllm_args):
+    vllm_args.vllm_pipeline_parallel_size = 1
+    vllm_args.vllm_data_parallel_size = 2
+    vllm_args.vllm_dp_size = 2
+    with pytest.raises(NotImplementedError, match="data parallelism"):
+        mod._resolve_vllm_parallel_sizes(vllm_args, gpus_per_engine=4)


### PR DESCRIPTION
Hardening on top of #68 (`feature/multi_nodes`). Two fixes of **one root cause**: TP / parallel sizing read the **global** `rollout_num_gpus_per_engine` instead of the **per-engine** value, in the two engine-launch paths. No new features.

## P2 — managed launch: TP was not actually per-engine
`validate_args` unconditionally set a global `args.vllm_tp_size = global rollout_num_gpus_per_engine // pp`, and `_resolve_vllm_parallel_sizes` preferred it — so the per-engine `tp = gpus_per_engine // pp` branch was **dead code in real runs**. A heterogeneous per-group engine (e.g. a group with `num_gpus_per_engine=2`, tp=2) therefore launched with the **global** TP, while the trainer sized the NCCL weight-transfer rendezvous from the per-group `engine_gpu_counts`. They disagreed → the rendezvous hung 300 s (`3/4 clients joined` / `DistStoreError`).

- TP is now derived **per engine** in `_resolve_vllm_parallel_sizes` (no global shadow), matching upstream slime's `sglang_engine` (`tp = _gpus_per_engine // pp`).
- The global `vllm_tp_size` computation in `validate_args` is removed.
- `dp>1` raises `NotImplementedError` (DP/EP wiring is a follow-up PR); `pp` divisibility is validated per engine.

## P1 — external engine: weak, wrong-baseline, not node-rank aware
`_wait_external_config_ready` compared the engine's reported TP against the same **global** flag and only **warned**, and it ran on headless workers (`node_rank>0`) that own no HTTP. Replaced with `_sanity_check_external_server_args`:
- compares `tp/pp/dp/nnodes` against the **per-engine** expectation (`self._server_args`) and **raises** on mismatch (fail fast at init instead of a 300 s rendezvous hang later);
- gated to `node_rank == 0`;
- skips fields `/server_info` does not report (vLLM `parallel_config` may omit `nnodes`), so it stays strict without false-failing.

## Note on #66
#66 (`aoshen/vllm-mirror-sglang-arch`) carries the **identical** global-TP shadow (`_get_vllm_tp_size` + its `validate_args`). This is a fix **both** branches need, not a port from #66.

## Tests
- New unit tests: per-engine TP, heterogeneous per-group TP via `compute_vllm_engine_topology`, `dp>1` guard, and the strict external check (match / mismatch-raises / unreported-field-skipped / missing-parallel-config).
- Existing #68 topology unit tests are unchanged and still pass (they set `pp` consistently, so `gpus//pp` equals their old `vllm_tp_size`).
- Verified the new logic in a fresh r3 container (py_compile + inline drivers for all cases). E2E confirmation on `test_qwen2.5_0.5B_vllm_config_distributed` (heterogeneous tp=2/tp=1) to follow.

AI assistance (Claude Code) was used for this change.