### PR TITLE
[Doc] align Claude skills with vime APIs

### DIFF
--- a/.claude/skills/add-dynamic-filter/SKILL.md
+++ b/.claude/skills/add-dynamic-filter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-dynamic-filter
-description: Guide for adding dynamic/filter hooks in slime rollout pipeline. Use when user wants sample-group selection during rollout, buffer filtering before training, or per-sample masking/processing hooks.
+description: Guide for adding dynamic/filter hooks in the vime rollout pipeline. Use when user wants sample-group selection during rollout, buffer filtering before training, or per-sample masking/processing hooks.
 ---
 
 # Add Dynamic Filter
@@ -27,7 +27,7 @@ Use this skill when:
 
 ### Step 2: Implement the Function Signature
 
-Dynamic sampling filter (called in `slime/rollout/vllm_rollout.py`):
+Dynamic sampling filter (called in `vime/rollout/vllm_rollout.py`; one group = `list[Sample]` with length `n_samples_per_prompt`):
 
 ```python
 def filter_function(args, samples, **kwargs):
@@ -37,22 +37,24 @@ def filter_function(args, samples, **kwargs):
 Preferred return type:
 
 ```python
-from slime.rollout.filter_hub.base_types import DynamicFilterOutput
+from vime.rollout.filter_hub.base_types import DynamicFilterOutput
 
 return DynamicFilterOutput(keep=True, reason=None)
 ```
 
-Buffer filter (called in `slime/rollout/data_source.py`):
+Buffer filter (called in `vime/rollout/data_source.py`; default is `vime.rollout.data_source.pop_first`):
 
 ```python
-def buffer_filter(args, rollout_id, buffer, num_samples):
+def buffer_filter(args, rollout_id, buffer: list[list[Sample]], num_samples: int) -> list[list[Sample]]:
     return selected_groups
 ```
 
-Rollout sample filter:
+`rollout_id` is often `None` when the buffer invokes the filter.
+
+Rollout sample filter (mutates `Sample.remove_sample` on the train batch):
 
 ```python
-def rollout_sample_filter(args, samples):
+def filter_function(args, groups: list[list[Sample]]) -> None:
     # modify sample.remove_sample in-place where needed
 ```
 
@@ -74,9 +76,9 @@ def process_all_samples(args, all_samples, data_source):
 Example wiring:
 
 ```bash
---dynamic-sampling-filter-path slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std
+--dynamic-sampling-filter-path vime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std
 --buffer-filter-path <module>.buffer_filter
---rollout-sample-filter-path <module>.rollout_sample_filter
+--rollout-sample-filter-path <module>.filter_function
 --rollout-all-samples-process-path <module>.process_all_samples
 ```
 
@@ -95,7 +97,7 @@ Example wiring:
 
 ## Reference Locations
 
-- Dynamic filter types: `slime/rollout/filter_hub/base_types.py`
-- Dynamic filter example: `slime/rollout/filter_hub/dynamic_sampling_filters.py`
-- Rollout generation hook points: `slime/rollout/vllm_rollout.py`
-- Buffer filter hook point: `slime/rollout/data_source.py`
+- Dynamic filter types: `vime/rollout/filter_hub/base_types.py`
+- Dynamic filter example: `vime/rollout/filter_hub/dynamic_sampling_filters.py`
+- Rollout generation hook points: `vime/rollout/vllm_rollout.py`
+- Buffer filter hook point: `vime/rollout/data_source.py`

--- a/.claude/skills/add-dynamic-filter/SKILL.md
+++ b/.claude/skills/add-dynamic-filter/SKILL.md
@@ -51,10 +51,10 @@ def buffer_filter(args, rollout_id, buffer: list[list[Sample]], num_samples: int
 
 `rollout_id` is often `None` when the buffer invokes the filter.
 
-Rollout sample filter (mutates `Sample.remove_sample` on the train batch):
+Rollout sample filter (mutates `Sample.remove_sample` on the train batch; `samples` is `list[list[Sample]]`):
 
 ```python
