### PR TITLE
[Example] Add Qwen3-30B-A3B multi-node guide in qwen3-30B-A3B doc and run script

### DIFF
--- a/docs/en/examples/qwen3-30B-A3B.md
+++ b/docs/en/examples/qwen3-30B-A3B.md
@@ -93,15 +93,82 @@ This will trigger FP8 inference. Currently, we directly cast the BF16 weights to
 
 ### Multi-Node Support
 
-For a multi-node environment, the following modifications are necessary:
+The following uses **two machines with 8 GPUs each (16 GPUs total)** as the starting example; scripts and parameters scale to **N nodes**. Key differences from single-node:
 
-  - Place the training model and data on a path accessible by all nodes.
-  - Set the `MASTER_ADDR` to an address that is accessible by all nodes.
-  - Remove configurations related to CPU Adam. This is because a distributed optimizer is used, which significantly reduces the optimizer's video memory (VRAM) usage in a multi-node setup.
+- Place weights, checkpoints, and data on storage visible to every node (e.g. NFS).
+- Set `MASTER_ADDR` to the head **LAN IP** (not `127.0.0.1`).
+- Omit CPU Adam (multi-node uses a distributed optimizer; do not use `--optimizer-cpu-offload`).
+- `global-batch-size` must equal `rollout-batch-size × n-samples-per-prompt`.
 
-In addition, you can make the following changes:
+#### Topology
 
