### PR TITLE
[Bugfix] colocate: keep the vLLM rollout subprocess on the trainer's physical GPUs under a non-zero CUDA_VISIBLE_DEVICES

### DIFF
--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -66,6 +66,29 @@ def test_to_local_gpu_id_maps_physical_id(monkeypatch):
 
 
 @pytest.mark.unit
+def test_resolve_subprocess_cvd_no_inherited_is_identity(monkeypatch):
+    # Full-machine / 0-based path: unchanged.
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    assert mod._resolve_subprocess_cvd("0,1,2,3") == "0,1,2,3"
+
+
+@pytest.mark.unit
+def test_resolve_subprocess_cvd_composes_through_inherited(monkeypatch):
+    # Launched with CVD=4,5,6,7 (GPU 0 occupied). Local "0,1,2,3" must map to the
+    # absolute physical "4,5,6,7" so vLLM colocates with the Ray-placed trainer.
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5,6,7")
+    assert mod._resolve_subprocess_cvd("0,1,2,3") == "4,5,6,7"
+    # A 2-GPU sub-slice starting at local 2 → physical 6,7.
+    assert mod._resolve_subprocess_cvd("2,3") == "6,7"
+
+
+@pytest.mark.unit
+def test_resolve_subprocess_cvd_identity_when_inherited_is_zero_based(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1,2,3,4,5,6,7")
+    assert mod._resolve_subprocess_cvd("0,1,2,3") == "0,1,2,3"
+
+
+@pytest.mark.unit
 def test_compute_vllm_engine_topology_single_node(vllm_args):
     vllm_args.num_gpus_per_node = 8
     vllm_args.rollout_num_gpus_per_engine = 4

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -55,49 +55,6 @@ def test_format_v6_uri_ipv4_unchanged():
 
 
 @pytest.mark.unit
-def test_to_local_gpu_id_without_cvd():
-    assert mod._to_local_gpu_id(3) == 3
-
-
-@pytest.mark.unit
-def test_to_local_gpu_id_maps_physical_id(monkeypatch):
-    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3,4")
-    assert mod._to_local_gpu_id(3) == 1
-
-
-@pytest.mark.unit
-def test_resolve_subprocess_cvd_no_inherited_is_identity(monkeypatch):
-    # Full-machine / 0-based path: unchanged.
-    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
-    assert mod._resolve_subprocess_cvd("0,1,2,3") == "0,1,2,3"
-
-
-@pytest.mark.unit
-def test_resolve_subprocess_cvd_composes_through_inherited(monkeypatch):
-    # Launched with CVD=4,5,6,7 (GPU 0 occupied). Local "0,1,2,3" must map to the
-    # absolute physical "4,5,6,7" so vLLM colocates with the Ray-placed trainer.
-    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5,6,7")
-    assert mod._resolve_subprocess_cvd("0,1,2,3") == "4,5,6,7"
-    # A 2-GPU sub-slice starting at local 2 → physical 6,7.
-    assert mod._resolve_subprocess_cvd("2,3") == "6,7"
-
-
-@pytest.mark.unit
-def test_resolve_subprocess_cvd_identity_when_inherited_is_zero_based(monkeypatch):
-    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1,2,3,4,5,6,7")
-    assert mod._resolve_subprocess_cvd("0,1,2,3") == "0,1,2,3"
-
-
-@pytest.mark.unit
-def test_resolve_subprocess_cvd_raises_on_out_of_range(monkeypatch):
-    # A local index that doesn't address the inherited set means a broken placement
-    # invariant — fail fast instead of silently mis-pinning the GPU.
-    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5")  # only 2 visible devices
-    with pytest.raises(IndexError):
-        mod._resolve_subprocess_cvd("0,1,2,3")  # local 2,3 out of range
-
-
-@pytest.mark.unit
 def test_compute_vllm_engine_topology_single_node(vllm_args):
     vllm_args.num_gpus_per_node = 8
     vllm_args.rollout_num_gpus_per_engine = 4

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -89,6 +89,15 @@ def test_resolve_subprocess_cvd_identity_when_inherited_is_zero_based(monkeypatc
 
 
 @pytest.mark.unit
+def test_resolve_subprocess_cvd_raises_on_out_of_range(monkeypatch):
+    # A local index that doesn't address the inherited set means a broken placement
+    # invariant — fail fast instead of silently mis-pinning the GPU.
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5")  # only 2 visible devices
+    with pytest.raises(IndexError):
+        mod._resolve_subprocess_cvd("0,1,2,3")  # local 2,3 out of range
+
+
+@pytest.mark.unit
 def test_compute_vllm_engine_topology_single_node(vllm_args):
     vllm_args.num_gpus_per_node = 8
     vllm_args.rollout_num_gpus_per_engine = 4

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -381,7 +381,14 @@ def _resolve_subprocess_cvd(visible_devices: str) -> str:
         if tok == "":
             continue
         idx = int(tok)
-        out.append(inh[idx] if 0 <= idx < len(inh) else tok)
+        if not (0 <= idx < len(inh)):
+            # Local indices must address the inherited set; an out-of-range index means a
+            # broken placement invariant — fail loudly rather than silently mis-pin the GPU.
+            raise IndexError(
+                f"local GPU index {idx} is out of range for inherited "
+                f"CUDA_VISIBLE_DEVICES={inherited!r} ({len(inh)} devices)"
+            )
+        out.append(inh[idx])
     return ",".join(out)
 
 

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -354,13 +354,44 @@ def redact_cmd_for_log(cmd: list[str]) -> str:
     return " ".join(parts)
 
 
+def _resolve_subprocess_cvd(visible_devices: str) -> str:
+    """Map ``visible_devices`` (LOCAL 0-based indices) to ABSOLUTE physical GPU ids.
+
+    ``compute_server_args`` builds ``visible_devices`` from ``_to_local_gpu_id`` — i.e.
+    indices into the actor's *visible* GPU set, not absolute physical ids.  Rollout
+    actors run with ``RAY_EXPERIMENTAL_NOSET_*`` so Ray does NOT restrict their CVD;
+    they inherit the raylet's ``CUDA_VISIBLE_DEVICES`` (e.g. ``"4,5,6,7"`` when the run
+    was launched that way to avoid an occupied GPU).  Setting the ``vllm serve``
+    subprocess CVD to the raw local indices (``"0,1,2,3"``) makes CUDA read them as
+    ABSOLUTE physical 0-3, desyncing colocate — the Megatron trainer (Ray-placed on the
+    inherited 4-7) and vLLM then sit on different physical GPUs, so the IPC weight
+    handles (keyed by physical GPU UUID) don't match ("IPC handle not found").
+
+    Composing the local indices back through the inherited set recovers the physical
+    ids (``"4,5,6,7"``).  No-op when CVD is unset or already identity 0-based, so the
+    full-machine / 0-based path is unchanged.
+    """
+    inherited = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if not inherited:
+        return visible_devices
+    inh = [x for x in inherited.split(",") if x.strip() != ""]
+    out: list[str] = []
+    for tok in visible_devices.split(","):
+        tok = tok.strip()
+        if tok == "":
+            continue
+        idx = int(tok)
+        out.append(inh[idx] if 0 <= idx < len(inh) else tok)
+    return ",".join(out)
+
+
 def build_vllm_subprocess_env(server_args: dict[str, Any]) -> dict[str, str]:
     """Child-process environment for ``vllm serve``."""
     args = server_args["args"]
     env = os.environ.copy()
     env.pop("PYTORCH_CUDA_ALLOC_CONF", None)
     env.setdefault("NCCL_CUMEM_ENABLE", "0")
-    env["CUDA_VISIBLE_DEVICES"] = server_args["visible_devices"]
+    env["CUDA_VISIBLE_DEVICES"] = _resolve_subprocess_cvd(server_args["visible_devices"])
     env.setdefault("VLLM_SERVER_DEV_MODE", "1")
     if getattr(args, "colocate", False):
         import vime

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -78,21 +78,6 @@ def get_base_gpu_id(args, rank):
     return start_index
 
 
-def _to_local_gpu_id(physical_gpu_id: int) -> int:
-    cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
-    if not cvd:
-        return physical_gpu_id
-    visible = [int(x) for x in cvd.split(",") if x.strip() != ""]
-    if physical_gpu_id in visible:
-        return visible.index(physical_gpu_id)
-    if 0 <= physical_gpu_id < len(visible):
-        return physical_gpu_id
-    raise RuntimeError(
-        f"GPU id {physical_gpu_id} is not valid under CUDA_VISIBLE_DEVICES={cvd}. "
-        f"Expected one of {visible} (physical) or 0..{len(visible)-1} (local)."
-    )
-
-
 @dataclasses.dataclass(frozen=True)
 class VllmEngineTopology:
     """Per-Ray-actor placement for one slice of a logical rollout engine."""
@@ -354,51 +339,13 @@ def redact_cmd_for_log(cmd: list[str]) -> str:
     return " ".join(parts)
 
 
-def _resolve_subprocess_cvd(visible_devices: str) -> str:
-    """Map ``visible_devices`` (LOCAL 0-based indices) to ABSOLUTE physical GPU ids.
-
-    ``compute_server_args`` builds ``visible_devices`` from ``_to_local_gpu_id`` — i.e.
-    indices into the actor's *visible* GPU set, not absolute physical ids.  Rollout
-    actors run with ``RAY_EXPERIMENTAL_NOSET_*`` so Ray does NOT restrict their CVD;
-    they inherit the raylet's ``CUDA_VISIBLE_DEVICES`` (e.g. ``"4,5,6,7"`` when the run
-    was launched that way to avoid an occupied GPU).  Setting the ``vllm serve``
-    subprocess CVD to the raw local indices (``"0,1,2,3"``) makes CUDA read them as
-    ABSOLUTE physical 0-3, desyncing colocate — the Megatron trainer (Ray-placed on the
-    inherited 4-7) and vLLM then sit on different physical GPUs, so the IPC weight
-    handles (keyed by physical GPU UUID) don't match ("IPC handle not found").
-
-    Composing the local indices back through the inherited set recovers the physical
-    ids (``"4,5,6,7"``).  No-op when CVD is unset or already identity 0-based, so the
-    full-machine / 0-based path is unchanged.
-    """
-    inherited = os.environ.get("CUDA_VISIBLE_DEVICES")
-    if not inherited:
-        return visible_devices
-    inh = [x for x in inherited.split(",") if x.strip() != ""]
-    out: list[str] = []
-    for tok in visible_devices.split(","):
-        tok = tok.strip()
-        if tok == "":
-            continue
-        idx = int(tok)
-        if not (0 <= idx < len(inh)):
-            # Local indices must address the inherited set; an out-of-range index means a
-            # broken placement invariant — fail loudly rather than silently mis-pin the GPU.
-            raise IndexError(
-                f"local GPU index {idx} is out of range for inherited "
-                f"CUDA_VISIBLE_DEVICES={inherited!r} ({len(inh)} devices)"
-            )
-        out.append(inh[idx])
-    return ",".join(out)
-
-
 def build_vllm_subprocess_env(server_args: dict[str, Any]) -> dict[str, str]:
     """Child-process environment for ``vllm serve``."""
     args = server_args["args"]
     env = os.environ.copy()
     env.pop("PYTORCH_CUDA_ALLOC_CONF", None)
     env.setdefault("NCCL_CUMEM_ENABLE", "0")
-    env["CUDA_VISIBLE_DEVICES"] = _resolve_subprocess_cvd(server_args["visible_devices"])
+    env["CUDA_VISIBLE_DEVICES"] = server_args["visible_devices"]
     env.setdefault("VLLM_SERVER_DEV_MODE", "1")
     if getattr(args, "colocate", False):
         import vime
@@ -1131,7 +1078,6 @@ def _compute_server_args(
 
     topology = compute_vllm_engine_topology(args, rank, num_gpus_per_engine=gpus_per_engine)
     base = base_gpu_id if base_gpu_id is not None else get_base_gpu_id(args, rank)
-    base = _to_local_gpu_id(base)
 
     master_addr: str | None = None
     master_port: int | None = None


### PR DESCRIPTION
### What

In colocate mode, when a run is pinned to a **non-zero** `CUDA_VISIBLE_DEVICES` (e.g. `4,5,6,7` because GPU 0
is occupied), the vLLM rollout subprocess and the Megatron trainer end up on **different physical GPUs**, so
IPC weight sync fails:

```
ValueError: IPC handle not found for GPU UUID ce05236b-...   # vLLM worker  (physical 0–3)
Available UUIDs: ['b6557281-...', 'fc4ecefd-...', ...]        # from trainer (physical 4–7)
```

This makes the vLLM subprocess land on the **same** physical GPUs as the trainer, so colocate works when
pinned to any contiguous GPU range, not just `0..N-1`.

### Root cause

Rollout actors run with `RAY_EXPERIMENTAL_NOSET_*`, so Ray does not restrict their `CUDA_VISIBLE_DEVICES`;
they inherit the raylet's CVD. `compute_server_args` builds `visible_devices` as **local 0-based indices**
(via `_to_local_gpu_id`), and `build_vllm_subprocess_env` sets that as the subprocess's **absolute**
`CUDA_VISIBLE_DEVICES`. When the inherited CVD is non-zero (`"4,5,6,7"`), the local string `"0,1,2,3"` is read
as **absolute physical 0–3**, while the Ray-placed trainer is on physical 4–7 → different GPUs → the IPC
weight handles (keyed by physical GPU UUID) don't match. Under an identity CVD (`0..N-1`) local and physical
indices coincide, which is why this only shows up when pinning to a non-zero range.

### Fix

`build_vllm_subprocess_env` maps the local visible-device indices back through the inherited CVD to absolute
physical ids (`_resolve_subprocess_cvd`). No-op when CVD is unset or already identity 0-based, so the
full-machine / 0-based path is unchanged.

### Tests

- Unit (`tests/unit/backends/vllm_utils/test_vllm_engine.py`): `test_resolve_subprocess_cvd_*`
  (no-inherited identity / compose-through `4,5,6,7` → `4,5,6,7`, sub-slice `2,3` → `6,7` / identity `0..7`).
- E2E: a colocate run pinned to `CUDA_VISIBLE_DEVICES=4,5,6,7` (4×A100) now completes weight sync and
  rollouts; previously it failed with the `IPC handle not found` error above.

### Notes

- **Independent of DP/EP.** Surfaced while validating the DP+EP spike (#56) on free GPUs (GPU 0 was busy), but
  it affects any colocate run pinned to a non-zero `CUDA_VISIBLE_DEVICES`.
- AI assistance was used in root-causing and drafting this change.

Related: #56