### PR TITLE
fix(rollout): always use the full Rust router for PD; remove the unusable MiniLB path

### DIFF
--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -982,10 +982,11 @@ def _start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool 
             router_args.vllm_pd_disaggregation = True
         if hasattr(router_args, "disable_circuit_breaker"):
             router_args.disable_circuit_breaker = True
-
-    # MiniLB is PD-only in vllm-router; non-PD rollout needs the Rust Router (omit SLIME_VLLM_ROUTER_USE_RUST).
-    if has_pd_disaggregation and os.environ.get("SLIME_VLLM_ROUTER_USE_RUST", "") != "1":
-        router_args.mini_lb = True
+        # PD uses the full Rust router: it accepts dynamic /workers registration (engines register
+        # after the router is up), matching slime's launch-router-then-register flow. vllm-router's
+        # MiniLB is a debug-only load balancer that requires STATIC prefill/decode URLs at
+        # construction, which slime never provides, so it can never work here. MiniLB stays off
+        # (RouterArgs defaults mini_lb=False); the old SLIME_VLLM_ROUTER_USE_RUST gate is removed.
 
     if any(f.name == "disable_health_check" for f in dataclasses.fields(type(router_args))):
         router_args.disable_health_check = True
@@ -1002,8 +1003,8 @@ def _start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool 
     if not process.is_alive():
         raise RuntimeError(
             f"Router subprocess exited (exitcode={process.exitcode}). "
-            "For vllm-router non-PD mode, install the Rust router (pip wheel with Router); "
-            "MiniLB is only valid with PD disaggregation. See slime.utils.http_utils run_router logs."
+            "Ensure the vllm-router (Rust) wheel is installed; both PD and non-PD rollout use it. "
+            "See slime.utils.http_utils run_router logs."
         )
     logger.info(f"Router launched at {router_ip}:{router_port}, Prometheus port: {router_args.prometheus_port}")
     return router_ip, router_port, router_args.prometheus_port


### PR DESCRIPTION
## What
`_start_router` defaulted PD to **MiniLB** (`mini_lb=True` unless `SLIME_VLLM_ROUTER_USE_RUST=1`). MiniLB (`vllm_router/mini_lb.py`) is a **debug-only** load balancer that **requires static `prefill_urls`/`decode_urls` at construction**. slime never provides those — it launches the router first and engines register **dynamically** via `POST /workers` — so MiniLB can never work in slime's flow.

## Fix
Remove the MiniLB activation and the dead `SLIME_VLLM_ROUTER_USE_RUST` gate. PD now uses the **full Rust router** (accepts dynamic worker registration like the non-PD path). MiniLB stays off via `RouterArgs`' own default (`mini_lb=False`) — **no explicit setter needed**. Also dropped the stale MiniLB mention from the router-startup-failure error message.

## Scope / caveat
Routing-layer fix only. PD end-to-end additionally needs the **engine-side KV transport** (`--kv-transfer-config`, currently NIXL) to initialize in the loaded vLLM engine — a separate, still-open blocker (`NIXL_ERR_BACKEND`). The Rust-router PD path was not run end-to-end here.

AI assistance (Claude Code) was used for this change.