### PR TITLE
revert: [Bugfix][Rollout] Record prefix_cache_hit_rate from vLLM usage

### DIFF
--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -481,11 +481,6 @@ def build_vllm_cmd_and_env(server_args: dict[str, Any]) -> tuple[list[str], dict
 
     if getattr(args, "use_rollout_routing_replay", False):
         cmd += ["--enable-return-routed-experts"]
-    # Prefix-cache accounting: vLLM only emits usage.prompt_tokens_details.cached_tokens
-    # (the numerator behind rollout/prefix_cache_hit_rate) when the OpenAI frontend is
-    # started with this flag. It lives on FrontendArgs, not AsyncEngineArgs, so it is NOT
-    # reachable via --vllm-* auto-forwarding and must be set explicitly here.
-    cmd += ["--enable-prompt-tokens-details"]
 
     # gpu_memory_utilization: no vime-forced default. In colocate, training and rollout do not
     # occupy the GPU simultaneously (sleep/offload cycles), so vLLM's own default is fine. A user

--- a/vime/rollout/vllm_rollout.py
+++ b/vime/rollout/vllm_rollout.py
@@ -157,11 +157,6 @@ def _vllm_meta_from_generate_choice(args: Namespace, choice: dict, usage: dict |
     if usage:
         meta["prompt_tokens"] = usage.get("prompt_tokens", 0)
         meta["completion_tokens"] = usage.get("completion_tokens", 0)
-        # vLLM reports the prefix-cache hit count nested under prompt_tokens_details
-        # (only populated when the server runs with --enable-prompt-tokens-details).
-        # Surface it so Sample.PrefixCacheInfo.add can populate prefix_cache_hit_rate;
-        # without this the numerator is pinned to 0 and the metric always reads 0.
-        meta["cached_tokens"] = (usage.get("prompt_tokens_details") or {}).get("cached_tokens", 0)
     return meta
 
 


### PR DESCRIPTION
Reverts PR #83 / commit b502fed.

Removes the explicit `--enable-prompt-tokens-details` server flag and the `cached_tokens` extraction from vLLM usage so the change can be split out cleanly.

Verification: /home/aoshen/vime/.venv/bin/python -m py_compile vime/backends/vllm_utils/vllm_engine.py vime/rollout/vllm_rollout.py