### PR TITLE
[Docker] upgrade torch_memory_saver to a193d9dd + reduce host memory (slime #1916, #1924, #1932)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ ARG PATCH_VERSION=latest
 ARG MEGATRON_COMMIT=1dcf0dafa884ad52ffb243625717a3471643e087
 
 ARG ENABLE_CUDA_13=0
+ARG TMS_CUDA_MAJOR=
 
 # ======================================== Setup =============================================
 
@@ -82,9 +83,12 @@ RUN NVCC_APPEND_FLAGS="--threads 4" \
 RUN git clone https://github.com/NVIDIA/Megatron-LM.git --recursive && \
     cd Megatron-LM && git checkout ${MEGATRON_COMMIT}
 
-# Pinned to d64a639 (older than vime upstream's a193d9d); the newer commit
-# requires TMS_CUDA_MAJOR env var to build a multi-CUDA wheel.
-RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@d64a639 --no-cache-dir --force-reinstall
+# torch_memory_saver pinned to a193d9dd (upstream slime #1916). The newer commit
+# ships a multi-CUDA wheel and requires TMS_CUDA_MAJOR at build time; default it
+# to the running torch's CUDA major (slime #1924).
+RUN TMS_CUDA_MAJOR="${TMS_CUDA_MAJOR:-$(python -c 'import torch; print(torch.version.cuda.split(".")[0])')}" && \
+    export TMS_CUDA_MAJOR && \
+    pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@a193d9dd1b877d33c64a41cfb3db9f867df2d926 --no-cache-dir --force-reinstall
 RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@bridge --no-deps --no-build-isolation
 RUN pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation
 

--- a/docker/patch/latest/megatron.patch
+++ b/docker/patch/latest/megatron.patch
@@ -49,6 +49,99 @@ index a5b6c009b..22794d7e6 100644
              ),
          )
  
+diff --git a/megatron/core/distributed/distributed_data_parallel.py b/megatron/core/distributed/distributed_data_parallel.py
+index 55179ff30..43ef12a29 100644
+--- a/megatron/core/distributed/distributed_data_parallel.py
++++ b/megatron/core/distributed/distributed_data_parallel.py
+@@ -45,6 +45,7 @@ class DistributedDataParallel(_BaseDataParallel):
+         module: torch.nn.Module,
+         disable_bucketing: bool = False,
+         pg_collection: Optional[ProcessGroupCollection] = None,
++        disable_grad_buffers_cpu_backup: bool = False,
+     ):
+         super().__init__(config=config, module=module)
+         if has_config_logger_enabled(config):
+@@ -209,6 +210,7 @@ class DistributedDataParallel(_BaseDataParallel):
+                         param_and_grad_dtype_to_indices[(param_dtype, grad_dtype)],
+                         self.ddp_config.nccl_ub,
+                         pg_collection,
++                        disable_grad_buffers_cpu_backup=disable_grad_buffers_cpu_backup,
+                     )
+                 )
+ 
+diff --git a/megatron/core/distributed/param_and_grad_buffer.py b/megatron/core/distributed/param_and_grad_buffer.py
+index 088374fbf..7a416f8e4 100644
+--- a/megatron/core/distributed/param_and_grad_buffer.py
++++ b/megatron/core/distributed/param_and_grad_buffer.py
+@@ -599,6 +599,7 @@ class _ParamAndGradBuffer:
+         param_indices: List[int],
+         nccl_ub: bool,
+         pg_collection: Optional[ProcessGroupCollection] = None,
++        disable_grad_buffers_cpu_backup: bool = False,
+     ):
+ 
+         if pg_collection is None:
+@@ -755,6 +756,9 @@ class _ParamAndGradBuffer:
+ 
+         if self.nccl_ub:
+             # If nccl_ub is True, use nccl_allocator to allocate memory for param_data/grad_data.
++            assert not disable_grad_buffers_cpu_backup, (
++                "disable_grad_buffers_cpu_backup is not supported with nccl_ub=True"
++            )
+             nccl_allocator.init()
+             pool = nccl_allocator.create_nccl_mem_pool(
+                 symmetric=not self.ddp_config.disable_symmetric_registration
+@@ -773,8 +777,30 @@ class _ParamAndGradBuffer:
+             torch.distributed.barrier()
+         else:
+             # If nccl_ub is False, mem_alloc_context is nullcontext.
++            # Individual param/grad contexts below handle TMS regions separately.
+             mem_alloc_context = nullcontext
+ 
++        def _make_no_backup_context(tag, disable):
++            if disable:
++                try:
++                    from torch_memory_saver import torch_memory_saver
++                except ImportError as e:
++                    raise ImportError(
++                        "disable_grad_buffers_cpu_backup=True requires torch_memory_saver. "
++                        "Install with: pip install torch-memory-saver"
++                    ) from e
++
++                return partial(
++                    torch_memory_saver.region,
++                    tag=tag,
++                    enable_cpu_backup=False,
++                )
++            return nullcontext
++
++        grad_mem_alloc_context = _make_no_backup_context(
++            "grad_buffer", disable_grad_buffers_cpu_backup
++        )
++
+         with mem_alloc_context():
+             # For MXFP8 param: Create a shared buffer for param AG and grad RS for memory efficiency
+             # The buffer is mapped to weight gradients whose dtype is either bf16 or FP32.
+@@ -803,12 +829,13 @@ class _ParamAndGradBuffer:
+                         device=torch.cuda.current_device(),
+                         requires_grad=False,
+                     )
+-                self.grad_data = torch.zeros(
+-                    self.numel,
+-                    dtype=self.grad_dtype,
+-                    device=torch.cuda.current_device(),
+-                    requires_grad=False,
+-                )
++                with grad_mem_alloc_context():
++                    self.grad_data = torch.zeros(
++                        self.numel,
++                        dtype=self.grad_dtype,
++                        device=torch.cuda.current_device(),
++                        requires_grad=False,
++                    )
+ 
+         self.grad_data_size = 0
+         self.param_data_size = 0
 diff --git a/megatron/core/extensions/transformer_engine.py b/megatron/core/extensions/transformer_engine.py
 index ef8527e9e..57fbe5bd7 100644
 --- a/megatron/core/extensions/transformer_engine.py