-def filter_function(args, groups: list[list[Sample]]) -> None:
+def rollout_sample_filter(args, samples):
     # modify sample.remove_sample in-place where needed
 ```
 
@@ -78,7 +78,7 @@ Example wiring:
 ```bash
 --dynamic-sampling-filter-path vime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std
 --buffer-filter-path <module>.buffer_filter
---rollout-sample-filter-path <module>.filter_function
+--rollout-sample-filter-path <module>.rollout_sample_filter
 --rollout-all-samples-process-path <module>.process_all_samples
 ```
 

--- a/.claude/skills/add-eval-dataset-config/SKILL.md
+++ b/.claude/skills/add-eval-dataset-config/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: add-eval-dataset-config
-description: Guide for adding and validating evaluation dataset configuration in slime. Use when user wants to configure eval datasets via --eval-config or --eval-prompt-data, add per-dataset overrides, or customize evaluation rollout behavior.
+description: Guide for adding and validating evaluation dataset configuration in vime. Use when user wants to configure eval datasets via --eval-config or --eval-prompt-data, add per-dataset overrides, or customize evaluation rollout behavior.
 ---
 
 # Add Eval Dataset Config
 
-Configure evaluation datasets in slime with explicit dataset-level overrides and predictable runtime behavior.
+Configure evaluation datasets in vime with explicit dataset-level overrides and predictable runtime behavior.
 
 ## When to Use
 
@@ -53,7 +53,7 @@ eval:
 
 ### Step 3: Understand Override Priority
 
-`slime/utils/eval_config.py` resolves fields in this order:
+`vime/utils/eval_config.py` resolves fields in this order:
 
 1. Dataset-level values in `eval.datasets[*]`
 2. `eval.defaults`
@@ -67,8 +67,10 @@ Common overridable fields include:
 
 ### Step 4: Wire Eval Function if Needed
 
-By default, eval uses `--eval-function-path` (defaults to rollout function path).
+By default, eval uses `--eval-function-path`, which is set to `--rollout-function-path` in `slime_validate_args` when unset.
 Use a separate eval function when inference/eval behavior must differ from training rollout.
+
+Note: `--group-rm` is not supported for eval rollout.
 
 ### Step 5: Validate Parsing and Runtime
 
@@ -85,7 +87,7 @@ Use a separate eval function when inference/eval behavior must differ from train
 
 ## Reference Locations
 
-- Eval config model: `slime/utils/eval_config.py`
-- Eval config resolution: `slime/utils/arguments.py`
-- Eval rollout path: `slime/rollout/vllm_rollout.py`
+- Eval config model: `vime/utils/eval_config.py`
+- Eval config resolution: `vime/utils/arguments.py`
+- Eval rollout path: `vime/rollout/vllm_rollout.py`
 - Customization docs: `docs/en/get_started/customization.md`

--- a/.claude/skills/add-reward-function/SKILL.md
+++ b/.claude/skills/add-reward-function/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: add-reward-function
-description: Guide for adding a custom reward function in slime and wiring it through --custom-rm-path (and optional reward post-processing). Use when user wants new reward logic, remote/service reward integration, or task-specific reward shaping.
+description: Guide for adding a custom reward function in vime and wiring it through --custom-rm-path (and optional reward post-processing). Use when user wants new reward logic, remote/service reward integration, or task-specific reward shaping.
 ---
 
 # Add Reward Function
 
-Implement custom reward logic and connect it to slime rollout/training safely.
+Implement custom reward logic and connect it to vime rollout/training safely.
 
 ## When to Use
 
@@ -21,14 +21,14 @@ Use this skill when:
 
 Pick one of these:
 
-- Single-sample mode (`--group-rm` disabled): custom function gets one `Sample`
-- Group/batch mode (`--group-rm` enabled): custom function gets `list[Sample]`
+- Single-sample mode (`--group-rm` disabled): `--custom-rm-path` function receives one `Sample` via `async_rm`
+- Group mode (`--group-rm` enabled): the same path receives `list[Sample]` (one prompt group) via `batched_async_rm`
 
-`slime.rollout.rm_hub.__init__.py` calls your function via `--custom-rm-path`.
+The imported symbol name is whatever you put after the last `.` in `--custom-rm-path`; it must be `async def`.
 
 ### Step 2: Create Reward Module
 
-Create `slime/rollout/rm_hub/<your_rm>.py`.
+Create `vime/rollout/rm_hub/<your_rm>.py`.
 
 Supported signatures:
 
@@ -66,14 +66,14 @@ Wire with:
 --custom-reward-post-process-path <module>.post_process_rewards
 ```
 
