### PR TITLE
fix(ray): derive num_gpus_per_node from actor config for multi-node colocate

### DIFF
--- a/vime/utils/arguments.py
+++ b/vime/utils/arguments.py
@@ -1750,6 +1750,19 @@ def slime_validate_args(args):
             args.offload_train = True
         if args.offload_rollout is None:
             args.offload_rollout = True
+        # In colocate mode the rollout engines share the actor's physical nodes, so the
+        # GPUs-per-physical-node equals actor_num_gpus_per_node. --num-gpus-per-node defaults
+        # to 8 (an 8-GPU/node assumption); on hardware with a different per-node count (e.g.
+        # 4x GB200/node) that default is wrong for MULTI-NODE colocate: the rollout-engine
+        # addr/port allocation computes node_index via num_gpus_per_node and maps every engine
+        # to node 0, so worker-node engines are handed the head node's IP and fail to bind
+        # (OSError: [Errno 99] Cannot assign requested address). Derive the real per-node count.
+        if args.num_gpus_per_node != args.actor_num_gpus_per_node:
+            logger.info(
+                f"colocate: overriding num_gpus_per_node {args.num_gpus_per_node} -> "
+                f"actor_num_gpus_per_node {args.actor_num_gpus_per_node} (per-physical-node GPU count)."
+            )
+            args.num_gpus_per_node = args.actor_num_gpus_per_node
         if args.rollout_num_gpus != args.actor_num_gpus_per_node * args.actor_num_nodes:
             logger.info(
                 f"rollout_num_gpus {args.rollout_num_gpus} != actor_num_gpus_per_node {args.actor_num_gpus_per_node} "


### PR DESCRIPTION
## Problem

`--num-gpus-per-node` defaults to **8** (an 8-GPU/node assumption). On hardware with a different per-node GPU count — e.g. **4× GB200/node**, where an 8-GPU job must span **2 physical nodes** — that default is wrong for **multi-node colocate** runs.

The rollout-engine addr/port allocator (`_allocate_rollout_engine_addr_and_ports_normal`) computes each engine's node via `num_engines_per_node = num_gpus_per_node // gpus_per_engine` and assigns all engines on a `node_index` the IP of that node's first engine. With `num_gpus_per_node=8` but only 4 GPUs/node and `rollout_num_gpus_per_engine=2`, `num_engines_per_node` becomes **4** instead of **2**, so all 4 engines map to `node_index=0` and every engine is handed the **head node's IP**. Worker-node engines then fail to bind:

```
OSError: [Errno 99] Cannot assign requested address  ->  vLLM server exited unexpectedly with code 1
```

(The arg help already warns "If you are going to use less than 8 gpus per node under colocate mode, you should set this number" — easy to miss, and it silently breaks multi-node placement.)

## Fix

In colocate mode the rollout engines share the actor's physical nodes, so GPUs-per-physical-node is exactly `actor_num_gpus_per_node`. Derive `num_gpus_per_node` from it in the colocate reconciliation block. Single-node 8-GPU runs are unaffected (`actor_num_gpus_per_node == 8 == default`).

## Verification (gb200, 4 GPU/node, 2 nodes, 30B colocate)

- **Before:** `Ports for engine {0..3}: host=192.168.0.109` (all head) → worker engines `Cannot assign requested address`.
- **After:** `colocate: overriding num_gpus_per_node 8 -> 4`; engines split correctly `host=.109` (head) for 0,1 and `host=.110` (worker) for 2,3 — bind error gone.

(A separate cross-node NCCL/RoCE env issue surfaces after this, unrelated to engine IP assignment.) AI assistance was used.