### PR TITLE
fix(ray): enable NCCL cuMem on cross-node train actors so MNNVL engages on GB200

### DIFF
--- a/slime/ray/actor_group.py
+++ b/slime/ray/actor_group.py
@@ -51,9 +51,7 @@ class RayTrainGroup:
         pg, reordered_bundle_indices, _reordered_gpu_ids = pg
 
         env_vars = {
-            # Default NCCL_CUMEM_ENABLE to "0" to prevent intermittent NCCL
-            # init errors observed when the vLLM side disables CUMEM.
-            "NCCL_CUMEM_ENABLE": os.environ.get("NCCL_CUMEM_ENABLE", "0"),
+            "NCCL_CUMEM_ENABLE": os.environ.get("NCCL_CUMEM_ENABLE", "1" if self._num_nodes > 1 else "0"),
             "NVTE_FP8_BLOCK_SCALING_FP32_SCALES": os.environ.get("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", "1"),
             **{name: "1" for name in NOSET_VISIBLE_DEVICES_ENV_VARS_LIST},
             **self.args.train_env_vars,


### PR DESCRIPTION
## Problem

On a multi-node **GB200 NVL72**, the Megatron train communicator — including the cross-node **EP alltoall** — never uses the **MNNVL** NVLink fabric. Every cross-node collective reports `MNNVL 0` and falls back to `NET/IB` (RoCE), despite the fabric being healthy and reachable.

## Root cause

MNNVL fabric P2P requires **CUDA cuMem fabric handles** (`cuMemCreate` with the fabric handle type). The train actors hard-set `NCCL_CUMEM_ENABLE=0` in `RayTrainGroup`, which disables cuMem entirely → no fabric handles → MNNVL can never engage, regardless of device visibility/topology.

Evidence (identical fabric detected in both, same `cliqueId`):
- cuMem default (1): `MNNVL 1 cliqueSize 8`, channels `via P2P/MNNVL`
- cuMem 0 (train actors): `MNNVL 0` on **every** comm, including single-rank ones

That `=0` default came from **sglang** colocate compatibility (sglang forces cuMem off). vime is **vLLM-only**, and cuMem=1 is compatible with vLLM colocate + `torch_memory_saver` offload — vLLM itself already enables the cuMem allocator for sleep mode.

## Fix

Default `NCCL_CUMEM_ENABLE=1` **only for cross-node train groups** (`num_nodes > 1`), where MNNVL fabric is the whole point. Single-node behavior is unchanged, and the value remains overridable via the `NCCL_CUMEM_ENABLE` env var.

```python
"NCCL_CUMEM_ENABLE": os.environ.get("NCCL_CUMEM_ENABLE", "1" if self._num_nodes > 1 else "0"),
```

## Validation

2-node 8×GB200 (Qwen3-30B-A3B, train TP4/PP1/EP8/ETP1 colocate, rollout vLLM TP2):

| | cuMem=0 (before) | cuMem=1 (after) |
|---|---|---|
| 8-rank EP comm | `nNodes 2 … MNNVL 0`, NET/IB | `nNodes 1 localRanks 8 cliqueSize 8 MNNVL 1`, `via P2P/MNNVL` |
| weight sync / EP alltoall / train step | (RoCE) | all succeed, no nccl error |
| train throughput | baseline | **~1.5–1.6× vs RoCE** |

No device-visibility (`CUDA_VISIBLE_DEVICES` / NOSET) change required — slime's device design is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)