-  - When the total number of GPUs is not a multiple or divisor of the total number of experts, enable vLLM's EPLB (Expert Parallelism Load Balancer) and configure redundant experts via `--vllm-eplb-config`. For example, in a 24-GPU scenario:
+| Component | Dual-node defaults |
+|-----------|-------------------|
+| Cluster | `ACTOR_NUM_NODES=2`, `ACTOR_NUM_GPUS_PER_NODE=8` |
+| Megatron training | TP=8, EP=8, CP=2 (experts sharded across nodes) |
+| vLLM rollout | Cross-node TP=16 (`rollout-num-gpus-per-engine = nodes × GPUs per node`) |
+| Scheduling | Ray cluster + `--colocate` mode |
+
+Convert checkpoints with Megatron parallelism matching training (dual-node: TP=8, EP=8). Checkpoint EP must match `--expert-model-parallel-size`, or `load_checkpoint` may hang or resharding may be extremely slow.
+
+#### Start the Ray Cluster
+
+Start Ray **outside** the training script on each node. Join all workers first; verify `ray status` reports the expected GPU count, then submit training from the head. Dual-node example:
+
+```bash
+# === Head node ===
+export MASTER_ADDR=<head_lan_ip>
+ray start --head --node-ip-address="${MASTER_ADDR}" --num-gpus 8 --disable-usage-stats \
+   --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+# === Each worker node ===
+export MASTER_ADDR=<head_lan_ip>
+ray start --address="${MASTER_ADDR}:6379" --node-ip-address=<this_node_lan_ip> --num-gpus 8
+```
+
+See [Quick Start — Multi-node training](../get_started/quick_start.md#multi-node-training-for-large-scale-moe-models) for more details.
+
+#### Run Training
+
+After the Ray cluster is ready, on the **head node** set multi-node env vars and run the **same script as single-node** (`ACTOR_NUM_NODES>1` skips Ray startup and applies multi-node defaults):
+
+```bash
+export MASTER_ADDR=<head_lan_ip>
+export ACTOR_NUM_NODES=2
+export ACTOR_NUM_GPUS_PER_NODE=8
+cd /root/vime
+bash scripts/run-qwen3-30B-A3B.sh
+```
+
+2-step smoke test:
+
+```bash
+NUM_ROLLOUT=2 ENABLE_R3=0 bash scripts/run-qwen3-30B-A3B.sh
+```
+
+To scale to N nodes (e.g. 4×8), join all workers to Ray, set `ACTOR_NUM_NODES=4` on the head, and tune `MEGATRON_TP` / `MEGATRON_EP` / `MEGATRON_CP` / `ROLLOUT_NUM_GPUS_PER_ENGINE` for total GPU count.
+
+#### Key Multi-Node Parameters
+
+| Variable | Dual-node default | Description |
+|----------|-------------------|-------------|
+| `ACTOR_NUM_NODES` | 2 (default 1 for single-node) | Total nodes including head; script skips Ray startup when >1 |
+| `ACTOR_NUM_GPUS_PER_NODE` | 8 | GPUs per node |
+| `MEGATRON_TP` / `MEGATRON_EP` / `MEGATRON_CP` | 8 / 8 / 2 | Megatron parallelism |
+| `ROLLOUT_NUM_GPUS_PER_ENGINE` | total GPUs | vLLM engine GPU count |
+| `ENABLE_R3` | 1 | set to 0 to disable R3 |
+
+Default batch: `rollout-batch-size=4`, `n-samples-per-prompt=2`, `global-batch-size=8`; vLLM uses `--vllm-moe-backend triton`.
+
+#### Multi-Node Troubleshooting
+
+- **Worker cannot join Ray / NCCL failures**: check `MASTER_ADDR`, container `/etc/hosts` (hostname must not map to `127.0.0.1`), `NCCL_SOCKET_IFNAME` / `GLOO_SOCKET_IFNAME`.
+- **`Not enough samples X for global_batch_size Y`**: keep `global-batch-size` equal to `rollout-batch-size × n-samples-per-prompt`.
+- **GPU memory full but no processes**: restart the container or run `ray stop --force` to clear stale vLLM contexts.
+
+#### EPLB
+
+When the total number of GPUs is not a multiple or divisor of the total number of experts, enable vLLM's EPLB (Expert Parallelism Load Balancer) and configure redundant experts via `--vllm-eplb-config`. For example, in a 24-GPU scenario:
 
    ```bash
    VLLM_ARGS=(

--- a/docs/zh/examples/qwen3-30B-A3B.md
+++ b/docs/zh/examples/qwen3-30B-A3B.md
@@ -92,14 +92,82 @@ hf download Qwen/Qwen3-30B-A3B-FP8 --local-dir /root/Qwen3-30B-A3B-FP8
 
 ### 多机支持
 
-对于多机环境，需要进行如下的几点修改：
-- 将训练模型，数据放在所有机器都可以访问到的路径上；
-- 设置各台机器都可以访问到的 `MASTER_ADDR` 之外；
-- 去掉 CPU adam 相关的配置，因为使用了 distributed optimizer，所以多机环境下 optimizer 的显存占比会明显下降。
+以下以 **2台机器、每台8卡（共16GPU）** 为入门示例；脚本与参数可扩展到 **N节点**。多机与单机的主要差异：
 
-除此之外，还可以进行如下的修改：
+- 训练模型、数据放在所有节点均可访问的路径（如 NFS）；
+- `MASTER_ADDR` 设为 head 节点的 **局域网 IP**（非 `127.0.0.1`）；
+- 去掉 CPU Adam（多机使用 distributed optimizer，无需 `--optimizer-cpu-offload`）；
+- `global-batch-size` 必须等于 `rollout-batch-size × n-samples-per-prompt`。
 
-- 当总卡数并不能被 expert 总数整除时，可以开启 vLLM 的 EPLB（Expert Parallelism Load Balancer），通过 `--vllm-eplb-config` 配置冗余 expert。例如对于 24 卡的场景：
+#### 拓扑概览
+
+| 组件 | 双机默认配置 |
+|------|------|
+| 集群 | `ACTOR_NUM_NODES=2`，`ACTOR_NUM_GPUS_PER_NODE=8` |
+| Megatron训练 | TP=8, EP=8, CP=2（expert 分片跨节点） |
+| vLLM Rollout | 跨节点 TP=16（`rollout-num-gpus-per-engine = 节点数 × 每节点GPU`） |
+| 调度 | Ray 集群 + `--colocate` 共卡模式 |
+
+转换 checkpoint 时建议使用与训练一致的 Megatron 并行度（双机示例 TP=8, EP=8）。checkpoint 的 EP 需与 `--expert-model-parallel-size` 一致，否则 `load_checkpoint` 可能极慢或卡住。
+
+#### 启动 Ray 集群
+
+Ray 集群需在各节点上 **单独启动**，不在训练脚本内。先在所有 worker 节点加入集群，确认 `ray status` 显示预期 GPU 总数后，再在 head 提交训练。示例（双机）：
+
+```bash
+# === Head 节点 ===
+export MASTER_ADDR=<head_局域网_IP>
+ray start --head --node-ip-address="${MASTER_ADDR}" --num-gpus 8 --disable-usage-stats \
+   --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+# === 各 Worker 节点 ===
+export MASTER_ADDR=<head_局域网_IP>
+ray start --address="${MASTER_ADDR}:6379" --node-ip-address=<本机_局域网_IP> --num-gpus 8
+```
+
+更多说明见 [快速开始 — 多机训练](../get_started/quick_start.md#multi-node-training-for-large-scale-moe-models)。
+
+#### 执行训练
+
+Ray 集群就绪后，在 **head 节点** 设置多机环境变量并运行 **与单机相同的脚本**（`ACTOR_NUM_NODES>1` 时脚本不会启动 Ray，并使用多机默认参数）：
+
+```bash
+export MASTER_ADDR=<head_局域网_IP>
+export ACTOR_NUM_NODES=2
+export ACTOR_NUM_GPUS_PER_NODE=8
+cd /root/vime
+bash scripts/run-qwen3-30B-A3B.sh
+```
+
+2 step 冒烟示例：
+
+```bash
+NUM_ROLLOUT=2 ENABLE_R3=0 bash scripts/run-qwen3-30B-A3B.sh
+```
+
+扩展到 N 节点（例如 4×8）时，在各 worker 加入 Ray 后，于 head 设置 `ACTOR_NUM_NODES=4` 并按总卡数调整 `MEGATRON_TP` / `MEGATRON_EP` / `MEGATRON_CP` / `ROLLOUT_NUM_GPUS_PER_ENGINE`。
+
+#### 多机关键参数
+
+| 变量 | 双机默认 | 说明 |
+|------|----------|------|
+| `ACTOR_NUM_NODES` | 2（单机默认为 1） | 训练节点总数（含 head）；>1 时脚本不启动 Ray |
+| `ACTOR_NUM_GPUS_PER_NODE` | 8 | 每节点 GPU 数 |
+| `MEGATRON_TP` / `MEGATRON_EP` / `MEGATRON_CP` | 8 / 8 / 2 | Megatron 并行 |
+| `ROLLOUT_NUM_GPUS_PER_ENGINE` | 总 GPU 数 | vLLM engine 占用卡数 |
+| `ENABLE_R3` | 1 | 设为 0 可关闭 R3 路径 |
+
+脚本默认 batch：`rollout-batch-size=4`，`n-samples-per-prompt=2`，`global-batch-size=8`；vLLM 使用 `--vllm-moe-backend triton`。
+
+#### 多机常见问题
+
+- **Worker 无法加入 Ray / NCCL 失败**：检查 `MASTER_ADDR`、容器 `/etc/hosts`（hostname 勿指向 `127.0.0.1`）、`NCCL_SOCKET_IFNAME` / `GLOO_SOCKET_IFNAME`。
+- **`Not enough samples X for global_batch_size Y`**：同步调整 `global-batch-size` 与 `rollout-batch-size × n-samples-per-prompt`。
+- **GPU 显存占满但无进程**：重启容器或 `ray stop --force` 清理残留 vLLM 上下文。
+
+#### EPLB
+
+当总卡数并不能被 expert 总数整除时，可以开启 vLLM 的 EPLB（Expert Parallelism Load Balancer），通过 `--vllm-eplb-config` 配置冗余 expert。例如对于 24 卡的场景：
 
    ```bash
    VLLM_ARGS=(

--- a/scripts/run-qwen3-30B-A3B.sh
+++ b/scripts/run-qwen3-30B-A3B.sh
@@ -1,15 +1,24 @@
 #!/bin/bash
 
-# for rerun the task
-pkill -9 -f "vllm serve"
-sleep 3
-ray stop --force
-pkill -9 ray
-pkill -9 python
-sleep 3
-pkill -9 ray
-pkill -9 python
-pkill -9 redis
+ACTOR_NUM_NODES="${ACTOR_NUM_NODES:-1}"
+ACTOR_NUM_GPUS_PER_NODE="${ACTOR_NUM_GPUS_PER_NODE:-8}"
+TOTAL_GPUS=$((ACTOR_NUM_NODES * ACTOR_NUM_GPUS_PER_NODE))
+
+if [[ "${ACTOR_NUM_NODES}" -le 1 ]]; then
+   # for rerun the task (single-node only)
+   pkill -9 -f "vllm serve"
+   sleep 3
+   ray stop --force
+   pkill -9 ray
+   pkill -9 python
+   sleep 3
+   pkill -9 ray
+   pkill -9 python
+   pkill -9 redis
+else
+   export SLIME_SCRIPT_EXTERNAL_RAY=1
+   export MASTER_ADDR="${MASTER_ADDR:?Set MASTER_ADDR to head LAN IP}"
+fi
 
 set -ex
 
@@ -25,124 +34,244 @@ fi
 echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+VIME_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 source "${SCRIPT_DIR}/models/qwen3-30B-A3B.sh"
 
-CKPT_ARGS=(
-   --hf-checkpoint /root/Qwen3-30B-A3B
-   #--hf-checkpoint /root/Qwen3-30B-A3B-FP8
-   --ref-load /root/Qwen3-30B-A3B_torch_dist
-   --load /root/Qwen3-30B-A3B_slime/
-   --save /root/Qwen3-30B-A3B_slime/
-   --save-interval 20
-)
+if [[ "${ACTOR_NUM_NODES}" -le 1 ]]; then
+   CKPT_ARGS=(
+      --hf-checkpoint /root/Qwen3-30B-A3B
+      #--hf-checkpoint /root/Qwen3-30B-A3B-FP8
+      --ref-load /root/Qwen3-30B-A3B_torch_dist
+      --load /root/Qwen3-30B-A3B_slime/
+      --save /root/Qwen3-30B-A3B_slime/
+      --save-interval 20
+   )
 
-ROLLOUT_ARGS=(
-   --prompt-data /root/dapo-math-17k/dapo-math-17k.jsonl
-   --input-key prompt
-   --label-key label
-   --apply-chat-template
-   --rollout-shuffle
-   --rm-type deepscaler
-   --num-rollout 3000
-   --rollout-batch-size 32
-   --n-samples-per-prompt 8
-   --rollout-max-response-len 8192
-   --rollout-temperature 1
+   ROLLOUT_ARGS=(
+      --prompt-data /root/dapo-math-17k/dapo-math-17k.jsonl
+      --input-key prompt
+      --label-key label
+      --apply-chat-template
+      --rollout-shuffle
+      --rm-type deepscaler
+      --num-rollout 3000
+      --rollout-batch-size 32
+      --n-samples-per-prompt 8
+      --rollout-max-response-len 8192
+      --rollout-temperature 1
 
-   --global-batch-size 256
-   --balance-data
-)
+      --global-batch-size 256
+      --balance-data
+   )
 
-EVAL_ARGS=(
-   --eval-interval 20
-   --eval-prompt-data aime /root/aime-2024/aime-2024.jsonl
-   --n-samples-per-eval-prompt 16
-   --eval-max-response-len 16384
-   --eval-top-p 1
-)
+   EVAL_ARGS=(
+      --eval-interval 20
+      --eval-prompt-data aime /root/aime-2024/aime-2024.jsonl
+      --n-samples-per-eval-prompt 16
+      --eval-max-response-len 16384
+      --eval-top-p 1
+   )
 
-PERF_ARGS=(
-   --tensor-model-parallel-size 4
-   --sequence-parallel
-   --pipeline-model-parallel-size 1
-   --context-parallel-size 1
-   --expert-model-parallel-size 8
-   --expert-tensor-parallel-size 1
+   PERF_ARGS=(
+      --tensor-model-parallel-size 4
+      --sequence-parallel
+      --pipeline-model-parallel-size 1
+      --context-parallel-size 1
+      --expert-model-parallel-size 8
+      --expert-tensor-parallel-size 1
 
-   --recompute-granularity full
-   --recompute-method uniform
-   --recompute-num-layers 1
+      --recompute-granularity full
+      --recompute-method uniform
+      --recompute-num-layers 1
 
-   # --micro-batch-size 1
-   --use-dynamic-batch-size
-   --max-tokens-per-gpu 20480
-)
+      # --micro-batch-size 1
+      --use-dynamic-batch-size
+      --max-tokens-per-gpu 20480
+   )
 
-GRPO_ARGS=(
-   --advantage-estimator grpo
-   --use-kl-loss
-   --kl-loss-coef 0.00
-   --kl-loss-type low_var_kl
-   --entropy-coef 0.00
-   --eps-clip 0.2
-   --eps-clip-high 0.28
-)
+   GRPO_ARGS=(
+      --advantage-estimator grpo
+      --use-kl-loss
+      --kl-loss-coef 0.00
+      --kl-loss-type low_var_kl
+      --entropy-coef 0.00
+      --eps-clip 0.2
+      --eps-clip-high 0.28
+   )
 
-OPTIMIZER_ARGS=(
-   --optimizer adam
-   --lr 1e-6
-   --lr-decay-style constant
-   --weight-decay 0.1
-   --adam-beta1 0.9
-   --adam-beta2 0.98
+   OPTIMIZER_ARGS=(
+      --optimizer adam
+      --lr 1e-6
+      --lr-decay-style constant
+      --weight-decay 0.1
+      --adam-beta1 0.9
+      --adam-beta2 0.98
 
-   --optimizer-cpu-offload
-   --overlap-cpu-optimizer-d2h-h2d
-   --use-precision-aware-optimizer
-)
+      --optimizer-cpu-offload
+      --overlap-cpu-optimizer-d2h-h2d
+      --use-precision-aware-optimizer
+   )
 
-WANDB_ARGS=(
-   #--use-wandb
-   # --wandb-project vime-dev
-   # --wandb-group qwen3-30B-A3B-test
-   # --wandb-key ${WANDB_KEY}
-)
+   WANDB_ARGS=(
+      #--use-wandb
+      # --wandb-project vime-dev
+      # --wandb-group qwen3-30B-A3B-test
+      # --wandb-key ${WANDB_KEY}
+   )
 
-VLLM_ARGS=(
-   --rollout-num-gpus-per-engine 8
-   --vllm-gpu-memory-utilization 0.7
-   --vllm-cudagraph-capture-sizes 1 2 4 8 $(seq 16 8 256)
-)
+   VLLM_ARGS=(
+      --rollout-num-gpus-per-engine 8
+      --vllm-gpu-memory-utilization 0.7
+      --vllm-cudagraph-capture-sizes 1 2 4 8 $(seq 16 8 256)
+   )
 
-MISC_ARGS=(
-   # default dropout in megatron is 0.1
-   --attention-dropout 0.0
-   --hidden-dropout 0.0
-   # should be good for model performance
-   --accumulate-allreduce-grads-in-fp32
-   --attention-softmax-in-fp32
-   # need to comment this when using model with MLA
-   --attention-backend flash
-)
+   MISC_ARGS=(
+      # default dropout in megatron is 0.1
+      --attention-dropout 0.0
+      --hidden-dropout 0.0
+      # should be good for model performance
+      --accumulate-allreduce-grads-in-fp32
+      --attention-softmax-in-fp32
+      # need to comment this when using model with MLA
+      --attention-backend flash
+   )
 
-# launch the master node of ray in container
-export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
-ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+else
+   MEGATRON_TP="${MEGATRON_TP:-8}"
+   MEGATRON_PP="${MEGATRON_PP:-1}"
+   MEGATRON_CP="${MEGATRON_CP:-2}"
+   MEGATRON_EP="${MEGATRON_EP:-8}"
+   ROLLOUT_NUM_GPUS_PER_ENGINE="${ROLLOUT_NUM_GPUS_PER_ENGINE:-${TOTAL_GPUS}}"
+   NUM_GPUS_PER_NODE="${NUM_GPUS_PER_NODE:-${ACTOR_NUM_GPUS_PER_NODE}}"
+   NUM_ROLLOUT="${NUM_ROLLOUT:-100}"
+   ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:-4}"
+   N_SAMPLES_PER_PROMPT="${N_SAMPLES_PER_PROMPT:-2}"
+   ROLLOUT_MAX_RESPONSE_LEN="${ROLLOUT_MAX_RESPONSE_LEN:-2048}"
+   GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:-$((ROLLOUT_BATCH_SIZE * N_SAMPLES_PER_PROMPT))}"
+   ENABLE_R3="${ENABLE_R3:-1}"
+   HF_CKPT="${HF_CKPT:-/root/Qwen3-30B-A3B}"
+   TORCH_DIST="${TORCH_DIST:-/root/models/Qwen3-30B-A3B_torch_dist}"
+   PROMPT_DATA="${PROMPT_DATA:-/root/datasets/dapo-math-17k/dapo-math-17k.jsonl}"
 
