### PR TITLE
refactor(vllm): streamline rollout config and weight-update wiring

### DIFF
--- a/vime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -6,7 +6,6 @@ import socket
 import time
 from argparse import Namespace
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any
 
 import ray
 import torch
@@ -339,6 +338,7 @@ class UpdateWeightFromDistributed:
         """
         Lock → broadcast → clear → unlock → pbar++. Lock prevents NCCL deadlock.
         """
+        # lock the rollout engines to prevent dead lock on broadcast.
         while not ray.get(self.rollout_engine_lock.acquire.remote()):
             time.sleep(0.1)
 
@@ -363,7 +363,7 @@ def connect_rollout_engines_from_distributed(
     group_name: str,
     rollout_engines: Sequence[ActorHandle],
     engine_gpu_counts: Sequence[int] | None = None,
-) -> Any:
+) -> dist.ProcessGroup:
     """
     Create NCCL group: training rank 0 + all engine GPUs. Blocks until joined.
 
@@ -426,19 +426,20 @@ def connect_rollout_engines_from_distributed(
 def disconnect_rollout_engines_from_distributed(
     args: Namespace,
     group_name: str,
-    model_update_groups: Any,
+    model_update_groups: dist.ProcessGroup,
     rollout_engines: Sequence[ActorHandle],
 ) -> None:
     """
     Destroy NCCL on training and engines.
     """
     refs = [engine.destroy_weights_update_group.remote(group_name) for engine in rollout_engines]
+    dist.destroy_process_group(model_update_groups)
     ray.get(refs)
 
 
 def update_weights_from_distributed(
     group_name: str,
-    group: Any,
+    group: dist.ProcessGroup,
     weight_version: int,
     rollout_engines: Sequence[ActorHandle],
     converted_named_tensors: Sequence[tuple[str, torch.Tensor]],
@@ -451,16 +452,17 @@ def update_weights_from_distributed(
     The *group* is a vLLM ``PyNcclCommunicator`` from ``trainer_init``
     in the Megatron trainer process.
     """
