### PR TITLE
fix(vllm): drop nonexistent RouterArgs.disable_health_check (crashes RolloutManager)

### DIFF
--- a/vime/ray/rollout.py
+++ b/vime/ray/rollout.py
@@ -938,9 +938,6 @@ def _start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool 
         # contention under high load) and do not indicate a dead server.
         router_args.disable_circuit_breaker = True
 
-    # We will not use the health check from router.
-    router_args.disable_health_check = True
-
     logger.info(f"Launch router with args: {router_args}")
 
     process = multiprocessing.Process(


### PR DESCRIPTION
## Problem
`vime/ray/rollout.py` (router launch) sets:
```python
# We will not use the health check from router.
router_args.disable_health_check = True
```
but **`vllm-router`'s `RouterArgs` has no `disable_health_check` field** — neither in the image we run (sync1916) nor in the latest upstream `vllm-router`. It exposes granular health-check knobs instead:
`health_check_endpoint`, `health_check_timeout_secs`, `health_check_interval_secs`, `health_failure_threshold`, `health_success_threshold`.

The stray attribute is forwarded into `Router.__new__`, which raises:
```
TypeError: Router.__new__() got an unexpected keyword argument 'disable_health_check'
```
→ `RolloutManager.__init__()` dies at startup (`ActorDiedError`), so the rollout engine never comes up. This blocks any run that launches the vllm-router (reproduced on Qwen3-30B-A3B colocate, 8/16-GPU).

## Fix
Remove the line. The router falls back to its default health-check behavior (the pre-refactor behavior that ran fine). `disable_circuit_breaker` just above it is a **real** `RouterArgs` field and is left untouched.

## Test
With the line removed, the router starts cleanly and RolloutManager initializes; rollout + training proceed (verified on the 30B-A3B colocate run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)