### PR TITLE
fix(ray): default cuMem on cross-node train actors

### DIFF
--- a/vime/ray/actor_group.py
+++ b/vime/ray/actor_group.py
@@ -51,9 +51,7 @@ class RayTrainGroup:
         pg, reordered_bundle_indices, _reordered_gpu_ids = pg
 
         env_vars = {
-            # Default NCCL_CUMEM_ENABLE to "0" to prevent intermittent NCCL
-            # init errors observed when the vLLM side disables CUMEM.
-            "NCCL_CUMEM_ENABLE": os.environ.get("NCCL_CUMEM_ENABLE", "0"),
+            "NCCL_CUMEM_ENABLE": os.environ.get("NCCL_CUMEM_ENABLE", "1" if self._num_nodes > 1 else "0"),
             "NVTE_FP8_BLOCK_SCALING_FP32_SCALES": os.environ.get("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", "1"),
             **{name: "1" for name in NOSET_VISIBLE_DEVICES_ENV_VARS_LIST},
             **self.args.train_env_vars,


### PR DESCRIPTION
Default NCCL_CUMEM_ENABLE to 1 for multi-node Megatron train actors so MNNVL can engage, while preserving explicit env overrides.\n\nVerification: /home/aoshen/vime/.venv/bin/python -m py_compile vime/ray/actor_group.py