### PR TITLE
feat: add critic wandb config logging (slime #1919)

### DIFF
--- a/vime/backends/megatron_utils/actor.py
+++ b/vime/backends/megatron_utils/actor.py
@@ -60,7 +60,7 @@ class MegatronTrainRayActor(TrainRayActor):
         init(args)
 
         if is_megatron_main_rank():
-            init_tracking(args, primary=False)
+            init_tracking(args, primary=False, role=role)
 
         self.prof = TrainProfiler(args)
 

--- a/vime/utils/wandb_utils.py
+++ b/vime/utils/wandb_utils.py
@@ -130,7 +130,7 @@ def reinit_wandb_primary_with_open_metrics(args, router_addr):
 
 
 def _compute_config_for_logging(args):
-    output = deepcopy(args.__dict__)
+    output = _args_to_config_dict(args)
 
     whitelist_env_vars = [
         "SLURM_JOB_ID",
@@ -138,11 +138,39 @@ def _compute_config_for_logging(args):
     ]
     output["env_vars"] = {k: v for k, v in os.environ.items() if k in whitelist_env_vars}
 
+    if getattr(args, "use_critic", False):
+        critic_args = _get_role_args_for_logging(args, role="critic")
+        output.update(_prefix_config_keys(_args_to_config_dict(critic_args), "critic"))
+
     return output
 
 
+def _args_to_config_dict(args):
+    return deepcopy(args.__dict__)
+
+
+def _prefix_config_keys(config, prefix):
+    return {f"{prefix}/{key}": value for key, value in config.items()}
+
+
+def _get_role_args_for_logging(args, role):
+    if getattr(args, "megatron_config_path", None) is None:
+        return args
+
+    from vime.utils.arguments import parse_megatron_role_args
+
+    return parse_megatron_role_args(args, args.megatron_config_path, role=role)
+
+
+def _compute_secondary_config_for_logging(args, role=None):
+    config = _args_to_config_dict(args)
+    if role == "critic":
+        return _prefix_config_keys(config, "critic")
+    return config
+
+
 # https://docs.wandb.ai/guides/track/log/distributed-training/#track-all-processes-to-a-single-run
-def init_wandb_secondary(args):
+def init_wandb_secondary(args, role=None):
     wandb_run_id = getattr(args, "wandb_run_id", None)
     if wandb_run_id is None:
         return
@@ -170,7 +198,7 @@ def init_wandb_secondary(args):
         "id": wandb_run_id,
         "entity": args.wandb_team,
         "project": args.wandb_project,
-        "config": args.__dict__,
+        "config": _compute_secondary_config_for_logging(args, role=role),
         "resume": "allow",
         "reinit": True,
         "settings": wandb.Settings(**settings_kwargs),


### PR DESCRIPTION
## What
Sync of upstream **THUDM/slime#1919** ("add critic wandb config") into vime (RFC #107). ✅ MERGE — clean `slime/→vime/` port.

When `use_critic` is set, the secondary W&B run now also logs the **critic** role's megatron config under a `critic/`-prefixed key namespace (parsed via `parse_megatron_role_args` from `megatron_config_path`), alongside the actor's config.

## Changes
- **vime/utils/wandb_utils.py** — `_compute_config_for_logging` merges critic args when `use_critic`; new helpers `_args_to_config_dict` / `_prefix_config_keys` / `_get_role_args_for_logging` / `_compute_secondary_config_for_logging`; `init_wandb_secondary(args, role=None)`.
- **vime/backends/megatron_utils/actor.py** — thread `role` into `init_tracking(..., role=role)`.

## vime notes
- `init_tracking` already accepts `**kwargs` (`vime/utils/logging_utils.py`) and `parse_megatron_role_args` already exists in vime — structural-clean port.
- The vLLM rollout caller (`vime/ray/rollout.py`) keeps `role=None` default; critic config logging is train-actor-side only, matching slime's scope.

## Validation
- cpu-contract suite (arg-validation + 4 plugin_contracts) PASS in the cu129 CI image on H200.
- `pre-commit run` (pinned hooks) PASS.
- Logging-only change: the new path only executes under a live W&B run (`wandb_run_id` set), so GPU e2e adds no coverage here.

Refs: THUDM/slime#1919, #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)
