### PR TITLE
fix(fp8): import deep_gemm from vLLM-vendored namespace

### DIFF
--- a/vime/backends/megatron_utils/fp8_helpers.py
+++ b/vime/backends/megatron_utils/fp8_helpers.py
@@ -6,14 +6,7 @@ available, which disables the UE8M0 requantization path.
 
 import torch
 
-# deep_gemm is a third-party DeepSeek MoE GEMM library; not all images ship it.
-# When missing, the UE8M0 requantization path falls back to None so callers can
-# skip it gracefully (matches the module docstring contract).
 try:
-    # vLLM vendors deep_gemm at vllm.third_party.deep_gemm (compiled .so + utils/layout
-    # present on x86 and arm64). A bare top-level `import deep_gemm` only resolves against
-    # the SGLang sgl-deep-gemm wheel, which vLLM images do NOT ship -> import silently fails
-    # and the UE8M0 requant path goes dead. Import the vendored namespace directly.
     import vllm.third_party.deep_gemm.utils.layout as _deep_gemm_layout
     from vllm.utils.deep_gemm import get_tma_aligned_size as _get_tma_aligned_size
 

--- a/vime/backends/megatron_utils/fp8_helpers.py
+++ b/vime/backends/megatron_utils/fp8_helpers.py
@@ -10,7 +10,11 @@ import torch
 # When missing, the UE8M0 requantization path falls back to None so callers can
 # skip it gracefully (matches the module docstring contract).
 try:
-    import deep_gemm.utils.layout as _deep_gemm_layout
+    # vLLM vendors deep_gemm at vllm.third_party.deep_gemm (compiled .so + utils/layout
+    # present on x86 and arm64). A bare top-level `import deep_gemm` only resolves against
+    # the SGLang sgl-deep-gemm wheel, which vLLM images do NOT ship -> import silently fails
+    # and the UE8M0 requant path goes dead. Import the vendored namespace directly.
+    import vllm.third_party.deep_gemm.utils.layout as _deep_gemm_layout
     from vllm.utils.deep_gemm import get_tma_aligned_size as _get_tma_aligned_size
 
     _HAS_DEEP_GEMM = True


### PR DESCRIPTION
## Problem

`vime/backends/megatron_utils/fp8_helpers.py` imports `deep_gemm` as a **top-level package**:

```python
import deep_gemm.utils.layout as _deep_gemm_layout
```

This is a holdover from SGLang, where `deep_gemm` ships as the standalone `sgl-deep-gemm` wheel. **vLLM-based images do not ship that top-level package** — vLLM *vendors* deep_gemm at `vllm.third_party.deep_gemm` (compiled `_C.*.so` + `utils/layout.py`, present on **both x86 and arm64**).

So under any vLLM image the top-level import silently fails, `_HAS_DEEP_GEMM` stays `False`, and the **first FP8 + deepep rollout** that needs UE8M0 weight-requant dies with:

```
RuntimeError: deep_gemm not installed; UE8M0 requantization unavailable.
```

This is **not** an arm/Blackwell env gap — x86 fails identically. The FP8+deepep path had simply never been exercised on x86.

## Fix

Import the vendored namespace directly:

```python
import vllm.third_party.deep_gemm.utils.layout as _deep_gemm_layout
```

This mirrors how vLLM's own loader (`vllm/utils/deep_gemm.py`) resolves deep_gemm — it tries `import deep_gemm` then falls back to `importlib.import_module("vllm.third_party.deep_gemm")`. The outer `try/except ImportError` is kept, so a truly missing deep_gemm still degrades to `None` per the module's fall-back contract.

## Verification

- `_HAS_DEEP_GEMM=True` in-image on **both** arm64 (gb200) and x86 (h200); the vendored `utils/layout` resolves and exposes the symbol vime calls (`get_mn_major_tma_aligned_packed_ue8m0_tensor`).
- End-to-end on the `Qwen3-30B-A3B` FP8 + deepep rollout: the `deep_gemm not installed` `RuntimeError` is **gone**; the run now reaches the E8M0 FP8 kernels (`DeepGEMM E8M0 enabled`, `FlashInferFp8DeepGEMMDynamicBlockScaledKernel` selected) and executes the Megatron→vLLM `update_weights` requant path that was previously dead.

## Scope

This PR fixes only the deep_gemm import namespace. A separate, downstream FP8-MoE `w2` weight-transfer numel mismatch (`fused_moe/layer.py:_load_w2`) surfaces *after* this fix unblocks the requant path — it is unrelated to the import and is being tracked separately.