-    kwargs: dict[str, Any] = {
-        "names": [name for name, _ in converted_named_tensors],
-        "dtypes": [param.dtype for _, param in converted_named_tensors],
-        "shapes": [param.shape for _, param in converted_named_tensors],
-        "group_name": group_name,
-        "weight_version": str(weight_version),
-        "packed": packed,
-    }
-
-    refs = [engine.update_weights_from_distributed.remote(**kwargs) for engine in rollout_engines]
+    refs = [
+        engine.update_weights_from_distributed.remote(
+            names=[name for name, _ in converted_named_tensors],
+            dtypes=[param.dtype for _, param in converted_named_tensors],
+            shapes=[param.shape for _, param in converted_named_tensors],
+            group_name=group_name,
+            weight_version=str(weight_version),
+            packed=packed,
+        )
+        for engine in rollout_engines
+    ]
 
     named_gpu_iter = (
         (name, (param.data if hasattr(param, "data") else param).contiguous())

--- a/vime/backends/vllm_utils/vllm_config.py
+++ b/vime/backends/vllm_utils/vllm_config.py
@@ -1,24 +1,4 @@
-"""Deployment configuration dataclasses for the vLLM rollout engine.
-
-YAML format::
-
-    vllm:
-      - name: actor
-        model_path: /path/to/actor
-        update_weights: true
-        num_gpus_per_engine: 2
-        server_groups:
-          - worker_type: prefill
-            num_gpus: 4
-          - worker_type: decode
-            num_gpus: 8
-      - name: ref
-        model_path: /path/to/ref
-        update_weights: false
-        server_groups:
-          - worker_type: regular
-            num_gpus: 4
-"""
+"""Configuration dataclasses for vLLM engine deployment."""
 
 import dataclasses
 import logging
@@ -43,7 +23,9 @@ class ServerGroupConfig:
         num_gpus: Total number of GPUs for this group.
         num_gpus_per_engine: GPUs per engine for this group.  Overrides the
                              model-level or global ``--rollout-num-gpus-per-engine``.
-        overrides: Optional dict of vLLM engine argument field overrides.
+        overrides: Optional dict of vLLM ``ServerArgs`` field overrides.
+                   These are applied on top of the base CLI ``--vllm-*``
+                   arguments in ``_compute_server_args``.
     """
 
     worker_type: str
@@ -90,9 +72,11 @@ class ModelConfig:
         for g in self.server_groups:
             if g.num_gpus_per_engine is None:
                 g.num_gpus_per_engine = default_gpus_per_engine
+            # Inject model_path into overrides so _compute_server_args picks it up.
             if "model_path" not in g.overrides:
                 g.overrides["model_path"] = default_model_path
 
+        # Validate: all server groups within a model must share the same model_path.
         if self.server_groups:
             model_paths = {g.overrides["model_path"] for g in self.server_groups}
             assert len(model_paths) == 1, (
@@ -103,6 +87,7 @@ class ModelConfig:
         else:
             effective_model_path = default_model_path
 
+        # Auto-infer update_weights when not explicitly set.
         if self.update_weights is None:
             if effective_model_path != args.hf_checkpoint:
                 logger.warning(
@@ -131,10 +116,40 @@ class ModelConfig:
 class VllmConfig:
     """Configuration for vLLM rollout engine deployment.
 
-    Loaded from ``--vllm-config`` YAML file.  Supports multi-model
-    serving, PD disaggregation, and heterogeneous server groups.
+    Loaded from ``--vllm-config`` YAML file.
 
-    See module docstring for the YAML format.
+    **Config format**::
+
+        vllm:
+          - name: actor
+            model_path: /path/to/actor
+            update_weights: true          # receives training weight updates (default)
+            num_gpus_per_engine: 2
+            server_groups:
+              - worker_type: prefill
+                num_gpus: 4
+                num_gpus_per_engine: 2
+              - worker_type: decode
+                num_gpus: 8
+                num_gpus_per_engine: 4
+          - name: ref
+            model_path: /path/to/ref
+            update_weights: false          # frozen, no weight updates
+            server_groups:
+              - worker_type: regular
+                num_gpus: 4
+
+    Each model gets its own router.  ``placeholder`` groups reserve GPU
+    slots without creating engines.  ``overrides`` are ``ServerArgs``
+    field names applied on top of the base ``--vllm-*`` CLI args.
+
+    Set ``update_weights: false`` for frozen models (reference, reward,
+    etc.) that should not receive weight updates from training.
+
+    .. note::
+
+       ``engine_groups`` is accepted as a backward-compatible alias for
+       ``server_groups`` in the YAML config.
     """
 
     models: list[ModelConfig]
@@ -144,11 +159,10 @@ class VllmConfig:
         with open(path) as f:
             data = yaml.safe_load(f)
 
-        if "vllm" not in data:
-            raise ValueError(
-                f"vllm config must have a 'vllm' key, got {list(data.keys())}. "
-                "Wrap your server_groups inside a model entry under 'vllm'."
-            )
+        assert "vllm" in data, (
+            f"vllm config must have a 'vllm' key, got {list(data.keys())}. "
+            f"Wrap your server_groups inside a model entry under 'vllm'."
+        )
         models = []
         for m in data["vllm"]:
             # Accept both "server_groups" and legacy "engine_groups".

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -1,6 +1,6 @@
 """Ray actor and launch helpers for vLLM OpenAI HTTP rollout.
 
-Per-Ray-actor ``server_args`` dict is built via :func:`compute_server_args`,
+Per-Ray-actor ``server_args`` dict is built via :func:`_compute_server_args`,
 then :func:`build_vllm_cmd_and_env` turns it into ``vllm serve`` CLI + subprocess env.
 :class:`VLLMEngine` manages the runtime HTTP control plane.
 User-facing vLLM knobs remain on ``train.py`` as ``--vllm-*`` (see ``arguments.py``).
@@ -241,62 +241,6 @@ def _apply_vllm_overrides(args, server_args: dict[str, Any], vllm_overrides: dic
         logger.debug("vllm_overrides: unrecognized key %s (rank=%s)", key, rank)
 
 
-def compute_server_args(
-    args,
-    rank,
-    dist_init_addr,
-    host,
-    port,
-    *,
-    worker_type: str = "regular",
-    base_gpu_id: int | None = None,
-    model_path: str | None = None,
-    vllm_overrides: dict | None = None,
-    num_gpus_per_engine: int | None = None,
-) -> dict[str, Any]:
-    """Build per-actor launch config for ``launch_server_process``."""
-    gpus_per_engine = num_gpus_per_engine or args.rollout_num_gpus_per_engine
-    if gpus_per_engine > args.num_gpus_per_node and gpus_per_engine % args.num_gpus_per_node != 0:
-        raise ValueError(
-            "vLLM multi-node rollout requires rollout_num_gpus_per_engine to be divisible by "
-            f"num_gpus_per_node, got rollout_num_gpus_per_engine={gpus_per_engine} "
-            f"num_gpus_per_node={args.num_gpus_per_node}."
-        )
-
-    topology = compute_vllm_engine_topology(args, rank, num_gpus_per_engine=gpus_per_engine)
-    base = base_gpu_id if base_gpu_id is not None else get_base_gpu_id(args, rank)
-    base = _to_local_gpu_id(base)
-
-    master_addr: str | None = None
-    master_port: int | None = None
-    if topology.multi_node:
-        if not dist_init_addr:
-            raise ValueError("dist_init_addr is required when launching a multi-node vLLM engine")
-        master_addr, master_port = parse_dist_init_addr(dist_init_addr)
-
-    server_args = {
-        "args": args,
-        "rank": rank,
-        "worker_type": worker_type,
-        "model_path": model_path or args.hf_checkpoint,
-        "host": _format_v6_uri(host),
-        "port": port,
-        "master_addr": master_addr,
-        "master_port": master_port,
-        "dist_init_addr": dist_init_addr,
-        "nnodes": topology.nnodes,
-        "node_rank": topology.node_rank,
-        "topology": topology,
-        "visible_devices": ",".join(str(base + i) for i in range(topology.local_num_gpus)),
-        "tp_size": topology.tensor_parallel_size,
-        "pp_size": topology.pipeline_parallel_size,
-        "dp_size": _get_vllm_dp_size(args),
-        "seed": getattr(args, "seed", 1234) + rank,
-    }
-    _apply_vllm_overrides(args, server_args, vllm_overrides, rank)
-    return server_args
-
-
 class _RobustJsonEncoder:
     @staticmethod
     def default(obj):
@@ -532,6 +476,24 @@ def _exec_vllm_cmd(cmd: list[str], env: dict[str, str]) -> None:
     os.execvpe(cmd[0], cmd, env)
 
 
+def _normalize_vllm_wake_tags(tags: list[str] | None) -> list[str] | None:
+    if not tags:
+        return tags
+    normalized = [t for t in tags if t in _VLLM_WAKE_TAGS]
+    dropped = set(tags) - set(normalized)
+    if dropped:
+        logger.debug("vLLM wake_up: dropped tags not supported by vLLM: %s", sorted(dropped))
+    return normalized or None
+
+
+def launch_server_process(server_args: dict) -> multiprocessing.Process:
+    """Spawn ``vllm serve`` from a :func:`_compute_server_args` dict."""
+    cmd, env = build_vllm_cmd_and_env(server_args)
+    p = _spawn_ctx.Process(target=_exec_vllm_cmd, args=(cmd, env))
+    p.start()
+    return p
+
+
 def _wait_worker_process_alive(process: multiprocessing.Process, timeout_s: float = 300.0) -> None:
     """Non-head nodes have no HTTP health endpoint; ensure the subprocess stays up."""
     start = time.time()
@@ -564,26 +526,6 @@ def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None)
         if process is not None and not process.is_alive():
             raise RuntimeError(f"vLLM server exited unexpectedly with code {process.exitcode}")
         time.sleep(2)
-
-
-def launch_server_process(server_args: dict) -> multiprocessing.Process:
-    """Spawn ``vllm serve`` from a :func:`compute_server_args` dict."""
-    cmd, env = build_vllm_cmd_and_env(server_args)
-    p = _spawn_ctx.Process(target=_exec_vllm_cmd, args=(cmd, env))
-    p.start()
-    return p
-
-
-def _normalize_vllm_wake_tags(tags: list[str] | None) -> list[str] | None:
-    if not tags:
-        return tags
-    normalized = [t for t in tags if t in _VLLM_WAKE_TAGS]
-    dropped = set(tags) - set(normalized)
-    if dropped:
-        logger.debug("vLLM wake_up: dropped tags not supported by vLLM: %s", sorted(dropped))
-    return normalized or None
-
-
 class VLLMEngine(RayActor):
     """Ray actor for vLLM OpenAI HTTP rollout (connect or spawn local ``vllm serve``)."""
 
@@ -593,7 +535,6 @@ class VLLMEngine(RayActor):
         rank: int,
         worker_type: str = "regular",
         base_gpu_id: int | None = None,
-        model_path: str | None = None,
         vllm_overrides: dict | None = None,
         num_gpus_per_engine: int | None = None,
     ):