-# Build the runtime environment JSON with proper variable substitution
-RUNTIME_ENV_JSON="{
-  \"env_vars\": {
-    \"PYTHONPATH\": \"/root/Megatron-LM/\",
-    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
-    \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\"
-  }
-}"
+   CKPT_ARGS=(
+      --hf-checkpoint "${HF_CKPT}"
+      --ref-load "${TORCH_DIST}"
+   )
 
-ray job submit --address="http://127.0.0.1:8265" \
+   ROLLOUT_ARGS=(
+      --prompt-data "${PROMPT_DATA}"
+      --input-key prompt
+      --label-key label
+      --apply-chat-template
+      --rollout-shuffle
+      --rm-type deepscaler
+      --num-rollout "${NUM_ROLLOUT}"
+      --rollout-batch-size "${ROLLOUT_BATCH_SIZE}"
+      --n-samples-per-prompt "${N_SAMPLES_PER_PROMPT}"
+      --rollout-max-response-len "${ROLLOUT_MAX_RESPONSE_LEN}"
+      --rollout-temperature 1
+      --global-batch-size "${GLOBAL_BATCH_SIZE}"
+      --balance-data
+   )
+
+   EVAL_ARGS=()
+   WANDB_ARGS=()
+
+   PERF_ARGS=(
+      --tensor-model-parallel-size "${MEGATRON_TP}"
+      --sequence-parallel
+      --pipeline-model-parallel-size "${MEGATRON_PP}"
+      --context-parallel-size "${MEGATRON_CP}"
+      --expert-model-parallel-size "${MEGATRON_EP}"
+      --expert-tensor-parallel-size 1
+      --recompute-granularity full
+      --recompute-method uniform
+      --recompute-num-layers 1
+      --use-dynamic-batch-size
+      --max-tokens-per-gpu "${MAX_TOKENS_PER_GPU:-4096}"
+   )
+
+   GRPO_ARGS=(
+      --advantage-estimator gspo
+      --kl-loss-coef 0.00
+      --kl-loss-type low_var_kl
+      --kl-coef 0.00
+      --entropy-coef 0.00
+      --eps-clip 4e-4
+   )
+   if [[ "${ENABLE_R3}" == "1" ]]; then
+      GRPO_ARGS+=(--use-rollout-routing-replay)
+   fi
+
+   OPTIMIZER_ARGS=(
+      --optimizer adam
+      --lr 1e-6
+      --lr-decay-style constant
+      --weight-decay 0.1
+      --adam-beta1 0.9
+      --adam-beta2 0.98
+   )
+
+   VLLM_ARGS=(
+      --rollout-num-gpus-per-engine "${ROLLOUT_NUM_GPUS_PER_ENGINE}"
+      --num-gpus-per-node "${NUM_GPUS_PER_NODE}"
+      --vllm-gpu-memory-utilization "${VLLM_GPU_MEMORY_UTILIZATION:-0.65}"
+      --vllm-moe-backend "${VLLM_MOE_BACKEND:-triton}"
+   )
+   if [[ "${ENABLE_R3}" == "1" ]]; then
+      VLLM_ARGS+=(
+         --vllm-max-model-len "${VLLM_MAX_MODEL_LEN:-6144}"
+         --vllm-server-concurrency "${VLLM_SERVER_CONCURRENCY:-96}"
+         --update-weight-buffer-size "${UPDATE_WEIGHT_BUFFER_SIZE:-$((512 * 1024 * 1024))}"
+      )
+   fi
+
+   MISC_ARGS=(
+      --attention-dropout 0.0
+      --hidden-dropout 0.0
+      --accumulate-allreduce-grads-in-fp32
+      --attention-softmax-in-fp32
+      --attention-backend flash
+      --moe-token-dispatcher-type alltoall
+   )
+fi
+
+RAY_ADDRESS="${RAY_ADDRESS:-http://127.0.0.1:8265}"
+
+if [[ "${ACTOR_NUM_NODES}" -le 1 ]]; then
+   # launch the master node of ray in container
+   export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+   ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus "${ACTOR_NUM_GPUS_PER_NODE}" \
+      --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+   RUNTIME_ENV_JSON="{
+     \"env_vars\": {
+       \"PYTHONPATH\": \"/root/Megatron-LM/\",
+       \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+       \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\"
+     }
+   }"
+else
+   RUNTIME_ENV_JSON="{
+     \"env_vars\": {
+       \"PYTHONPATH\": \"${VIME_ROOT}:/root/Megatron-LM/\",
+       \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+       \"MASTER_ADDR\": \"${MASTER_ADDR}\",
+       \"NCCL_SOCKET_IFNAME\": \"${NCCL_SOCKET_IFNAME:-ens90f0np0,ens90f1np1,ens92f0np0,ens92f1np1}\",
+       \"GLOO_SOCKET_IFNAME\": \"${GLOO_SOCKET_IFNAME:-enp130s0f0}\",
+       \"NCCL_IB_DISABLE\": \"${NCCL_IB_DISABLE:-1}\",
+       \"SLIME_NCCL_BRIDGE_CPU_FALLBACK\": \"${SLIME_NCCL_BRIDGE_CPU_FALLBACK:-1}\",
+       \"VLLM_SERVER_DEV_MODE\": \"1\"
+     }
+   }"
+   cd "${VIME_ROOT}"
+fi
+
+ray job submit --address="${RAY_ADDRESS}" \
    --runtime-env-json="${RUNTIME_ENV_JSON}" \
    -- python3 train.py \
