### PR TITLE
warn: --dist-ckpt-optim-fully-reshardable OOMs host RAM on single node (PAO 81/52 trade-off)

### DIFF
--- a/vime/backends/megatron_utils/arguments.py
+++ b/vime/backends/megatron_utils/arguments.py
@@ -89,6 +89,31 @@ def validate_args(args):
             "pipeline_model_parallel_size is 1."
         )
 
+    # --dist-ckpt-optim-fully-reshardable stores the optimizer in a model-centric layout that avoids
+    # the precision-aware-optimizer (PAO) + cpu-offload load failure
+    #   "Cannot merge two lists with different lengths (81 and 52)"
+    # (the default bucket-centric `dp_reshardable` shards are not equal-length across save/load ranks
+    # under PAO, so the dist-ckpt merge fails). The cost is paid at SAVE time: Megatron NCCL
+    # all-gathers the full optimizer state into model space on EVERY rank. On a single node all ranks
+    # materialize that copy in host RAM concurrently (~190 GB/rank for Qwen3-30B-A3B => ~1.5 TB), which
+    # OOMs the host. On >=2 nodes the ranks split across hosts and it fits. Warn so single-node users
+    # can drop the flag (cheap `dp_reshardable` save; resume then requires the same TP/PP/EP layout)
+    # rather than OOMing at the first checkpoint.
+    if (
+        getattr(args, "dist_ckpt_optim_fully_reshardable", False)
+        and getattr(args, "optimizer_cpu_offload", False)
+        and getattr(args, "actor_num_nodes", 1) == 1
+    ):
+        logger.warning(
+            "[ckpt] --dist-ckpt-optim-fully-reshardable + --optimizer-cpu-offload on a single node: "
+            "the optimizer state is NCCL all-gathered into model space on every rank at save time and "
+            "held in host RAM concurrently (~190 GB/rank for a 30B model), which can OOM the host. "
+            "This flag is only needed to avoid the PAO load error 'Cannot merge two lists with "
+            "different lengths (81 and 52)'. For single-node runs prefer dp_reshardable (drop the "
+            "flag; resume then needs the same TP/PP/EP layout); keep fully_reshardable only for "
+            ">=2-node runs where the per-host optimizer copy fits."
+        )
+
 
 def _hf_validate_args(args, hf_config):
     def equal(x, y):


### PR DESCRIPTION
## Problem

Single-node 8-GPU colocate Qwen3-30B-A3B with the PAO optimizer trio
(`--optimizer-cpu-offload` + `--overlap-cpu-optimizer-d2h-h2d` +
`--use-precision-aware-optimizer`) **OOMs the host RAM at the first checkpoint save**.
Ray kills a worker at **1836 GB / 1929 GB (95%)**; the top processes are the 8
`MegatronTrainRayActor.save_model` procs at **~190 GB each** (~1.5 TB total).

Localized to one cause (instrumented, single iteration): the spike is **100% anonymous
memory in the save processes** — shmem (CUDA-IPC weight transfer) stays flat, and the
offloaded weights are pulled back to GPU before save. The culprit is the optimizer
checkpoint **format**, selected by `--dist-ckpt-optim-fully-reshardable`.

## The 81/52 ↔ host-OOM trade-off (why this is a warning, not a behavior change)

`--dist-ckpt-optim-fully-reshardable` is a **two-sided coin**:

- **Why it's there (load side).** Without it, resuming under the PAO + cpu-offload combo
  fails at load with:
  ```
  ValueError: Cannot merge two lists with different lengths (81 and 52)
  @ optimizer.param_state / (torch.bfloat16, torch.float32)
  ```
  Megatron's default `dp_reshardable` stores the optimizer in the internal **bucket**
  layout — each bucket emits a *variable-length list* of ShardedTensors (params + intra-param
  paddings). Under PAO the `param_state` mixes bf16 params, an fp32 master copy and a scalar
  `step`, so the number of list entries per bucket differs across ranks/dtypes (81 vs 52) and
  the dist-ckpt merge across the global metadata fails. This was the reason the flag was added
  (#27 / #50). **It is a Megatron distributed-optimizer + PAO issue — not megatron-bridge**
  (bridge only converts weights and never touches `optimizer.param_state`; bisect confirmed:
  `CKPT_NO_OPTIM_OFFLOAD=1` makes save+load pass).

- **What it costs (save side).** `fully_reshardable` reshapes every parameter into a
  deterministic model-space tensor (so the merge can't mismatch), but to do so it
  **NCCL all-gathers the full optimizer state into model space on _every_ rank** at save time
  (`mem_efficient=False`, the default; `sharded_param_state_fully_reshardable` in
  `distrib_optimizer.py`). On a single node all 8 ranks materialize that copy in host RAM at
  once (~190 GB/rank for 30B → ~1.5 TB) → host OOM. On ≥2 nodes the ranks split across hosts
  (4/host) and it fits — which is why multi-node training and the small 4B ckpt test never hit
  this.

`--distrib-optim-fully-reshardable-mem-efficient` (Gloo, materialize only on DP rank 0) does
**not** help single-node MoE layouts where DP=1 (TP×CP×EP fills the node), because every rank
is its own DP-rank-0 and still materializes.

## What this PR does

Adds a **non-breaking startup warning** in `validate_args` when
`dist_ckpt_optim_fully_reshardable` + `optimizer_cpu_offload` are set on a single node
(`actor_num_nodes == 1`). It explains the host-OOM risk, names the 81/52 error the flag exists
to avoid, and points single-node users at `dp_reshardable` (drop the flag; resume then requires
the same TP/PP/EP layout). It intentionally does **not** change the format automatically —
that's a resume-capability vs. host-memory trade-off the operator should make.

For reference, none of slime / miles / verl force `fully_reshardable`; all default to
`dp_reshardable` (verl makes `fully_reshardable` opt-in with a `mem_efficient` companion).

## Verification

Dropping the flag (→ `dp_reshardable`) on the same single-node 30B run: save with `save_optim=True`
completes, host `anon` goes **420 → 423 GB** (vs **420 → 1256 GB** with the flag), peak host
**~1.5 TB** (was OOM at 1.9 TB), `successfully saved checkpoint from iteration 0`, no 81/52.

## Test plan

- `python tests/test_qwen3_4B_ckpt.py` (unchanged; still passes with the flag — 4B is small enough
  that the gather fits).
- Warning is log-only; no behavior change.