-This hook is consumed in `slime/ray/rollout.py`.
+This hook is consumed in `vime/ray/rollout.py`.
 
 ### Step 5: Wire and Validate
 
 Use:
 
 ```bash
---custom-rm-path slime.rollout.rm_hub.<your_rm>.custom_rm
+--custom-rm-path vime.rollout.rm_hub.<your_rm>.custom_rm
 ```
 
 ## Common Mistakes
@@ -82,9 +82,10 @@ Use:
 - Mixing scalar rewards and reward dicts without `reward_key` config
 - Doing blocking network calls without async handling
 - Forgetting to validate reward behavior on truncated/failed samples
+- Using synchronous `def` instead of `async def` for `--custom-rm-path`
 
 ## Reference Locations
 
-- Reward dispatch: `slime/rollout/rm_hub/__init__.py`
-- Reward post-process hook: `slime/ray/rollout.py`
+- Reward dispatch: `vime/rollout/rm_hub/__init__.py`
+- Reward post-process hook: `vime/ray/rollout.py`
 - Customization docs: `docs/en/get_started/customization.md`

--- a/.claude/skills/add-rollout-function/SKILL.md
+++ b/.claude/skills/add-rollout-function/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: add-rollout-function
-description: Guide for adding a new rollout function in slime and wiring it through --rollout-function-path. Use when user wants to implement custom rollout data generation logic, custom train/eval rollout outputs, or migrate from the default vLLM rollout path.
+description: Guide for adding a new rollout function in vime and wiring it through --rollout-function-path. Use when user wants to implement custom rollout data generation logic, custom train/eval rollout outputs, or migrate from the default vLLM rollout path.
 ---
 
 # Add Rollout Function
 
-Implement a custom rollout function and integrate it safely with slime training/eval flow.
+Implement a custom rollout function and integrate it safely with vime training/eval flow.
 
 ## When to Use
 
 Use this skill when:
 
 - User asks to add a new rollout task or rollout generation function
-- User asks to replace default `slime.rollout.vllm_rollout.generate_rollout`
+- User asks to replace default `vime.rollout.vllm_rollout.generate_rollout`
 - User asks to customize train/eval data generation behavior
 
 ## Step-by-Step Guide
@@ -21,24 +21,28 @@ Use this skill when:
 
 Start from one of these references:
 
-- Async RL-style rollout: `slime/rollout/vllm_rollout.py`
-- Simple SFT-style rollout: `slime/rollout/sft_rollout.py`
+- Async RL-style rollout: `vime/rollout/vllm_rollout.py`
+- Simple SFT-style rollout: `vime/rollout/sft_rollout.py`
 
 If the task needs engine-based async generation and rewards, use the vLLM path as base.
 If the task is file/buffer-driven and simple, use sft path as base.
 
 ### Step 2: Create the New Rollout Module
 
-Create a new file, for example: `slime/rollout/<your_rollout>.py`
+Create a new file, for example: `vime/rollout/<your_rollout>.py`
 
-Required callable signature:
+Required callable signature (vLLM default path uses `data_source`):
 
 ```python
 def generate_rollout(args, rollout_id, data_source, evaluation=False) -> RolloutFnTrainOutput | RolloutFnEvalOutput:
     ...
 ```
 
-Return types are defined in `slime/rollout/base_types.py`.
+The SFT example (`vime/rollout/sft_rollout.py`) names the third argument `data_buffer` and asserts `not evaluation`.
+
+Default vLLM rollout also expects `args.rollout_global_dataset` (do not pass `--disable-rollout-global-dataset` unless your custom path supports it).
+
+Return types are defined in `vime/rollout/base_types.py`.
 
 ### Step 3: Implement Train and Eval Branches Explicitly
 