@@ -601,7 +542,6 @@ class VLLMEngine(RayActor):
         self.rank = rank
         self.worker_type = worker_type
         self.base_gpu_id = base_gpu_id
-        self.model_path = model_path or args.hf_checkpoint
         self.vllm_overrides = vllm_overrides or {}
         self.num_gpus_per_engine = num_gpus_per_engine
         self.process: multiprocessing.Process | None = None
@@ -633,7 +573,7 @@ class VLLMEngine(RayActor):
         gpus_per_engine = self.num_gpus_per_engine or self.args.rollout_num_gpus_per_engine
         host = host or get_host_info()[1]
 
-        self._server_args = compute_server_args(
+        self._server_args = _compute_server_args(
             self.args,
             self.rank,
             dist_init_addr,
@@ -641,7 +581,6 @@ class VLLMEngine(RayActor):
             port,
             worker_type=self.worker_type,
             base_gpu_id=self.base_gpu_id,
-            model_path=self.model_path,
             vllm_overrides=self.vllm_overrides,
             num_gpus_per_engine=gpus_per_engine,
         )
@@ -1132,3 +1071,58 @@ class VLLMEngine(RayActor):
             return
         logger.info("Simulating crash on vLLM engine %s:%s...", self.server_host, self.server_port)
         self.shutdown()
+
+
+def _compute_server_args(
+    args,
+    rank,
+    dist_init_addr,
+    host,
+    port,
+    *,
+    worker_type: str = "regular",
+    base_gpu_id: int | None = None,
+    vllm_overrides: dict | None = None,
+    num_gpus_per_engine: int | None = None,
+) -> dict[str, Any]:
+    """Build per-actor launch config for ``launch_server_process``."""
+    gpus_per_engine = num_gpus_per_engine or args.rollout_num_gpus_per_engine
+    if gpus_per_engine > args.num_gpus_per_node and gpus_per_engine % args.num_gpus_per_node != 0:
+        raise ValueError(
+            "vLLM multi-node rollout requires rollout_num_gpus_per_engine to be divisible by "
+            f"num_gpus_per_node, got rollout_num_gpus_per_engine={gpus_per_engine} "
+            f"num_gpus_per_node={args.num_gpus_per_node}."
+        )
+
+    topology = compute_vllm_engine_topology(args, rank, num_gpus_per_engine=gpus_per_engine)
+    base = base_gpu_id if base_gpu_id is not None else get_base_gpu_id(args, rank)
+    base = _to_local_gpu_id(base)
+
+    master_addr: str | None = None
+    master_port: int | None = None
+    if topology.multi_node:
+        if not dist_init_addr:
+            raise ValueError("dist_init_addr is required when launching a multi-node vLLM engine")
+        master_addr, master_port = parse_dist_init_addr(dist_init_addr)
+
+    server_args = {
+        "args": args,
+        "rank": rank,
+        "worker_type": worker_type,
+        "model_path": args.hf_checkpoint,
+        "host": _format_v6_uri(host),
+        "port": port,
+        "master_addr": master_addr,
+        "master_port": master_port,
+        "dist_init_addr": dist_init_addr,
+        "nnodes": topology.nnodes,
+        "node_rank": topology.node_rank,
+        "topology": topology,
+        "visible_devices": ",".join(str(base + i) for i in range(topology.local_num_gpus)),
+        "tp_size": topology.tensor_parallel_size,
+        "pp_size": topology.pipeline_parallel_size,
+        "dp_size": _get_vllm_dp_size(args),
+        "seed": getattr(args, "seed", 1234) + rank,
+    }
+    _apply_vllm_overrides(args, server_args, vllm_overrides, rank)
+    return server_args

--- a/vime/ray/rollout.py
+++ b/vime/ray/rollout.py
@@ -14,7 +14,7 @@ import ray
 import torch
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from vime.backends.vllm_utils.vllm_config import ModelConfig, ServerGroupConfig, VllmConfig
-
+from vime.backends.vllm_utils.vllm_engine import VLLMEngine
 # Memory-type tag strings shared with the vLLM engine's sleep/wake_up API.
 GPU_MEMORY_TYPE_KV_CACHE = "kv_cache"
 GPU_MEMORY_TYPE_WEIGHTS = "weights"
@@ -36,31 +36,6 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("httpcore").setLevel(logging.WARNING)
 
 logger = logging.getLogger(__name__)
-
-
-def _sanitize_vllm_router_args(ra: Any) -> Any:
-    """Replace negative int fields with dataclass defaults (legacy CLI may use -1; vllm-router rejects it)."""
-    from vllm_router.router_args import RouterArgs as VR
-
-    fixes: dict[str, Any] = {}
-    for f in dataclasses.fields(VR):
-        val = getattr(ra, f.name, None)
-        if not isinstance(val, int) or val >= 0:
-            continue
-        if f.default is not dataclasses.MISSING:
-            fixes[f.name] = f.default
-        elif f.default_factory is not dataclasses.MISSING:  # type: ignore[attr-defined]
-            fixes[f.name] = f.default_factory()  # type: ignore[misc]
-        else:
-            logger.warning("vllm-router: field %r is negative (%s); leaving as-is", f.name, val)
-    return dataclasses.replace(ra, **fixes) if fixes else ra
-
-
-def _vllm_router_args_from_cli(args: Namespace) -> Any:
-    from vllm_router.router_args import RouterArgs
-
-    ra = RouterArgs.from_cli_args(args, use_router_prefix=True)
-    return _sanitize_vllm_router_args(ra)
 
 
 @dataclasses.dataclass
@@ -116,8 +91,6 @@ class ServerGroup:
 
         pg, reordered_bundle_indices, reordered_gpu_ids = self.pg
 
-        from vime.backends.vllm_utils.vllm_engine import VLLMEngine
-
         RolloutRayActor = ray.remote(VLLMEngine)
 
         rollout_engines = []
@@ -157,7 +130,6 @@ class ServerGroup:
                 rank=global_rank,
                 worker_type=self.worker_type,
                 base_gpu_id=base_gpu_id,
-                model_path=self.model_path,
                 vllm_overrides=self.vllm_overrides,
                 num_gpus_per_engine=self.num_gpus_per_engine,
             )
