### PR TITLE
fix(weight-sync): loud guard when packed update reached with no NCCL group

### DIFF
--- a/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -222,6 +222,17 @@ class UpdateWeightFromDistributed:
 
     def _update_weights_vllm_packed(self, converted_named_tensors: list[tuple[str, torch.Tensor]]) -> None:
         """Single-shot vLLM weight update using packed broadcast."""
+        # P4 guard: this path is only reached on the PP source rank (see _sync_weights_to_rollout_engines),
+        # which always connects _model_update_groups first. If it is still None here the NCCL weight-sync
+        # group was never built — passing None down would hang the rendezvous (the 300s class of bug) with
+        # an opaque error. Fail loudly and point at the [vllm-topo] sizing logs instead.
+        if self._model_update_groups is None:
+            raise RuntimeError(
+                "[vllm-topo] _update_weights_vllm_packed reached with _model_update_groups=None "
+                f"(is_pp_src_rank={getattr(self, '_is_pp_src_rank', None)} group={getattr(self, '_group_name', None)}). "
+                "The weight-sync NCCL group was never connected; check engine_gpu_counts vs launched tp "
+                "in the [vllm-topo] server_args logs."
+            )
         while not ray.get(self.rollout_engine_lock.acquire.remote()):
             time.sleep(0.1)
 


### PR DESCRIPTION
## What
`_update_weights_vllm_packed` is only entered on the PP source rank (see
`_sync_weights_to_rollout_engines`), which always connects `_model_update_groups` first — so in
normal flow the value is never `None`. But the function did not guard the `None` case: if it were
ever reached without a connected group, `None` was passed straight down to
`update_weights_from_distributed` → NCCL, which **hangs the weight-sync rendezvous (~300s)** with an
opaque error rather than failing fast.

## Fix
Add a loud guard at the top of `_update_weights_vllm_packed`: if `_model_update_groups is None`,
`raise RuntimeError(...)` with a diagnostic (`is_pp_src_rank`, `group`) that points at the
`[vllm-topo]` per-engine sizing logs. Strictly better than a silent 300s hang; no behavior change on
the healthy path.

AI assistance (Claude Code) was used for this change.