@@ -48,7 +52,7 @@ Return types are defined in `slime/rollout/base_types.py`.
 Minimal skeleton:
 
 ```python
-from slime.rollout.base_types import RolloutFnTrainOutput, RolloutFnEvalOutput
+from vime.rollout.base_types import RolloutFnTrainOutput, RolloutFnEvalOutput
 
 
 def generate_rollout(args, rollout_id, data_source, evaluation=False):
@@ -83,12 +87,12 @@ If partial rollout or masking logic is involved, keep `loss_mask` semantics cons
 Set your function path via CLI:
 
 ```bash
---rollout-function-path slime.rollout.<your_rollout>.generate_rollout
+--rollout-function-path vime.rollout.<your_rollout>.generate_rollout
 ```
 
 The default and signature expectation are documented in:
 
-- `slime/utils/arguments.py`
+- `vime/utils/arguments.py`
 - `docs/en/get_started/customization.md`
 
 ## Common Mistakes
@@ -100,9 +104,9 @@ The default and signature expectation are documented in:
 
 ## Reference Locations
 
-- Default rollout: `slime/rollout/vllm_rollout.py`
-- Simple custom example: `slime/rollout/sft_rollout.py`
-- Output dataclasses: `slime/rollout/base_types.py`
-- Wiring/loading: `slime/ray/rollout.py`
-- Argument definition: `slime/utils/arguments.py`
+- Default rollout: `vime/rollout/vllm_rollout.py`
+- Simple custom example: `vime/rollout/sft_rollout.py`
+- Output dataclasses: `vime/rollout/base_types.py`
+- Wiring/loading: `vime/ray/rollout.py`
+- Argument definition: `vime/utils/arguments.py`
 - Customization docs: `docs/en/get_started/customization.md`

--- a/.claude/skills/add-tests-and-ci/SKILL.md
+++ b/.claude/skills/add-tests-and-ci/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: add-tests-and-ci
-description: Guide for adding or updating slime tests and CI wiring. Use when tasks require new test cases, CI registration, test matrix updates, or workflow template changes.
+description: Guide for adding or updating vime tests and CI wiring. Use when tasks require new test cases, CI registration, test matrix updates, or workflow template changes.
 ---
 
 # Add Tests and CI
 
-Add reliable tests and integrate them with slime CI flow.
+Add reliable tests and integrate them with vime CI flow.
 
 ## When to Use
 
@@ -20,9 +20,10 @@ Use this skill when:
 
 ### Step 1: Pick the Right Test Pattern
 
-- Follow existing naming: `tests/test_<feature>.py`
+- Follow existing naming: `tests/test_<feature>.py` or `tests/plugin_contracts/test_*.py`
 - Start from nearest existing test file for your model/path
 - Keep test scope small and behavior-focused
+- Plugin hook contracts under `tests/plugin_contracts/` validate `--rollout-function-path`, filters, and `--custom-rm-path` loading (no GPU; PR label `run-ci-plugin-contracts`)
 
 ### Step 2: Keep CI Compatibility
 
@@ -62,6 +63,7 @@ Include:
 - Adding tests without following existing constants/conventions
 - Making tests too large or non-deterministic
 - Skipping local validation and relying only on remote CI
+- Using `slime.*` module paths in test CLI strings (use `vime.*`)
 
 ## Reference Locations
 


### PR DESCRIPTION
## Summary

- Refresh five `.claude/skills/*` guides after the slime → vime rename
- Fix hook signatures and wiring examples (dynamic/buffer/sample filters, rollout, reward, eval config)
- Document SFT `data_buffer`, `rollout_global_dataset`, eval `eval-function-path` fallback, and plugin-contract CI label

## Test plan

- [x] Cross-checked against `vime/` source and `tests/plugin_contracts/`
- [x] `load_function` paths smoke-tested in A800-server2 `vime_v22` container
- [x] `pre-commit run --files` on changed SKILL.md files