### PR TITLE
[Chore] satisfy pre-commit on rollout.py + vllm_engine.py (pre-existing lint debt)

### DIFF
--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -521,6 +521,8 @@ def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None)
         if process is not None and not process.is_alive():
             raise RuntimeError(f"vLLM server exited unexpectedly with code {process.exitcode}")
         time.sleep(2)
+
+
 class VLLMEngine(RayActor):
     """Ray actor for vLLM OpenAI HTTP rollout (connect or spawn local ``vllm serve``)."""
 

--- a/vime/ray/rollout.py
+++ b/vime/ray/rollout.py
@@ -5,7 +5,6 @@ import multiprocessing
 import os
 import random
 import time
-from argparse import Namespace
 from pathlib import Path
 from typing import Any
 
@@ -13,8 +12,10 @@ import numpy as np
 import ray
 import torch
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
 from vime.backends.vllm_utils.vllm_config import ModelConfig, ServerGroupConfig, VllmConfig
 from vime.backends.vllm_utils.vllm_engine import VLLMEngine
+
 # Memory-type tag strings shared with the vLLM engine's sleep/wake_up API.
 GPU_MEMORY_TYPE_KV_CACHE = "kv_cache"
 GPU_MEMORY_TYPE_WEIGHTS = "weights"
@@ -919,9 +920,9 @@ def _start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool 
         if router_port is None:
             router_port = find_available_port(random.randint(3000, 4000))
 
-    from vime.utils.http_utils import run_router
-
     from vllm_router.router_args import RouterArgs
+
+    from vime.utils.http_utils import run_router
 
     router_args = RouterArgs.from_cli_args(args, use_router_prefix=True)
 


### PR DESCRIPTION
## What

Mechanical pre-commit cleanup of two files that carry **pre-existing** lint debt on `main`. Decoupled into its own PR (per maintainer request) so the functional sync PRs (#137 PR-F, #138 PR-C) stay free of unrelated reformatting noise.

Applies exactly what the repo's own pre-commit hooks (ruff `--fix`, autoflake, isort `--profile=black`, black `-l119`) produce — no hand edits:

- **`vime/ray/rollout.py`**
  - drop unused `from argparse import Namespace` (ruff F401 / autoflake; zero remaining refs)
  - isort group separation (blank line after the `ray.util` third-party import)
  - reorder two **function-local lazy imports** in `_start_router` so third-party (`vllm_router.router_args.RouterArgs`) precedes first-party (`vime.utils.http_utils.run_router`) — behavior-neutral
- **`vime/backends/vllm_utils/vllm_engine.py`**
  - +2 blank lines before `class VLLMEngine` (black E302)

## Why

`main` is already red on `pre-commit run --all-files` in these two files. Any PR touching them inherits the red gate. Fixing it here keeps the gate green for #137/#138 without bundling formatting churn into review.

## Verification

- All 4 pre-commit hooks pass after the change.
- `python -m py_compile` clean on both files.
- +6/−3, no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)