@@ -458,18 +430,6 @@ class RolloutManager:
     def dispose(self):
         for monitor in self._health_monitors:
             monitor.stop()
-        # Release vLLM inference workers. debug_rollout_only still hits this path at train.py end.
-        shutdown_refs = []
-        for srv in self.servers.values():
-            for group in srv.server_groups:
-                for eng in group.all_engines:
-                    if eng is not None:
-                        shutdown_refs.append(eng.shutdown.remote())
-        if shutdown_refs:
-            try:
-                ray.get(shutdown_refs)
-            except Exception as e:
-                logger.warning("Engine shutdown during dispose failed (non-fatal): %s", e)
         logging_utils.finish_tracking(self.args)
 
     @property
@@ -772,16 +732,8 @@ class RolloutManager:
         if samples[0].rollout_log_probs is not None:
             train_data["rollout_log_probs"] = [sample.rollout_log_probs for sample in samples]
 
-        if getattr(self.args, "use_rollout_routing_replay", False):
-            routed = [sample.rollout_routed_experts for sample in samples]
-            missing = [i for i, r in enumerate(routed) if r is None]
-            if missing:
-                raise ValueError(
-                    f"use_rollout_routing_replay: {len(missing)}/{len(samples)} samples missing "
-                    "rollout_routed_experts (see rollout logs for vLLM routing replay errors). "
-                    "Ensure vLLM 0.22+ serves with --enable-return-routed-experts."
-                )
-            train_data["rollout_routed_experts"] = routed
+        if samples[0].rollout_routed_experts is not None:
+            train_data["rollout_routed_experts"] = [sample.rollout_routed_experts for sample in samples]
 
         if samples[0].train_metadata is not None:
             train_data["metadata"] = [sample.train_metadata for sample in samples]