@@ -809,3 +902,28 @@ index 17df57dda..260a5f6c8 100644
              **kwargs,
          )
          self._vocab = self._tokenizer.get_vocab()
+diff --git a/megatron/training/training.py b/megatron/training/training.py
+index e9736ac08..a83482bf1 100644
+--- a/megatron/training/training.py
++++ b/megatron/training/training.py
+@@ -1327,6 +1327,12 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
+         # Wait for the default stream to complete before starting ddp_stream
+         ddp_stream.wait_stream(torch.cuda.current_stream())
+         # Make ddp_stream start after whatever the default stream already queued
++        dp_extra_kwargs = {}
++        if DP is DDP:
++            dp_extra_kwargs['disable_grad_buffers_cpu_backup'] = getattr(
++                args, 'disable_grad_buffers_cpu_backup', False
++            )
++
+         with torch.cuda.stream(ddp_stream):
+             model = [
+                 DP(
+@@ -1337,6 +1343,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
+                     # model chunks is overlapped with compute anyway.
+                     disable_bucketing=(model_chunk_idx > 0)
+                     or args.overlap_param_gather_with_optimizer_step,
++                    **dp_extra_kwargs,
+                 )
+                 for (model_chunk_idx, model_chunk) in enumerate(model)
+             ]

--- a/docker/version.txt
+++ b/docker/version.txt
@@ -1,1 +1,1 @@
-nightly-dev-20260430b
+nightly-dev-20260519a

