### PR TITLE
[Test] compact/fan-out e2e + Sample unit tests (port slime #1941, stacked on #119)

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        info: [{"num_gpus": 4, "test_file": "test_qwen3.5_0.8B_gsm8k_async_short.py"}, {"num_gpus": 4, "test_file": "test_qwen3.5_0.8B_gsm8k_short.py"}, {"num_gpus": 4, "test_file": "test_qwen2.5_0.5B_ppo_critic_only_short.py"}, {"num_gpus": 4, "test_file": "test_qwen2.5_0.5B_fully_async_short.py"}]
+        info: [{"num_gpus": 4, "test_file": "test_qwen3.5_0.8B_gsm8k_async_short.py"}, {"num_gpus": 4, "test_file": "test_qwen3.5_0.8B_gsm8k_short.py"}, {"num_gpus": 4, "test_file": "test_qwen2.5_0.5B_ppo_critic_only_short.py"}, {"num_gpus": 4, "test_file": "test_qwen2.5_0.5B_fully_async_short.py"}, {"num_gpus": 4, "test_file": "test_qwen2.5_0.5B_fanout_short.py"}]
     defaults:
       run:
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -6,6 +6,7 @@
         {'test_file': 'test_qwen3.5_0.8B_gsm8k_short.py', 'num_gpus': 4},
         {'test_file': 'test_qwen2.5_0.5B_ppo_critic_only_short.py', 'num_gpus': 4},
         {'test_file': 'test_qwen2.5_0.5B_fully_async_short.py', 'num_gpus': 4},
+        {'test_file': 'test_qwen2.5_0.5B_fanout_short.py', 'num_gpus': 4},
       ],
     },
     'e2e-test-vllm-config': {

--- a/tests/test_qwen2.5_0.5B_fanout_short.py
+++ b/tests/test_qwen2.5_0.5B_fanout_short.py
@@ -1,0 +1,224 @@
+"""E2E test: one prompt → random 1..3 training samples (compact / subagent fan-out).
+
+What this test pins
+-------------------
+The "compact" pattern (where one rollout execution emits a *variable*
+number of training samples sharing a single ``rollout_id``) has CPU unit
+coverage at the piece-level (``test_dp_schedule.py`` for the rollout-
+aware step splitter, ``test_sample.py`` for ``Sample.rollout_id`` round-
+trip, ``test_cp_utils.py`` for the per-rollout-mean reducer). But until
+this test, **no e2e training run had ever exercised the full chain**:
+
+  custom_generate returns list[Sample] sharing rollout_id
+    → _validate_rollout_id_annotated at depth ≥ 2 passes
+    → _split_train_data_by_dp groups by rollout_id and trims to N steps
+       using ``rollout_batch_size * n_samples_per_prompt / global_batch_size``
+       (NOT total sample count, which would inflate steps once N>1)
+    → loss aggregation uses ``rollout_mask_sums`` so every sibling sample
+       contributes one token-weighted mean per rollout
+    → train_one_step's ``step_global_batch_size`` denominator equals
+       num_rollouts (not num_samples), keeping grad magnitude stable
+       independent of fan-out
+
+The fan-out function itself lives in
+``vime/rollout/_fanout_test_helpers.py`` — it has to be at a dot-free
+module path so ``importlib.import_module`` can resolve the string
+``--custom-generate-function-path`` flag (this filename has dots).
+
+Test choices
+------------
+- **Deterministic fan-out** ``N = 1 + (sample.index % MAX_FANOUT)`` for
+  reproducibility. Every value in {1, 2, 3} gets exercised in a single
+  rollout. N=1 keeps the backward-compat (no fan-out) path alive in CI.
+- **Smoke + implicit step-count assertion**. ``--ci-test`` flips the
+  framework's built-in numerical guards (KL divergence, log_prob ≈
+  ref_log_prob); a step-counting / loss-denominator regression would
+  trip them.  Plus the helper writes one line per call to a tmp counter
+  file — post-train we assert the count equals
+  ``num_rollout * rollout_batch_size``, proving the custom path actually
+  drove every prompt (vs. silent fallback to default rollout).
+"""
+
+import os
+import tempfile
+
+import vime.utils.external_utils.command_utils as U
+
+TIGHT_DEVICE_MEMORY = U.get_bool_env_var("SLIME_TEST_TIGHT_DEVICE_MEMORY", "1")
+
+MODEL_NAME = "Qwen2.5-0.5B-Instruct"
+MODEL_TYPE = "qwen2.5-0.5B"
+NUM_GPUS = 4
+
+# Counter file used by the compact_generate helper. We pass its path
+# through to the Ray-submitted job via an env var so all worker
+# processes write to the same path.
+FANOUT_COUNTER_FILE = os.environ.get(
+    "SLIME_FANOUT_TEST_COUNTER_FILE",
+    os.path.join(tempfile.gettempdir(), "slime_fanout_test_counter.log"),
+)
+
+
+def prepare():
+    U.exec_command("mkdir -p /root/models /root/datasets")
+    U.exec_command(f"hf download Qwen/{MODEL_NAME} --local-dir /root/models/{MODEL_NAME}")
+    U.hf_download_dataset("zhuzilin/dapo-math-17k")
+    # Clear the counter so a previous run's invocations don't bleed in.
+    try:
+        os.remove(FANOUT_COUNTER_FILE)
+    except FileNotFoundError:
+        pass
+
+
+def execute():
+    ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}/ " f"--ref-load /root/models/{MODEL_NAME}/ "
+
+    # Shape: rollout_batch_size=8 prompts, n_samples_per_prompt=1 (all
+    # fan-out is owned by compact_generate; this knob stays at 1 so a
+    # regression that confuses sample count vs rollout count surfaces),
+    # global_batch_size=4 → 2 training steps per rollout, num_rollout=3
+    # → 6 total training steps.
+    #
+    # NB no ``--group-rm``: when custom_generate returns ``list[Sample]``
+    # the per-sample rm path inside ``generate_and_rm`` (vllm_rollout.py:
+    # 283-293) handles the fan-out correctly via ``batched_async_rm`` on
+    # the flat sibling list. ``--group-rm`` defers rm to
+    # ``generate_and_rm_group:345`` which assumes ``group`` is already
+    # flat ``list[Sample]`` — combining it with a list-returning
+    # custom_generate yields a ``list[list[Sample]]`` and crashes
+    # ``async_rm`` (`'list' object has no attribute 'metadata'`).
+    rollout_args = (
+        "--prompt-data /root/datasets/dapo-math-17k/dapo-math-17k.jsonl "
+        "--input-key prompt "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--rm-type deepscaler "
+        "--num-rollout 3 "
+        "--rollout-batch-size 8 "
+        "--n-samples-per-prompt 1 "
+        "--rollout-max-response-len 8192 "
+        "--rollout-temperature 0.8 "
+        "--global-batch-size 4 "
+        "--balance-data "
+        "--custom-generate-function-path vime.rollout._fanout_test_helpers.compact_generate "
+        # GRPO normalization needs per-prompt grouping. The default
+        # ``_post_process_rewards`` (vime/ray/rollout.py:618) reshapes
+        # by ``n_samples_per_prompt`` and falls back to "one big group"
+        # when the per-prompt count is uneven — fan-out trips exactly
+        # that fallback. The helper here groups by ``Sample.group_index``
+        # (the per-prompt counter the data source stamps; deepcopy in
+        # compact_generate preserves it across siblings) so each prompt's
+        # siblings normalize against each other, matching the GRPO
+        # semantics the default targets in the uniform case.
+        "--custom-reward-post-process-path vime.rollout._fanout_test_helpers.grpo_normalize_by_group_index "
+    )
+
+    perf_args = (
+        "--tensor-model-parallel-size 1 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 1 "
+        "--expert-model-parallel-size 1 "
+        "--expert-tensor-parallel-size 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 9216 "
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--use-kl-loss "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.00 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+    )
+
+    vllm_args = (
+        "--rollout-num-gpus-per-engine 1 "
+        f"--vllm-gpu-memory-utilization {0.6 if TIGHT_DEVICE_MEMORY else 0.7} "
+        "--vllm-max-cudagraph-capture-size 32 "
+    )
+
+    ci_args = "--ci-test "
+
+    fault_tolerance_args = (
+        "--use-fault-tolerance "
+        "--rollout-health-check-interval 5 "
+        "--rollout-health-check-timeout 10 "
+        "--rollout-health-check-first-wait 0 "
+    )
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        "--actor-num-nodes 1 "
+        "--actor-num-gpus-per-node 4 "
+        "--colocate "
+        "--megatron-to-hf-mode bridge "
+    )
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{U.get_default_wandb_args(__file__)} "
+        f"{perf_args} "
+        f"{vllm_args} "
+        f"{ci_args} "
+        f"{fault_tolerance_args} "
+        f"{misc_args} "
+    )
+
+    U.execute_train(
+        train_args=train_args,
+        num_gpus_per_node=NUM_GPUS,
+        megatron_model_type=MODEL_TYPE,
+        # Make the counter path visible inside the Ray-submitted job
+        # (helper picks it up via os.environ).
+        extra_env_vars={"SLIME_FANOUT_TEST_COUNTER_FILE": FANOUT_COUNTER_FILE},
+    )
+
+    # Post-train assertion: compact_generate must have been called exactly
+    # ``num_rollout * rollout_batch_size`` = 3 * 8 = 24 times. A regression
+    # that bypassed the custom path (arg parser drops the flag, or the
+    # path is silently mis-routed) would either skip the file entirely or
+    # under-count.
+    expected_calls = 3 * 8
+    try:
+        with open(FANOUT_COUNTER_FILE) as f:
+            actual_calls = sum(1 for _ in f)
+    except FileNotFoundError as e:
+        raise AssertionError(
+            f"compact_generate counter file {FANOUT_COUNTER_FILE} missing — the custom "
+            f"generate path was never invoked. Suggests --custom-generate-function-path "
+            f"was dropped by the arg parser or the resolved import path is wrong."
+        ) from e
+    assert actual_calls == expected_calls, (
+        f"compact_generate was called {actual_calls} times, expected {expected_calls} "
+        f"(num_rollout=3 × rollout_batch_size=8). A mismatch points at the rollout "
+        f"submission loop double-submitting / under-submitting prompts."
+    )
+
+
+if __name__ == "__main__":
+    prepare()
+    os.environ.pop("http_proxy")
+    os.environ.pop("https_proxy")
+    os.environ.pop("HTTP_PROXY")
+    os.environ.pop("HTTPS_PROXY")
+    execute()

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,0 +1,272 @@
+"""CPU unit tests for ``vime.utils.types.Sample``.
+
+Pins two contracts that the rollout / training boundary depends on:
+
+  1. ``to_dict`` / ``from_dict`` round-trip — Sample crosses Ray actor
+     boundaries as a dict (especially in async / fully-async / partial-
+     rollout paths). A silent field drop or enum corruption here means a
+     sample loses its status / spec_info / prefix_cache_info on the way
+     to the trainer with no crash signal.
+
+  2. ``update_from_meta_info`` finish_reason → Status enum mapping
+     (length→TRUNCATED, abort→ABORTED, stop→COMPLETED). The match
+     statement at types.py:176-182 is the only place sglang's
+     finish_reason gets translated; a typo'd enum or removed case here
+     would silently mis-tag every sample.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from vime.utils.types import Sample
+
+
+# ---------------------------------------------------------------------------
+# to_dict / from_dict round-trip
+# ---------------------------------------------------------------------------
+
+
+def _make_sample(**overrides) -> Sample:
+    """Build a Sample with one non-default value per field-category so the
+    round-trip test exercises every code path in to_dict/from_dict, not
+    just the trivial defaults case."""
+    base = dict(
+        group_index=0,
+        index=42,
+        rollout_id=7,
+        prompt="hello",
+        tokens=[1, 2, 3],
+        multimodal_inputs={"images": ["fake_url"]},
+        response="world",
+        response_length=5,
+        label="42",
+        reward=0.75,
+        loss_mask=[1, 1, 0, 1, 1],
+        weight_versions=["v1"],
+        rollout_log_probs=[-0.1, -0.2],
+        rollout_routed_experts=[[0, 1], [2, 3]],
+        remove_sample=False,
+        teacher_log_probs=[-0.3, -0.4],
+        status=Sample.Status.COMPLETED,
+        metadata={"rm_type": "math"},
+        generate_function_path="some.module.fn",
+        train_metadata={"loss_type": "policy_loss"},
+        session_id="uuid-1234",
+        non_generation_time=1.5,
+    )
+    base.update(overrides)
+    return Sample(**base)
+
+
+@pytest.mark.unit
+def test_to_dict_serializes_status_as_string_value():
+    """The ``status`` field is an enum on the dataclass; ``to_dict`` must
+    flatten it to its string value so it survives JSON / pickle across
+    Ray boundaries."""
+    sample = _make_sample()
+    d = sample.to_dict()
+    assert d["status"] == "completed"  # not Sample.Status.COMPLETED
+    assert isinstance(d["status"], str)
+
+
+@pytest.mark.unit
+def test_to_dict_flattens_spec_info_and_prefix_cache_info():
+    """``spec_info`` and ``prefix_cache_info`` are nested dataclasses;
+    to_dict converts each via its own to_dict (types.py:133-134)."""
+    sample = _make_sample()
+    sample.spec_info.spec_accept_token_num = 10
+    sample.spec_info.spec_draft_token_num = 20
+    sample.prefix_cache_info.cached_tokens = 5
+    sample.prefix_cache_info.total_prompt_tokens = 50
+
+    d = sample.to_dict()
+    assert d["spec_info"] == {
+        "spec_accept_token_num": 10,
+        "spec_draft_token_num": 20,
+        "spec_verify_ct": 0,
+        "completion_token_num": 0,
+    }
+    assert d["prefix_cache_info"] == {"cached_tokens": 5, "total_prompt_tokens": 50}
+
+
+@pytest.mark.unit
+def test_round_trip_preserves_every_field():
+    """Serialize → deserialize → compare. If any field gets silently
+    dropped on either side, the new sample won't equal the old. Uses
+    ``__dict__`` equality (not ``__eq__`` on the dataclass, which Sample
+    doesn't define) so nested SpecInfo / PrefixCacheInfo also get
+    compared structurally."""
+    original = _make_sample()
+    original.spec_info.spec_accept_token_num = 3
+    original.prefix_cache_info.cached_tokens = 7
+
+    restored = Sample.from_dict(original.to_dict())
+
+    # Status came back as the enum, not the string value.
+    assert restored.status is Sample.Status.COMPLETED
+    # Nested infos round-tripped as the correct type.
+    assert isinstance(restored.spec_info, Sample.SpecInfo)
+    assert isinstance(restored.prefix_cache_info, Sample.PrefixCacheInfo)
+    assert restored.spec_info.spec_accept_token_num == 3
+    assert restored.prefix_cache_info.cached_tokens == 7
+
+    # All non-nested fields preserved.
+    for field in (
+        "group_index",
+        "index",
+        "rollout_id",
+        "prompt",
+        "tokens",
+        "multimodal_inputs",
+        "response",
+        "response_length",
+        "label",
+        "reward",
+        "loss_mask",
+        "weight_versions",
+        "rollout_log_probs",
+        "rollout_routed_experts",
+        "remove_sample",
+        "teacher_log_probs",
+        "metadata",
+        "generate_function_path",
+        "train_metadata",
+        "session_id",
+        "non_generation_time",
+    ):
+        assert getattr(restored, field) == getattr(original, field), f"field {field} drifted"
+
+
+@pytest.mark.unit
+def test_from_dict_preserves_unknown_fields_as_attributes():
+    """``from_dict`` keeps unknown keys as attributes (types.py:148-150),
+    not as dataclass fields. This is what lets newer rollout code stash
+    extra metadata that older trainers will simply ignore — a back-compat
+    contract worth pinning."""
+    d = _make_sample().to_dict()
+    d["future_extension"] = "carried through"
+
+    restored = Sample.from_dict(d)
+    assert restored.future_extension == "carried through"  # type: ignore[attr-defined]
+
+
+@pytest.mark.unit
+def test_round_trip_through_default_constructed_sample():
+    """A bare Sample (only defaults) must also round-trip — this is the
+    common case for a freshly-spawned rollout. Catches regressions where
+    ``from_dict`` requires a key that ``to_dict`` doesn't always emit."""
+    original = Sample()
+    restored = Sample.from_dict(original.to_dict())
+    assert restored.status is Sample.Status.PENDING
+    assert restored.tokens == []
+    assert restored.metadata == {}
+
+
+# ---------------------------------------------------------------------------
+# update_from_meta_info — finish_reason → Status mapping
+# ---------------------------------------------------------------------------
+
+
+def _make_args(speculative: bool = False) -> argparse.Namespace:
+    """``update_from_meta_info`` only consults ``args.vllm_speculative_config``
+    — minimal stub is enough."""
+    return argparse.Namespace(vllm_speculative_config=speculative)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "finish_reason,expected_status",
+    [
+        ("length", Sample.Status.TRUNCATED),
+        ("abort", Sample.Status.ABORTED),
+        ("stop", Sample.Status.COMPLETED),
+    ],
+)
+def test_status_mapping_for_each_finish_reason(finish_reason, expected_status):
+    """The match statement at types.py:176-182 is the one place sglang's
+    finish_reason ever gets translated. Each branch must hit the right
+    enum; a typo in the enum name would crash later in unrelated places."""
+    sample = Sample()
+    sample.update_from_meta_info(
+        _make_args(),
+        meta_info={"finish_reason": {"type": finish_reason}},
+    )
+    assert sample.status is expected_status
+
+
+@pytest.mark.unit
+def test_unknown_finish_reason_leaves_status_unchanged():
+    """No ``case`` matches → status stays at whatever it was. Pins the
+    "no default clause means no-op" behavior so a future refactor adding
+    a default doesn't silently break this contract."""
+    sample = Sample()
+    sample.status = Sample.Status.PENDING
+    sample.update_from_meta_info(
+        _make_args(),
+        meta_info={"finish_reason": {"type": "something_new"}},
+    )
+    assert sample.status is Sample.Status.PENDING
+
+
+@pytest.mark.unit
+def test_weight_version_is_appended_when_present():
+    """``weight_version`` in meta_info is appended to the sample's list
+    (types.py:173-174) — partial-rollout uses this to track which model
+    version produced each chunk."""
+    sample = Sample()
+    sample.weight_versions = ["v1"]
+    sample.update_from_meta_info(
+        _make_args(),
+        meta_info={
+            "finish_reason": {"type": "stop"},
+            "weight_version": "v2",
+        },
+    )
+    assert sample.weight_versions == ["v1", "v2"]
+
+
+@pytest.mark.unit
+def test_prefix_cache_info_is_accumulated_across_calls():
+    """Every call to update_from_meta_info adds to prefix_cache_info
+    (types.py:171). Multi-turn rollouts call this once per turn — the
+    counts must accumulate, not overwrite."""
+    sample = Sample()
+    for prompt_tokens, cached_tokens in [(100, 0), (200, 50)]:
+        sample.update_from_meta_info(
+            _make_args(),
+            meta_info={
+                "finish_reason": {"type": "stop"},
+                "prompt_tokens": prompt_tokens,
+                "cached_tokens": cached_tokens,
+            },
+        )
+    assert sample.prefix_cache_info.cached_tokens == 50  # 0 + 50
+    assert sample.prefix_cache_info.total_prompt_tokens == 300  # 100 + 200
+
+
+@pytest.mark.unit
+def test_spec_info_only_updated_when_speculative_enabled():
+    """``spec_info.add`` is gated on ``args.vllm_speculative_config``
+    (types.py:166-168). Without the flag, spec stats stay at zero even
+    if sglang sends them."""
+    meta_info = {
+        "finish_reason": {"type": "stop"},
+        "spec_accept_token_num": 7,
+        "spec_draft_token_num": 10,
+    }
+
+    no_spec = Sample()
+    no_spec.update_from_meta_info(_make_args(speculative=False), meta_info=meta_info)
+    assert no_spec.spec_info.spec_accept_token_num == 0
+
+    with_spec = Sample()
+    with_spec.update_from_meta_info(_make_args(speculative=True), meta_info=meta_info)
+    assert with_spec.spec_info.spec_accept_token_num == 7
+    assert with_spec.spec_info.spec_draft_token_num == 10
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/vime/rollout/_fanout_test_helpers.py
+++ b/vime/rollout/_fanout_test_helpers.py
@@ -1,0 +1,115 @@
+"""Test-internal compact-rollout helpers used by ``test_qwen2.5_0.5B_fanout_short.py``.
+
+The underscore prefix marks this as test infrastructure — it is not part
+of the user-facing vime API and is not re-exported anywhere. It lives
+in ``vime/`` only so the test can reference it by a dotted module path
+(``--custom-generate-function-path`` / ``--custom-reward-post-process-path``
+resolve a string via ``importlib.import_module``, which can't handle the
+dots in the e2e test's filename).
+
+Two helpers:
+
+  - ``compact_generate``: fans one input sample out to N siblings
+    sharing the same ``rollout_id``. That's the contract the rest of the
+    framework (per-rollout step splitter, per-rollout-mean reducer,
+    ``_validate_rollout_id_annotated`` validator) is built around.
+
+  - ``grpo_normalize_by_group_index``: replaces the default
+    ``_post_process_rewards`` reshape-by-shape logic with a proper
+    ``group_index``-keyed grouping. The default at
+    ``vime/ray/rollout.py:618`` assumes every prompt produced exactly
+    ``n_samples_per_prompt`` samples and reshapes by that constant; when
+    compact/fanout makes the per-prompt count uneven, the reshape fails
+    and the fallback ``view(-1, total)`` collapses everything into ONE
+    group, destroying per-prompt centering. ``group_index`` (set by the
+    data source per-prompt, preserved through ``deepcopy``) is the right
+    key here.
+"""
+
+import copy
+import os
+from collections import defaultdict
+
+
+MAX_FANOUT = 3
+
+# Each invocation appends one line. The test file reads this after train
+# completes to assert the framework actually drove the custom path for
+# every prompt (no silent bypass / no double-submission).
+COUNTER_FILE_ENV = "SLIME_FANOUT_TEST_COUNTER_FILE"
+
+
+async def compact_generate(args, sample, sampling_params):
+    """One prompt → N siblings, deterministic N = 1 + (index % MAX_FANOUT).
+
+    Strategy: call sglang once, deepcopy N-1 times. Bounded GPU cost —
+    we're pinning the framework's per-rollout handling, not generation
+    diversity.
+    """
+    from vime.rollout.vllm_rollout import generate
+
+    counter_path = os.environ.get(COUNTER_FILE_ENV)
+    if counter_path:
+        try:
+            with open(counter_path, "a") as f:
+                f.write(f"{sample.index}\n")
+        except OSError:
+            # Counter file is best-effort — never fail training because of it.
+            pass
+
+    base_sample = await generate(args, sample, sampling_params)
+
+    n = 1 + (sample.index % MAX_FANOUT)
+    siblings = []
+    for _ in range(n):
+        s = copy.deepcopy(base_sample)
+        # Critical invariant: all siblings share ``rollout_id`` so the
+        # per-rollout reducer aggregates them as ONE rollout (not N) and
+        # the rollout-aware step splitter keeps them in the same step.
+        # ``group_index`` is inherited via ``deepcopy`` and is what the
+        # post-process reward hook below groups on for GRPO normalize.
+        s.rollout_id = sample.index
+        siblings.append(s)
+    return siblings
+
+
+def grpo_normalize_by_group_index(args, samples):
+    """Drop-in ``--custom-reward-post-process-path`` for compact/fanout.
+
+    The default ``_post_process_rewards`` (``vime/ray/rollout.py:618``)
+    reshapes the flat reward tensor as ``(-1, n_samples_per_prompt)``
+    when ``total == n_samples_per_prompt * rollout_batch_size``, falling
+    back to ``view(-1, total)`` (= one giant group) otherwise. With
+    fanout the count per prompt is uneven, so the fallback fires and
+    centering is computed across ALL samples in the batch instead of
+    per-prompt — that's silently wrong for GRPO.
+
+    This helper groups by ``Sample.group_index`` (the data-source-set
+    per-prompt counter, preserved through deepcopy in
+    ``compact_generate``) and applies the same mean-center + optional
+    std-normalize the default does, just with the correct grouping.
+
+    Returns ``(raw_rewards, normalized_rewards)`` matching the input
+    ``samples`` order — same shape as the default's return contract.
+    """
+    import torch
+
+    raw_rewards = [s.get_reward_value(args) for s in samples]
+
+    # group_index → list of (original_position, raw_reward)
+    groups: dict[int, list[tuple[int, float]]] = defaultdict(list)
+    for i, s in enumerate(samples):
+        groups[s.group_index].append((i, raw_rewards[i]))
+
+    out = [0.0] * len(samples)
+    use_std = getattr(args, "grpo_std_normalization", True)
+    for indexed in groups.values():
+        positions = [p for p, _ in indexed]
+        rewards = torch.tensor([r for _, r in indexed], dtype=torch.float)
+        rewards = rewards - rewards.mean()
+        if use_std:
+            rewards = rewards / (rewards.std() + 1e-6)
+        for pos, r in zip(positions, rewards.tolist(), strict=True):
+            out[pos] = r
+
+    return raw_rewards, out