@@ -969,7 +921,9 @@ def _start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool 
 
     from vime.utils.http_utils import run_router
 
-    router_args = _vllm_router_args_from_cli(args)
+    from vllm_router.router_args import RouterArgs
+
+    router_args = RouterArgs.from_cli_args(args, use_router_prefix=True)
 
     router_args.host = router_ip
     router_args.port = router_port
@@ -978,34 +932,26 @@ def _start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool 
     router_args.request_timeout_secs = args.router_request_timeout_secs
 
     if has_pd_disaggregation:
-        if hasattr(router_args, "vllm_pd_disaggregation"):
-            router_args.vllm_pd_disaggregation = True
-        if hasattr(router_args, "disable_circuit_breaker"):
-            router_args.disable_circuit_breaker = True
-        # PD uses the full Rust router: it accepts dynamic /workers registration (engines register
-        # after the router is up), matching slime's launch-router-then-register flow. vllm-router's
-        # MiniLB is a debug-only load balancer that requires STATIC prefill/decode URLs at
-        # construction, which slime never provides, so it can never work here. MiniLB stays off
-        # (RouterArgs defaults mini_lb=False); the old SLIME_VLLM_ROUTER_USE_RUST gate is removed.
+        router_args.vllm_pd_disaggregation = True
+        # Disable circuit breaker to prevent RDMA transfer timeouts from
+        # marking decode workers as dead. Timeouts are transient (PCIe
+        # contention under high load) and do not indicate a dead server.
+        router_args.disable_circuit_breaker = True
 
