### PR TITLE
ci: add always-on e2e-test-unit job (pytest tests/unit tests/utils)

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -616,6 +616,44 @@ jobs:
 
 
 
+  e2e-test-unit:
+    name: Unit & utils tests (pytest, in-image)
+    needs: pre-commit
+    # Always-on regression gate (like e2e-test-plugin-contracts): runs on every
+    # PR synchronize/label and on manual dispatch, no run-ci-* label required.
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: self-hosted
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Execute
+        shell: bash
+        run: |
+          # Run inside the CI image: it ships megatron + torch, which the
+          # tests/unit/backends/megatron_utils/update_weight tests need at
+          # import time. CPU/mock only -> no --gpus / no GPU lock.
+          docker run --rm \
+            --network host \
+            --ipc=host \
+            --shm-size=16g \
+            -e http_proxy \
+            -e https_proxy \
+            -e HTTP_PROXY \
+            -e HTTPS_PROXY \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+            -w "$GITHUB_WORKSPACE" \
+            inferactinc/public:vime-vllm-cu129-latest \
+            bash -lc '
+              set -euo pipefail
+              pip install -e . --no-deps --break-system-packages
+              pip install -q pytest --break-system-packages
+              python -m pytest tests/unit tests/utils
+            '
+
   e2e-test-changed-detect:
     needs: pre-commit
     if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'run-ci-changed'))

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -248,6 +248,44 @@ jobs:
 <% endif %>
 <% endfor %>
 
+  e2e-test-unit:
+    name: Unit & utils tests (pytest, in-image)
+    needs: pre-commit
+    # Always-on regression gate (like e2e-test-plugin-contracts): runs on every
+    # PR synchronize/label and on manual dispatch, no run-ci-* label required.
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: self-hosted
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Execute
+        shell: bash
+        run: |
+          # Run inside the CI image: it ships megatron + torch, which the
+          # tests/unit/backends/megatron_utils/update_weight tests need at
+          # import time. CPU/mock only -> no --gpus / no GPU lock.
+          docker run --rm \
+            --network host \
+            --ipc=host \
+            --shm-size=16g \
+            -e http_proxy \
+            -e https_proxy \
+            -e HTTP_PROXY \
+            -e HTTPS_PROXY \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+            -w "$GITHUB_WORKSPACE" \
+            inferactinc/public:vime-vllm-cu129-latest \
+            bash -lc '
+              set -euo pipefail
+              pip install -e . --no-deps --break-system-packages
+              pip install -q pytest --break-system-packages
+              python -m pytest tests/unit tests/utils
+            '
+
   e2e-test-changed-detect:
     needs: pre-commit
     if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'run-ci-changed'))


### PR DESCRIPTION
## What

Wires the **pytest-based** `tests/unit` + `tests/utils` suites into CI as a single dedicated, **always-on** job `e2e-test-unit`. Today these only run locally — nothing in any workflow executes them.

## Why a separate job (vs. folding into an existing one)

- Every existing job runs **one script per matrix entry** (`python tests/<file>` / `gpu_lock_exec.py`), never `pytest` on a directory.
- `tests/unit/backends/megatron_utils/update_weight/*` import `megatron.core` **at module load**, so they cannot run on the GitHub-hosted CPU `e2e-test-plugin-contracts` runner (no megatron there). They need the CI image.

So `e2e-test-unit` runs `pytest tests/unit tests/utils` **inside `inferactinc/public:vime-vllm-cu129-latest`** (ships megatron + torch) on the **self-hosted** runner, **0 GPUs**, **always-on** (no `run-ci-*` label, mirroring `e2e-test-plugin-contracts`). It does `needs: pre-commit` like the others.

## Coverage / risk

- `tests/unit` is **vime-original** (PRs #21/#22/#25) — covers the vLLM rollout/engine/arguments + colocate IPC weight-sync surface, i.e. the code most exposed to the ongoing slime→vime upstream sync.
- `tests/utils` is **mostly inherited from upstream slime** (#1204/#1742/#1776/#1866/#1874); only `test_vllm_config.py` is vime-adapted.
- Source-checked: **no** `cuda`/`.cuda()`/`device="cuda"`, no real `vllm`/`megatron` imports at test-file scope (megatron is transitive via the module-under-test). Pure CPU/mock → no `--gpus`, no GPU lock, no GPU contention with the other self-hosted jobs.

## Verification status (please confirm on the runner)

- ✅ Template edited + regenerated (`generate_github_workflows.py`); `pr-test.yml` is generated, not hand-edited.
- ✅ Generated YAML parses; 11 jobs; `check yaml` pre-commit hook passes.
- ✅ On a bare CPU box (no megatron): **149 passed**; the only failures were the 19 `update_weight` tests failing with `ModuleNotFoundError: megatron` — exactly what running **inside the image** fixes.
- ⏳ **Not yet executed inside the cu129 image** (the box I authored this on is arm64/cu13 and can't run that image). Please trigger via `workflow_dispatch` or a PR synchronize and confirm `e2e-test-unit` goes green; if the image lacks `pytest`, the job installs it.

## How to run

Always-on, so it fires on every PR `synchronize`/`labeled` and on manual dispatch:
```bash
gh workflow run pr-test.yml --repo vllm-project/vime --ref ci-unit-tests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)