-   --actor-num-nodes 1 \
-   --actor-num-gpus-per-node 8 \
+   --actor-num-nodes "${ACTOR_NUM_NODES}" \
+   --actor-num-gpus-per-node "${ACTOR_NUM_GPUS_PER_NODE}" \
    --colocate \
    ${MODEL_ARGS[@]} \
    ${CKPT_ARGS[@]} \
@@ -151,6 +280,6 @@ ray job submit --address="http://127.0.0.1:8265" \
    ${GRPO_ARGS[@]} \
    ${WANDB_ARGS[@]} \
    ${PERF_ARGS[@]} \
-   ${EVAL_ARGS[@]} \
+   ${EVAL_ARGS[@]+"${EVAL_ARGS[@]}"} \
    ${VLLM_ARGS[@]} \
    ${MISC_ARGS[@]}


### PR DESCRIPTION
## Summary

Extend the existing Qwen3-30B-A3B example for multi-node (2×8 GPU, scalable to N nodes):

- **Docs**: merge dual-node walkthrough into `docs/zh|en/examples/qwen3-30B-A3B.md` (topology, external Ray cluster setup, env vars, troubleshooting, EPLB)
- **Script**: extend `scripts/run-qwen3-30B-A3B.sh` — single-node behavior unchanged; when `ACTOR_NUM_NODES>1`, skip Ray startup and use multi-node training defaults
- **Removed**: standalone multinode doc pages and separate head/worker shell scripts (Ray cluster is started outside the training script, per review)

Multi-node usage (after Ray cluster is up on all nodes):

```bash
export MASTER_ADDR=<head_lan_ip>
export ACTOR_NUM_NODES=2 ACTOR_NUM_GPUS_PER_NODE=8
bash scripts/run-qwen3-30B-A3B.sh
```

## Test plan

- [x] Docs render in zh/en toctree
- [x] 2-node (2×8 GPU) smoke test: start worker on all nodes, then head with `NUM_ROLLOUT=2 ENABLE_R3=0`
  - Ray cluster forms and head waits until total GPU count is ready
  - vLLM cross-node rollout engine starts and loads HF weights
  - Training runs 2 rollout steps (generate → update weights) and completes without error
  - Worker exits cleanly after head job finishes (`BARRIER_DIR/test-done`)