-    if any(f.name == "disable_health_check" for f in dataclasses.fields(type(router_args))):
-        router_args.disable_health_check = True
+    # We will not use the health check from router.
+    router_args.disable_health_check = True
 
-    logger.info("Launch HTTP router with args: %s", router_args)
+    logger.info(f"Launch router with args: {router_args}")
 
-    process = multiprocessing.get_context("spawn").Process(
+    process = multiprocessing.Process(
         target=run_router,
         args=(router_args,),
     )
-    process.daemon = True
+    process.daemon = True  # Set the process as a daemon
     process.start()
+    # Wait 3 seconds
     time.sleep(3)
-    if not process.is_alive():
-        raise RuntimeError(
-            f"Router subprocess exited (exitcode={process.exitcode}). "
-            "Ensure the vllm-router (Rust) wheel is installed; both PD and non-PD rollout use it. "
-            "See vime.utils.http_utils run_router logs."
-        )
+    assert process.is_alive()
     logger.info(f"Router launched at {router_ip}:{router_port}, Prometheus port: {router_args.prometheus_port}")
     return router_ip, router_port, router_args.prometheus_port
 
@@ -1169,9 +1115,9 @@ def start_rollout_servers(args, pg) -> dict[str, RolloutServer]:
 
 def _resolve_vllm_config(args) -> VllmConfig:
     """Build a VllmConfig from args, choosing the right source."""
-    vllm_config_path = getattr(args, "vllm_config", None)
-    if vllm_config_path is not None:
-        config = VllmConfig.from_yaml(vllm_config_path)
+    if getattr(args, "vllm_config", None):
+        config = VllmConfig.from_yaml(args.vllm_config)
+        # Validate total GPUs match.
         expected = args.rollout_num_gpus
         actual = config.total_num_gpus
         assert actual == expected, f"vllm_config total GPUs ({actual}) != rollout_num_gpus ({expected})"

--- a/vime/utils/external_utils/command_utils.py
+++ b/vime/utils/external_utils/command_utils.py
@@ -226,6 +226,7 @@ def create_run_id() -> str:
 _warned_bool_env_var_keys = set()
 
 
+# copied from SGLang
 def get_bool_env_var(name: str, default: str = "false") -> bool:
     value = os.getenv(name, default)
     value = value.lower()


### PR DESCRIPTION
Summary:
- route vLLM model_path/config through VllmConfig and _compute_server_args
- simplify router startup and routed-expert handling in rollout
- tighten distributed weight-update types and explicit NCCL teardown

Checks:
- .venv/bin/python -m py_compile vime/backends/vllm_utils/vllm_config.py vime/backends/vllm_utils/vllm_engine.py vime/ray/rollout.py vime/utils/external_utils/command_utils.py vime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
- pytest was not available in .venv, so I could not run the targeted test modules locally