### PR TITLE
fix(fp8): send raw block scale for vLLM MoE weight update (drop SGLang mn-major pack)

### DIFF
--- a/vime/backends/megatron_utils/megatron_to_hf/processors/quantizer_fp8.py
+++ b/vime/backends/megatron_utils/megatron_to_hf/processors/quantizer_fp8.py
@@ -4,7 +4,7 @@ import torch
 
 from vime.backends.megatron_utils.kernels.fp8_kernel import blockwise_cast_to_fp8_triton
 
-from ...fp8_helpers import quant_weight_ue8m0, should_deepgemm_weight_requant_ue8m0, transform_scale_ue8m0
+from ...fp8_helpers import quant_weight_ue8m0, should_deepgemm_weight_requant_ue8m0
 
 
 def quantize_params_fp8(args, megatron_name, converted_named_params, quantization_config):
@@ -100,7 +100,15 @@ def _quantize_param(name, weight, weight_block_size):
             weight_block_size=weight_block_size
         ):
             qweight, scale = quant_weight_ue8m0(weight, weight_block_size=weight_block_size)
-            scale = transform_scale_ue8m0(scale, mn=qweight.shape[-2])
+            # vLLM's MoE FP8 loader expects the RAW block scale
+            # [ceil(n/128), ceil(k/128)] -- the on-disk weight_scale_inv format. It
+            # narrows the scale per-TP (shard_dim) and TMA-packs it itself inside
+            # process_weights_after_loading. transform_scale_ue8m0 produces SGLang's
+            # mn-major TMA-packed layout (slime targets the SGLang engine); under a
+            # vLLM rollout engine that pre-packed scale's numel mismatches vLLM's
+            # per-rank w2/w13 scale buffer (w2 expects [n/128,k/128] -> narrow on the
+            # k-block dim), so the online update_weights asserts in fused_moe _load_w2.
+            # Send the raw block scale and let vLLM do its own narrow + packing.
         else:
             qweight, scale = blockwise_cast_to_fp8_triton(weight, weight_block_size)
         scale_name = name.replace(".weight", ".weight_scale_inv")


### PR DESCRIPTION
## Problem

vime's FP8 quantizer (`megatron_to_hf/processors/quantizer_fp8.py::_quantize_param`, inherited verbatim from slime) emits the MoE weight scale on E8M0 platforms via `transform_scale_ue8m0`, which packs it into deep_gemm's **mn-major TMA-aligned** layout. That layout is what **SGLang**'s weight loader expects — slime targets SGLang.

vime swapped the rollout engine to **vLLM**, whose MoE FP8 loader instead expects the **raw block scale** `[ceil(n/128), ceil(k/128)]` (the on-disk `weight_scale_inv` format): it narrows the scale per-TP and TMA-packs it itself in `process_weights_after_loading`.

So under vLLM the pre-packed scale's numel mismatches the engine's per-rank w2/w13 scale buffer, and the first colocate `update_weights` aborts in fused_moe `_load_w2`:

```
reload/meta.py __torch_dispatch__: assert args[0].numel() == args[1].numel()
# w2 scale: dest [16,3] (per TP2 rank) vs the mn-major-packed src  ->  EngineCore 500
```

This only surfaces once the deep_gemm import fix (#128) unblocks the UE8M0 requant path, so the 30B deepep+fp8 rollout had never reached a weight update before. **Depends on #128.**

## Root cause (cross-checked against the other vLLM RL frameworks)

- slime/miles emit the mn-major packed scale and consume it from **SGLang** (`backends/megatron_utils/sglang.py`); AReaL labels the same helper "From SGLang fp8_utils.py".
- **verl** drives vLLM FP8 weight updates by sending the **raw** scale and re-running vLLM's own `process_weights_after_loading` (MoE path uses col-major TMA align) — i.e. vLLM owns the packing.
- vime kept slime's SGLang-only `transform_scale_ue8m0` while targeting vLLM → wrong layout.

## Fix

Emit the **raw block scale** (the `out_s` of `quant_weight_ue8m0`, already exactly `[ceil(n/128), ceil(k/128)]`) and let vLLM narrow + pack it. The non-E8M0 branch (`blockwise_cast_to_fp8_triton`) already sends the raw scale; this makes the E8M0 branch consistent. One line removed + the now-unused import dropped.

## Verification (gb200, Qwen3-30B-A3B deepep+fp8, colocate)

Instrumented the vLLM `_load_w2`/`_load_w13` loaders: on the on-disk checkpoint load (the format vLLM's online reload replays) vLLM expects raw **w2 `[16,6]`→narrow`[16,3]`** and **w13 `[6,16]`**, which `quant_weight_ue8m0`'s out_s matches 1:1.

After the fix, full end-to-end RL run is **GREEN (EXIT_RC=0)**:

| rollout | raw_reward | rollout_logprob ≈ train_logprob | actor train |
|---|---|---|---|
| 0 | 0.4375 | −0.281 ≈ −0.288 | 32/32 |
| 1 | 0.5625 | −0.236 ≈ −0.242 | 30/30 |
| 2 | 0.75 | −0.202 ≈ −0.207 | 32/32 |

`update_weights` returns 200 OK on all engines; rollout/train log-probs agree (weights are value-correct, not just shape-correct); raw_reward climbs 0.44→0.56→0.75. AI assistance was used.