### PR TITLE
[Sync][B] models/backends: MiniMax-M2.5 + rollout GPU-placement validation (slime #1929/#1992/#1934/#1944)

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -482,7 +482,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        info: [{"num_gpus": 0, "test_file": "test_megatron_argument_validation.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_rollout_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_runtime_hook_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_path_loading_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_generate_contracts.py"}, {"num_gpus": 0, "test_file": "test_rm_deepscaler.py"}, {"num_gpus": 0, "test_file": "test_rm_f1.py"}, {"num_gpus": 0, "test_file": "test_rm_gpqa.py"}, {"num_gpus": 0, "test_file": "test_rm_math.py"}, {"num_gpus": 0, "test_file": "test_rm_math_dapo.py"}]
+        info: [{"num_gpus": 0, "test_file": "test_megatron_argument_validation.py"}, {"num_gpus": 0, "test_file": "test_rollout_validation.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_rollout_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_runtime_hook_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_path_loading_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_generate_contracts.py"}, {"num_gpus": 0, "test_file": "test_rm_deepscaler.py"}, {"num_gpus": 0, "test_file": "test_rm_f1.py"}, {"num_gpus": 0, "test_file": "test_rm_gpqa.py"}, {"num_gpus": 0, "test_file": "test_rm_math.py"}, {"num_gpus": 0, "test_file": "test_rm_math_dapo.py"}]
     defaults:
       run:
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -55,6 +55,7 @@
       'cpu': True,
       'tests': [
         {'test_file': 'test_megatron_argument_validation.py', 'num_gpus': 0},
+        {'test_file': 'test_rollout_validation.py', 'num_gpus': 0},
         {'test_file': 'plugin_contracts/test_plugin_rollout_contracts.py', 'num_gpus': 0},
         {'test_file': 'plugin_contracts/test_plugin_runtime_hook_contracts.py', 'num_gpus': 0},
         {'test_file': 'plugin_contracts/test_plugin_path_loading_contracts.py', 'num_gpus': 0},

--- a/scripts/models/minimax-m2.sh
+++ b/scripts/models/minimax-m2.sh
@@ -1,0 +1,39 @@
+# MiniMax-M2.5 (229B, 62 layers, 256 experts, top-8)
+MODEL_ARGS=(
+    --spec "vime_plugins.models.minimax_m2" "get_minimax_m2_layer_spec"
+    --disable-bias-linear
+    --num-layers 62
+    --hidden-size 3072
+    --ffn-hidden-size 1536
+    --num-attention-heads 48
+    --kv-channels 128
+    --num-query-groups 8
+    --normalization RMSNorm
+    --position-embedding-type rope
+    --norm-epsilon 1e-6
+    --swiglu
+    --untie-embeddings-and-output-weights
+    --vocab-size 200064
+    --group-query-attention
+
+    --rotary-percent 0.5
+    --rotary-base 5000000
+    --qk-layernorm
+    --no-rope-fusion
+    --attention-softmax-in-fp32
+
+    # MoE
+    --num-experts 256
+    --moe-ffn-hidden-size 1536
+    --moe-router-topk 8
+    --moe-layer-freq "[1]*62"
+    --moe-router-pre-softmax
+    --moe-router-score-function sigmoid
+    --moe-router-enable-expert-bias
+    --moe-router-load-balancing-type none
+    --moe-token-dispatcher-type alltoall
+    --moe-router-dtype fp32
+    --moe-aux-loss-coeff 0
+    --moe-grouped-gemm
+    --moe-permute-fusion
+)

--- a/scripts/run-minimax-m2.sh
+++ b/scripts/run-minimax-m2.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# ============================================================
+# Script 2/3: MiniMax-M2.5 (229B MoE) RL Training
+# ============================================================
+
+# for rerun the task
+pkill -9 -f "vllm serve"
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python
+
+set -ex
+
+export PYTHONBUFFERED=16
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "$NVLINK_COUNT" -gt 0 ]; then
+    HAS_NVLINK=1
+else
+    HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+source "${SCRIPT_DIR}/models/minimax-m2.sh"
+
+# ---- Paths (modify according to your environment) ----
+BASE_DIR=${BASE_DIR:-"/root"}
+
+CKPT_ARGS=(
+   --hf-checkpoint ${BASE_DIR}/MiniMax-M2.5
+   --ref-load ${BASE_DIR}/MiniMax-M2.5_torch_dist
+   --load ${BASE_DIR}/MiniMax-M2.5_slime/
+   --save ${BASE_DIR}/MiniMax-M2.5_slime/
+   --save-interval 20
+   --megatron-to-hf-mode raw
+   --model-name minimax_m2
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data ${BASE_DIR}/dapo-math-17k/dapo-math-17k.jsonl
+   --input-key prompt
+   --label-key label
+   --apply-chat-template
+   --rollout-shuffle
+   --rm-type deepscaler
+   --num-rollout 3000
+   --rollout-batch-size 128
+   --n-samples-per-prompt 8
+   --rollout-max-response-len 32768
+   --rollout-temperature 1
+
+   --over-sampling-batch-size 256
+   --dynamic-sampling-filter-path vime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std
+
+   --num-steps-per-rollout 4
+   --balance-data
+)
+
+EVAL_ARGS=(
+   --eval-interval 20
+   --eval-prompt-data aime ${BASE_DIR}/rl_data/aime-2024.jsonl
+   --n-samples-per-eval-prompt 8
+   --eval-max-response-len 32768
+   --eval-top-p 1
+)
+
+# ---- Parallelism Strategy ----
+# 229B MoE, 256 experts -> requires many GPUs
+# Typical config: TP=2, PP=2, EP=4, training side 16 GPUs (2 nodes x 8 GPUs)
+# Inference side: vLLM on separate GPUs, EP=16+
+PERF_ARGS=(
+   --tensor-model-parallel-size 2
+   --sequence-parallel
+   --pipeline-model-parallel-size 2
+   --context-parallel-size 1
+   --expert-model-parallel-size 4
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 8192
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --use-kl-loss
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+WANDB_ARGS=(
+   # --use-wandb
+   # --wandb-project vime-dev
+   # --wandb-group minimax-m2-rl
+   # --wandb-key ${WANDB_KEY}
+)
+
+TB_ARGS=(
+   --use-tensorboard
+)
+
+VLLM_ARGS=(
+   --rollout-num-gpus-per-engine 16
+   --vllm-gpu-memory-utilization 0.7
+   --vllm-enable-expert-parallel
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+)
+
+# launch the master node of ray in container
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+export no_proxy="127.0.0.1,${MASTER_ADDR}"
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"no_proxy\": \"localhost,127.0.0.1,0.0.0.0,${MASTER_ADDR}\",
+    \"MASTER_ADDR\": \"${MASTER_ADDR}\",
+    \"PYTHONPATH\": \"/root/Megatron-LM/\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\"
+  }
+}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 train.py \
+   --actor-num-nodes 16 \
+   --actor-num-gpus-per-node 8 \
+   --colocate \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${TB_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${VLLM_ARGS[@]} \
+   ${MISC_ARGS[@]}

--- a/tests/test_rollout_validation.py
+++ b/tests/test_rollout_validation.py
@@ -1,0 +1,60 @@
+import pytest
+
+from vime.ray.rollout_validation import validate_server_group_gpu_indices
+
+
+@pytest.mark.unit
+def test_validate_server_group_gpu_indices_accepts_valid_config():
+    validate_server_group_gpu_indices(
+        worker_type="regular",
+        gpu_offset=2,
+        num_gpus_per_engine=1,
+        num_gpu_per_engine=1,
+        num_engines=2,
+        num_available_gpus=4,
+        rollout_num_gpus=4,
+        rollout_num_gpus_per_engine=1,
+    )
+
+
+@pytest.mark.unit
+def test_validate_server_group_gpu_indices_allows_empty_group():
+    validate_server_group_gpu_indices(
+        worker_type="placeholder",
+        gpu_offset=4,
+        num_gpus_per_engine=1,
+        num_gpu_per_engine=1,
+        num_engines=0,
+        num_available_gpus=4,
+        rollout_num_gpus=4,
+        rollout_num_gpus_per_engine=1,
+    )
+
+
+@pytest.mark.unit
+def test_validate_server_group_gpu_indices_reports_config_context():
+    with pytest.raises(ValueError) as exc_info:
+        validate_server_group_gpu_indices(
+            worker_type="regular",
+            gpu_offset=3,
+            num_gpus_per_engine=2,
+            num_gpu_per_engine=2,
+            num_engines=1,
+            num_available_gpus=4,
+            rollout_num_gpus=4,
+            rollout_num_gpus_per_engine=2,
+        )
+
+    message = str(exc_info.value)
+    assert "worker_type=regular" in message
+    assert "gpu_offset=3" in message
+    assert "num_gpus_per_engine=2" in message
+    assert "num_engines=1" in message
+    assert "required_gpu_slots=5" in message
+    assert "len(reordered_gpu_ids)=4" in message
+    assert "rollout_num_gpus=4" in message
+    assert "rollout_num_gpus_per_engine=2" in message
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/vime/backends/megatron_utils/megatron_to_hf/__init__.py
+++ b/vime/backends/megatron_utils/megatron_to_hf/__init__.py
@@ -4,6 +4,7 @@ from .glm4moe import convert_glm4moe_to_hf
 from .gpt_oss import convert_gpt_oss_to_hf
 from .llama import convert_llama_to_hf
 from .mimo import convert_mimo_to_hf
+from .minimax_m2 import convert_minimax_m2_to_hf
 from .processors import quantize_params, remove_padding
 from .qwen2 import convert_qwen2_to_hf
 from .qwen3_5 import convert_qwen3_5_to_hf
@@ -30,7 +31,9 @@ def convert_to_hf(args, model_name, name, param, quantization_config=None):
 
 # TODO optimize code details
 def _convert_to_hf_core(args, model_name, name, param):
-    if "glm4moelite" in model_name or "deepseekv3" in model_name:
+    if "minimaxm2" in model_name or "minimax_m2" in model_name:
+        converted_named_tensors = convert_minimax_m2_to_hf(args, name, param)
+    elif "glm4moelite" in model_name or "deepseekv3" in model_name:
         converted_named_tensors = convert_deepseekv3_to_hf(args, name, param)
     elif "glm4moe" in model_name:
         converted_named_tensors = convert_glm4moe_to_hf(args, name, param)

--- a/vime/backends/megatron_utils/megatron_to_hf/minimax_m2.py
+++ b/vime/backends/megatron_utils/megatron_to_hf/minimax_m2.py
@@ -1,0 +1,86 @@
+import re
+
+import torch
+
+
+def convert_minimax_m2_to_hf(args, name, param):
+    """Convert Megatron parameter names/tensors to HuggingFace format for MiniMax-M2.5.
+
+    HF uses `block_sparse_moe` prefix with expert naming w1(gate)/w2(down)/w3(up).
+    Custom SelfAttention uses `q_norm`/`k_norm` (not `q_layernorm`/`k_layernorm`).
+    """
+    # Direct mappings
+    if name == "module.module.embedding.word_embeddings.weight":
+        return [("model.embed_tokens.weight", param)]
+    if name == "module.module.output_layer.weight":
+        return [("lm_head.weight", param)]
+    if name == "module.module.decoder.final_layernorm.weight":
+        return [("model.norm.weight", param)]
+
+    try:
+        head_dim = args.kv_channels if args.kv_channels is not None else args.hidden_size // args.num_attention_heads
+    except AttributeError:
+        head_dim = args.hidden_size // args.num_attention_heads
+    value_num_per_group = args.num_attention_heads // args.num_query_groups
+
+    decoder_layers_pattern = r"module\.module\.decoder\.layers\.(\d+)\.(.+)"
+    match = re.match(decoder_layers_pattern, name)
+    if match:
+        layer_idx, rest = match.groups()
+
+        # MoE experts: linear_fc1 -> w1 (gate) + w3 (up), linear_fc2 -> w2 (down)
+        expert_pattern = r"mlp.experts\.(.+)\.weight(\d+)"
+        match = re.match(expert_pattern, rest)
+        if match:
+            rest, expert_idx = match.groups()
+            if rest == "linear_fc1":
+                gate_weight, up_weight = param.chunk(2, dim=0)
+                return [
+                    (f"model.layers.{layer_idx}.block_sparse_moe.experts.{expert_idx}.w1.weight", gate_weight),
+                    (f"model.layers.{layer_idx}.block_sparse_moe.experts.{expert_idx}.w3.weight", up_weight),
+                ]
+            elif rest == "linear_fc2":
+                return [
+                    (f"model.layers.{layer_idx}.block_sparse_moe.experts.{expert_idx}.w2.weight", param),
+                ]
+            else:
+                raise ValueError(f"Unknown expert parameter name: {name}")
+
+        # Attention: o_proj
+        if rest == "self_attention.linear_proj.weight":
+            return [(f"model.layers.{layer_idx}.self_attn.o_proj.weight", param)]
+
+        # Attention: fused QKV -> split into Q/K/V (GQA: 48 heads, 8 kv heads)
+        elif rest == "self_attention.linear_qkv.weight":
+            param = param.view(args.num_query_groups, -1, head_dim, args.hidden_size)
+            q_param, k_param, v_param = torch.split(param, split_size_or_sections=[value_num_per_group, 1, 1], dim=1)
+            q_param = q_param.reshape(-1, args.hidden_size)
+            k_param = k_param.reshape(-1, args.hidden_size)
+            v_param = v_param.reshape(-1, args.hidden_size)
+            return [
+                (f"model.layers.{layer_idx}.self_attn.q_proj.weight", q_param),
+                (f"model.layers.{layer_idx}.self_attn.k_proj.weight", k_param),
+                (f"model.layers.{layer_idx}.self_attn.v_proj.weight", v_param),
+            ]
+
+        # Input layernorm
+        elif rest == "self_attention.linear_qkv.layer_norm_weight":
+            return [(f"model.layers.{layer_idx}.input_layernorm.weight", param)]
+
+        # QK Norm (custom attention uses q_norm/k_norm, NOT q_layernorm/k_layernorm)
+        elif rest == "self_attention.q_norm.weight":
+            return [(f"model.layers.{layer_idx}.self_attn.q_norm.weight", param)]
+        elif rest == "self_attention.k_norm.weight":
+            return [(f"model.layers.{layer_idx}.self_attn.k_norm.weight", param)]
+
+        # Post-attention layernorm
+        elif rest == "pre_mlp_layernorm.weight":
+            return [(f"model.layers.{layer_idx}.post_attention_layernorm.weight", param)]
+
+        # Router
+        elif rest == "mlp.router.weight":
+            return [(f"model.layers.{layer_idx}.block_sparse_moe.gate.weight", param)]
+        elif rest == "mlp.router.expert_bias":
+            return [(f"model.layers.{layer_idx}.block_sparse_moe.e_score_correction_bias", param)]
+
+    raise ValueError(f"Unknown parameter name: {name}")

--- a/vime/ray/rollout.py
+++ b/vime/ray/rollout.py
@@ -31,6 +31,7 @@ from vime.utils.seqlen_balancing import get_seqlen_balanced_partitions
 from vime.utils.types import Sample
 
 from ..utils.metric_utils import has_repetition
+from .rollout_validation import validate_server_group_gpu_indices
 from .utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST, Lock
 
 logging.getLogger("httpx").setLevel(logging.WARNING)
@@ -91,6 +92,16 @@ class ServerGroup:
         num_gpu_per_engine = min(self.num_gpus_per_engine, self.args.num_gpus_per_node)
 
         pg, reordered_bundle_indices, reordered_gpu_ids = self.pg
+        validate_server_group_gpu_indices(
+            worker_type=self.worker_type,
+            gpu_offset=self.gpu_offset,
+            num_gpus_per_engine=self.num_gpus_per_engine,
+            num_gpu_per_engine=num_gpu_per_engine,
+            num_engines=len(self.all_engines),
+            num_available_gpus=len(reordered_gpu_ids),
+            rollout_num_gpus=self.args.rollout_num_gpus,
+            rollout_num_gpus_per_engine=self.args.rollout_num_gpus_per_engine,
+        )
 
         RolloutRayActor = ray.remote(VLLMEngine)
 

--- a/vime/ray/rollout_validation.py
+++ b/vime/ray/rollout_validation.py
@@ -27,6 +27,6 @@ def validate_server_group_gpu_indices(
         f"len(reordered_gpu_ids)={num_available_gpus}, "
         f"rollout_num_gpus={rollout_num_gpus}, "
         f"rollout_num_gpus_per_engine={rollout_num_gpus_per_engine}. "
-        "Please align --rollout-num-gpus and --rollout-num-gpus-per-engine "
-        "with the rollout engine GPU placement."
+        "Please align --rollout-num-gpus, --rollout-num-gpus-per-engine, "
+        "and --vllm-config server_groups."
     )

--- a/vime/ray/rollout_validation.py
+++ b/vime/ray/rollout_validation.py
@@ -1,0 +1,32 @@
+def validate_server_group_gpu_indices(
+    *,
+    worker_type: str,
+    gpu_offset: int,
+    num_gpus_per_engine: int,
+    num_gpu_per_engine: int,
+    num_engines: int,
+    num_available_gpus: int,
+    rollout_num_gpus: int,
+    rollout_num_gpus_per_engine: int,
+) -> None:
+    if num_engines == 0:
+        return
+
+    required_gpu_slots = gpu_offset + num_engines * num_gpu_per_engine
+    if gpu_offset >= 0 and num_gpu_per_engine > 0 and required_gpu_slots <= num_available_gpus:
+        return
+
+    raise ValueError(
+        "Invalid rollout server group GPU placement: "
+        f"worker_type={worker_type}, "
+        f"gpu_offset={gpu_offset}, "
+        f"num_gpus_per_engine={num_gpus_per_engine}, "
+        f"num_gpu_per_engine_on_node={num_gpu_per_engine}, "
+        f"num_engines={num_engines}, "
+        f"required_gpu_slots={required_gpu_slots}, "
+        f"len(reordered_gpu_ids)={num_available_gpus}, "
+        f"rollout_num_gpus={rollout_num_gpus}, "
+        f"rollout_num_gpus_per_engine={rollout_num_gpus_per_engine}. "
+        "Please align --rollout-num-gpus and --rollout-num-gpus-per-engine "
+        "with the rollout engine GPU placement."
+    )

--- a/vime_plugins/mbridge/__init__.py
+++ b/vime_plugins/mbridge/__init__.py
@@ -4,6 +4,7 @@ from .glm4moe import GLM4MoEBridge
 from .glm4moe_lite import GLM4MoELiteBridge
 from .gpt_oss import GptOssBridge
 from .mimo import MimoBridge
+from .minimax_m2 import MiniMaxM2Bridge
 from .qwen3_5 import Qwen3_5Bridge
 from .qwen3_next import Qwen3NextBridge
 
@@ -12,6 +13,7 @@ __all__ = [
     "GLM4MoEBridge",
     "GLM4MoELiteBridge",
     "GptOssBridge",
+    "MiniMaxM2Bridge",
     "Qwen3NextBridge",
     "Qwen3_5Bridge",
     "MimoBridge",

--- a/vime_plugins/mbridge/minimax_m2.py
+++ b/vime_plugins/mbridge/minimax_m2.py
@@ -1,0 +1,63 @@
+from mbridge.core import register_model
+from mbridge.models import Qwen2MoEBridge
+
+
+@register_model("minimax_m2")
+class MiniMaxM2Bridge(Qwen2MoEBridge):
+    """
+    Bridge for MiniMax-M2.5 (229B MoE).
+
+    Key differences from standard Qwen2MoE:
+    - HF uses `block_sparse_moe` prefix (not `mlp`) with expert naming w1/w2/w3
+    - Full-dimension QK Norm: custom SelfAttention uses `q_norm`/`k_norm` fields
+      (NOT the default `q_layernorm`/`k_layernorm`), so state_dict key is
+      `self_attention.q_norm.weight` / `self_attention.k_norm.weight`
+    - Sigmoid router with e_score_correction_bias
+    - Partial RoPE (rotary_percent=0.5)
+    - No shared experts
+    """
+
+    _ATTENTION_MAPPING = {
+        **Qwen2MoEBridge._ATTENTION_MAPPING,
+        # Override QK norm: custom MiniMaxM2SelfAttention uses self.q_norm / self.k_norm
+        # instead of the default self.q_layernorm / self.k_layernorm
+        "self_attention.q_norm.weight": ["model.layers.{layer_number}.self_attn.q_norm.weight"],
+        "self_attention.k_norm.weight": ["model.layers.{layer_number}.self_attn.k_norm.weight"],
+    }
+
+    _MLP_MAPPING = {
+        "pre_mlp_layernorm": ["model.layers.{layer_number}.post_attention_layernorm.weight"],
+        "mlp.router.weight": ["model.layers.{layer_number}.block_sparse_moe.gate.weight"],
+        "mlp.router.expert_bias": ["model.layers.{layer_number}.block_sparse_moe.e_score_correction_bias"],
+        "mlp.experts.linear_fc1": [
+            "model.layers.{layer_number}.block_sparse_moe.experts.{expert_id}.w1.weight",  # gate_proj
+            "model.layers.{layer_number}.block_sparse_moe.experts.{expert_id}.w3.weight",  # up_proj
+        ],
+        "mlp.experts.linear_fc2": [
+            "model.layers.{layer_number}.block_sparse_moe.experts.{expert_id}.w2.weight",  # down_proj
+        ],
+    }
+
+    def _build_config(self):
+        return self._build_base_config(
+            use_cpu_initialization=False,
+            persist_layer_norm=True,
+            bias_activation_fusion=True,
+            bias_dropout_fusion=True,
+            # MoE config
+            moe_ffn_hidden_size=self.hf_config.intermediate_size,
+            moe_router_topk=self.hf_config.num_experts_per_tok,
+            num_moe_experts=self.hf_config.num_local_experts,
+            moe_router_score_function="sigmoid",
+            moe_router_enable_expert_bias=True,
+            moe_router_pre_softmax=True,
+            moe_router_dtype="fp32",
+            moe_grouped_gemm=True,
+            moe_router_load_balancing_type="none",
+            # Attention config
+            qk_layernorm=True,
+            rotary_percent=0.5,
+            add_qkv_bias=False,
+            add_bias_linear=False,
+            rotary_interleaved=False,
+        )

--- a/vime_plugins/models/minimax_m2.py
+++ b/vime_plugins/models/minimax_m2.py
@@ -1,0 +1,93 @@
+from megatron.core import parallel_state
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
+from megatron.core.tensor_parallel import (
+    gather_from_tensor_model_parallel_region,
+    scatter_to_tensor_model_parallel_region,
+)
+from megatron.core.transformer.attention import SelfAttention
+from megatron.core.transformer.identity_op import IdentityOp
+from megatron.core.transformer.spec_utils import build_module
+
+
+class MiniMaxM2SelfAttention(SelfAttention):
+    """Custom SelfAttention for MiniMax-M2.5 with full-dimension QK Norm.
+
+    MiniMax-M2.5 applies RMSNorm over all heads concatenated:
+      Q: num_attention_heads * head_dim = 48 * 128 = 6144
+      K: num_kv_heads * head_dim       =  8 * 128 = 1024
+    instead of Megatron Core's default per-head norm (head_dim=128).
+
+    With tensor parallelism, the norm requires TP gather -> norm -> TP scatter.
+    """
+
+    def __init__(self, config, submodules, *args, **kwargs):
+        # Save real layernorm specs, replace with IdentityOp so Megatron
+        # does not create per-head norms
+        q_layernorm = submodules.q_layernorm
+        k_layernorm = submodules.k_layernorm
+        submodules.q_layernorm = IdentityOp
+        submodules.k_layernorm = IdentityOp
+
+        super().__init__(config, submodules, *args, **kwargs)
+
+        # Restore submodules in case they are reused elsewhere
+        submodules.q_layernorm = q_layernorm
+        submodules.k_layernorm = k_layernorm
+
+        # Create full-dimension norms
+        self.q_norm = build_module(
+            q_layernorm,
+            hidden_size=self.hidden_size_per_attention_head * config.num_attention_heads,
+            config=self.config,
+            eps=self.config.layernorm_epsilon,
+        )
+        self.k_norm = build_module(
+            k_layernorm,
+            hidden_size=self.hidden_size_per_attention_head * config.num_query_groups,
+            config=self.config,
+            eps=self.config.layernorm_epsilon,
+        )
+
+    def get_query_key_value_tensors(self, hidden_states, key_value_states=None, *args, **kwargs):
+        query, key, value = super().get_query_key_value_tensors(hidden_states, key_value_states, *args, **kwargs)
+        # query: [sq, b, num_heads_local, head_dim]
+        # key:   [sq, b, num_kv_heads_local, head_dim]
+
+        # Merge head dims: [sq, b, num_heads_local * head_dim]
+        query = query.reshape(*query.shape[:-2], -1)
+        key = key.reshape(*key.shape[:-2], -1)
+
+        # TP gather -> full-dimension norm -> TP scatter
+        tp_size = parallel_state.get_tensor_model_parallel_world_size()
+        if tp_size > 1:
+            query = gather_from_tensor_model_parallel_region(query)
+            key = gather_from_tensor_model_parallel_region(key)
+
+        query = self.q_norm(query)
+        key = self.k_norm(key)
+
+        if tp_size > 1:
+            query = scatter_to_tensor_model_parallel_region(query)
+            key = scatter_to_tensor_model_parallel_region(key)
+
+        # Reshape back: [sq, b, num_heads_local, head_dim]
+        query = query.view(*query.shape[:2], -1, self.hidden_size_per_attention_head)
+        key = key.view(*key.shape[:2], -1, self.hidden_size_per_attention_head)
+
+        return query, key, value
+
+
+def get_minimax_m2_layer_spec(args, config, vp_stage=None):
+    """Build layer spec for MiniMax-M2.5, replacing SelfAttention with the custom version.
+
+    Used via: --spec "vime_plugins.models.minimax_m2" "get_minimax_m2_layer_spec"
+    """
+    kwargs = {"use_transformer_engine": args.transformer_impl == "transformer_engine"}
+    if vp_stage is not None:
+        kwargs["vp_stage"] = vp_stage
+    spec = get_gpt_decoder_block_spec(config, **kwargs)
+
+    for layer_spec in spec.layer_specs:
+        layer_spec.submodules.self_attention.module = MiniMaxM2SelfAttention
+
+    return spec


### PR DESCRIPTION
## Scope — PR-B (models/backends mega-PR), part of RFC #107

This PR lands the **non-image** half of mega-PR B. The two image-gated pieces (#1947 FlashQLA, #1952 disable-param-backup) are **deliberately held** for follow-up commits because both modify the build (`Dockerfile` / `docker/patch/latest/megatron.patch`) and require a gb200+h200 image rebuild before their code can run — see "Pending" below.

### Included (B-core, runs on the current image)
- **slime #1934 + #1944 — rollout GPU-placement validation** (`07877b8`): `vime/ray/rollout_validation.py` + `validate_server_group_gpu_indices`, wired into rollout start + registered in CI (`test_rollout_validation.py`, 0-GPU). Reused as-is from the already-translated branch.
- **slime #1929 (minus #1992-deleted scripts) — MiniMax-M2.5 support** (`a262bd4`): megatron layer spec (`vime_plugins/models/minimax_m2.py`), mbridge online-sync bridge, megatron→hf converter, and `minimax-m2` / `run-minimax-m2` launchers. Rollout path translated **sglang→vLLM** (`--sglang-* → --vllm-*`, `--sglang-ep-size N → --vllm-enable-expert-parallel`, `pkill sglang → pkill -f "vllm serve"`). The two `convert-minimax-m2-*.sh` scripts that #1929 added are **omitted** (deleted by follow-up #1992).

### Pending (B-docker — separate commits, **image-rebuild-gated**)
- **slime #1947 — FlashQLA GDN backend**: edits `docker/Dockerfile` (`pip install FlashQLA`) → needs arm+x86 image rebuild. This is the **Megatron train-side** GDN kernel for Qwen3.5/Qwen3-Next (vLLM rollout already provides `qwen_gdn_attention_core`).
- **slime #1952 — disable param-buffers CPU backup**: edits `docker/patch/latest/megatron.patch` (DDP `_ParamAndGradBuffer` surgery) + actor/arguments python that *depends* on that patch (`disable_param_buffers_cpu_backup`) → also rebuild-gated; train-memory, higher-risk, will get its own careful review.

### CI
- cpu/arm gate on the F+C+B stack: in progress (placement test `test_rollout_validation.py` registered).
- Full gb200 matrix + h200 precision: runs on the cumulative stack (stack-3) per the solo CI workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
## Fidelity ledger (audited 2026-06-04)

| op | detail |
|---|---|
| **Ported** | #1929 MiniMax-M2 plugins (megatron_to_hf + mbridge + models) ; #1934/#1944 `ray/rollout_validation.py` GPU-placement pre-flight |
| **Translated** (sglang→vllm) | GPU-placement validation adapted to vLLM engine layout |
| **Deferred** | FlashQLA/GDN (qwen_gdn_backend + reloadable memory-skip) → **#1947**, edits Dockerfile, rebuild-gated |
| **Verified** | minimax present + `test_rollout_validation` PASS on rebuilt stack (8914) |