### PR TITLE
fix(vllm): wait for engine health with no time limit (SGLang-style), gated by liveness

### DIFF
--- a/slime/backends/vllm_utils/vllm_engine.py
+++ b/slime/backends/vllm_utils/vllm_engine.py
@@ -538,9 +538,17 @@ def _wait_worker_process_alive(process: multiprocessing.Process, timeout_s: floa
     raise RuntimeError(f"vLLM worker process exited unexpectedly with code {process.exitcode}")
 
 
-def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None, timeout_s: float = 300.0) -> None:
-    """Wait until the vLLM server responds on ``GET /health``."""
-    start = time.time()
+def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None) -> None:
+    """Wait until the vLLM server responds on ``GET /health`` (no time limit, SGLang-style).
+
+    Loops until /health returns 200, or — for a managed subprocess — until it dies (fail fast via
+    ``process.is_alive()``). There is no overall deadline, so a slow-but-healthy startup (a large
+    MoE / DP engine loading + compiling + capturing CUDA graphs across replicas) is never
+    spuriously timed out. The per-probe ``timeout=3`` bounds each individual request so a single
+    stuck socket cannot wedge the loop. In external mode (``process is None``) there is no liveness
+    signal, so a permanently unreachable URL loops indefinitely by design (the external engine is
+    caller-managed). Mirrors slime's SGLang backend _wait_server_healthy.
+    """
     while True:
         try:
             response = requests.get(f"{base_url}/health", timeout=3)
@@ -551,8 +559,6 @@ def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None,
 
         if process is not None and not process.is_alive():
             raise RuntimeError(f"vLLM server exited unexpectedly with code {process.exitcode}")
-        if time.time() - start > timeout_s:
-            raise TimeoutError(f"Timeout waiting for vLLM server healthy: {base_url}")
         time.sleep(2)
 
 

--- a/tests/test_vllm_generate_endpoint.py
+++ b/tests/test_vllm_generate_endpoint.py
@@ -133,7 +133,7 @@ def _execute_case(case: VLLMGenerateCase):
     )
 
     try:
-        _wait_server_healthy(f"http://127.0.0.1:{server_port}", process, timeout_s=case.timeout_s)
+        _wait_server_healthy(f"http://127.0.0.1:{server_port}", process)
 
         rollout_args = Namespace(
             ci_test=False,


### PR DESCRIPTION
## What
`_wait_server_healthy` hardcoded a 300s deadline. A large engine exceeds it while still loading weights + compiling + capturing CUDA graphs — a Qwen3-30B-A3B-FP8 `dp=2` colocate engine hit `TimeoutError: Timeout waiting for vLLM server healthy` at 300s even though it became healthy seconds later.

## Fix
Match slime's **SGLang backend** `_wait_server_healthy`: loop until `/health` returns 200, or — for a **managed subprocess** — until it dies (fail fast via `process.is_alive()`), with **no overall deadline**. The `timeout_s` parameter is **removed entirely** (cleaner). The per-probe `timeout=3` on each `/health` GET is kept so a single stuck socket can't wedge the loop.

`_wait_worker_process_alive` (headless-worker stability check, different semantics) is unchanged.

## Note on external mode
In external mode (`process is None`) there is no subprocess whose death signals failure, so a permanently-unreachable URL loops indefinitely — by design, since the external engine is caller-managed (this mirrors how SGLang's own health wait behaves). `test_vllm_generate_endpoint.py` updated to drop the now-removed `timeout_s` kwarg.

AI assistance (Claude Code) was used for this change.