### PR DESCRIPTION
**Stacked on #119** (base = `sync/slime-pr-1926-chain`; needs `Sample.rollout_id` + the rollout-aware step splitter #119 introduces). GitHub will retarget to main once #119 merges.

Ports THUDM/slime#1941 (multi-sample/compact fan-out e2e) + `test_sample.py` from #1939 (split here — it needs #119's `Sample.rollout_id`).

## Contents
- `tests/test_sample.py` — Sample round-trip/serialization unit tests. **12/12 cpu, validated locally.** Seam: slime fixture `sglang_speculative_algorithm` → vime `vllm_speculative_config`.
- `vime/rollout/_fanout_test_helpers.py` — `compact_generate` (one prompt→N siblings sharing `rollout_id`) + `grpo_normalize_by_group_index`. Seam: base `generate` import `sglang_rollout` → `vime.rollout.vllm_rollout`.
- `tests/test_qwen2.5_0.5B_fanout_short.py` — 4-GPU e2e pinning the full compact chain. Engine args translated sglang→vllm.
- `pr-test.yml.j2` — register fanout e2e in `e2e-test-short` (num_gpus:4).

## Validation
- cpu (local): test_sample **12/12 pass**; helper + e2e **parse/import clean**; ruff clean.
- **GPU validation pending** (no-GPU-CI tonight) — the 4-GPU e2e is the natural GPU validator for #119's compact-rollout machinery; run both together when a GPU window opens.

Skipped slime #1941's incidental `[tool.ruff.lint]` pyproject tweak. Part of #107 sync. 🤖 Generated with [Claude Code](https://claude.com/claude-code)