--- a/vime/backends/megatron_utils/update_weight/common.py
+++ b/vime/backends/megatron_utils/update_weight/common.py
@@ -135,7 +135,7 @@ def named_params_and_buffers(
 def _maybe_get_cpu_backup(x: torch.Tensor):
     from torch_memory_saver import torch_memory_saver
 
-    if (cpu_tensor := torch_memory_saver.get_cpu_backup(x)) is not None:
+    if (cpu_tensor := torch_memory_saver.get_cpu_backup(x, zero_copy=True)) is not None:
         return cpu_tensor
 
     return x

--- a/vime/ray/actor_group.py
+++ b/vime/ray/actor_group.py
@@ -62,11 +62,20 @@ class RayTrainGroup:
         if self.args.offload_train and self.args.train_backend == "megatron":
             import torch_memory_saver
 
-            dynlib_path = os.path.join(
-                os.path.dirname(os.path.dirname(torch_memory_saver.__file__)),
+            for path in [
+                "torch_memory_saver_hook_mode_preload_cu12.abi3.so",
                 "torch_memory_saver_hook_mode_preload.abi3.so",
-            )
-            assert os.path.exists(dynlib_path), f"LD_PRELOAD so file {dynlib_path} does not exist."
+            ]:
+                dynlib_path = os.path.join(
+                    os.path.dirname(os.path.dirname(torch_memory_saver.__file__)),
+                    path,
+                )
+                if os.path.exists(dynlib_path):
+                    break
+            else:
+                raise FileNotFoundError(
+                    "Cannot find torch_memory_saver dynamic library. Please make sure torch_memory_saver is properly installed."
+                )
 
             env_vars["LD_PRELOAD"] = dynlib_path
             env_vars["TMS_INIT_ENABLE"] = "1"

--- a/vime/utils/arguments.py
+++ b/vime/utils/arguments.py
@@ -1176,6 +1176,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 choices=["torch", "memray"],
                 default="torch",
             )
+            reset_arg(parser, "--record-memory-history", action="store_true", default=False)
             parser.add_argument("--check-weight-update-equal", action="store_true")
             return parser
 
@@ -1763,6 +1764,9 @@ def slime_validate_args(args):
 
     if args.use_critic:
         args.offload_train = True
+
+    if args.offload_train:
+        args.disable_grad_buffers_cpu_backup = True
 
     if args.eval_function_path is None:
         args.eval_function_path = args.rollout_function_path


### PR DESCRIPTION
## What
RFC #107 **Batch 1** — three build-coupled upstream slime PRs:

| slime PR | Title | Disposition |
|---|---|---|
| [#1916](https://github.com/THUDM/slime/pull/1916) | [docker] update torch memory saver | 🔧 PORT (was SKIP) |
| [#1924](https://github.com/THUDM/slime/pull/1924) | Reduce host memory with upgraded tms | ✅ MERGE |
| [#1932](https://github.com/THUDM/slime/pull/1932) | save host memory | ✅ MERGE (folded) |

## Why co-merged
#1916 bumps `torch_memory_saver` `d64a639 → a193d9dd`. The new wheel's `setup.py` (lines 117-124) **raises `RuntimeError` on CUDA builds unless `TMS_CUDA_MAJOR` is set** — only #1924 adds that plumbing, so a bare bump breaks the image build. #1932 then reorders the `offload_train → disable_grad_buffers_cpu_backup` assignment to sit **after** the `use_critic → offload_train=True` block (so critic runs get it); since it edits the exact line #1924 introduces, it's folded in here (can't apply to main without #1924).

## Changes
- **docker/Dockerfile** — `ARG TMS_CUDA_MAJOR`; tms pin → `a193d9dd`, default CUDA major from torch.
- **docker/patch/latest/megatron.patch** — +3 hunks: DDP `_make_no_backup_context`, `param_and_grad_buffer` no-backup region, `training/training.py` `dp_extra_kwargs`.
- **docker/version.txt** — `nightly-dev-20260519a`.
- **vime/ray/actor_group.py** — tms `.so` loader tries `_cu12`-suffixed name then unsuffixed.
- **vime/backends/megatron_utils/update_weight/common.py** — `get_cpu_backup(x, zero_copy=True)`.
- **vime/utils/arguments.py** — `--record-memory-history`; `offload_train ⇒ disable_grad_buffers_cpu_backup` (after `use_critic`, per #1932).

## Validation
- **Image build (arm64/cu129, from this branch):** tms wheel builds with `TMS_CUDA_MAJOR` ✅; `megatron.patch` applied via `git apply --3way` **cleanly to all 21 files** incl. the 3 grafted hunks (`distributed_data_parallel.py`, `param_and_grad_buffer.py`, `training/training.py`) ✅.
- **cpu suite** (`test_megatron_argument_validation.py` + plugin_contracts) PASS in the cu129 image — confirms the `arguments.py` change.
- **GPU e2e: pending** — add a `run-ci-*` label (or `gh workflow run pr-test.yml`) to exercise `offload_train` on the rebuilt image. (Was blocked tonight by an H200 access outage; the x86 image rebuild + offload smoke can run once a runner is up.)

Refs: THUDM/slime#1916, THUDM/slime#1924, THUDM/slime#1932, #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)
