### PR TITLE
Add Buildkite CI pipeline

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -1,0 +1,41 @@
+# vime Buildkite CI
+
+This pipeline follows the lightweight `vllm-omni` pattern: Buildkite loads
+`.buildkite/pipeline.yml`, a bootstrap step resolves docs-only skip-ci, then
+label-gated upload steps add the actual test suites.
+
+Always-on gates:
+
+- `Pre-commit`
+- `Plugin Contracts`
+- `Unit & utils tests`
+
+PR labels and matching environment overrides:
+
+- `run-ci-short` / `RUN_CI_SHORT=1`
+- `run-ci-vllm-config` / `RUN_CI_VLLM_CONFIG=1`
+- `run-ci-megatron` / `RUN_CI_MEGATRON=1`
+- `run-ci-precision` / `RUN_CI_PRECISION=1`
+- `run-ci-ckpt` / `RUN_CI_CKPT=1`
+- `run-ci-image` / `RUN_CI_IMAGE=1`
+- `run-ci-changed` / `RUN_CI_CHANGED=1`
+- `run-ci-all` / `RUN_ALL=1` or `VIME_RUN_ALL=1`
+
+The static test matrix is defined in `.buildkite/scripts/upload_suite.py`.
+
+All GPU jobs (4- and 8-GPU) run on the shared H100 Kubernetes pool
+(`mithril-h100-pool`); each job gets its own pod sized to its GPU count
+(`nvidia.com/gpu: <num_gpus>`, up to 8), and `tests/ci/gpu_lock_exec.py` locks
+the pod's visible GPUs. CPU jobs (pre-commit / plugin-contracts / unit) run the
+CI image on `small_cpu_queue_premerge` via the docker plugin.
+
+Cluster prerequisites:
+
+- Nodes must be able to pull the public image
+  `inferactinc/public:vime-vllm-cu129-latest`.
+- Secret `hf-token-secret` (key `token`) for gated HF model downloads.
+- Optional secret `wandb-api-key-secret` (key `api-key`) for wandb logging; if
+  absent, wandb runs unauthenticated.
+- vime models/datasets must be reachable inside the pod at `/root/models` and
+  `/root/datasets` (hostPath under `/mnt/hf-cache/vime` on the H100 nodes), or
+  resolvable via HF using `HF_HOME=/root/.cache/huggingface`.

--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -1,41 +1,83 @@
 # vime Buildkite CI
 
-This pipeline follows the lightweight `vllm-omni` pattern: Buildkite loads
-`.buildkite/pipeline.yml`, a bootstrap step resolves docs-only skip-ci, then
-label-gated upload steps add the actual test suites.
+vime PR CI is split into two layers:
 
-Always-on gates:
+- **Always-on lightweight checks** run automatically on every PR.
+- **GPU end-to-end suites** are label-gated and run only when the matching
+  `run-ci-*` label is added.
 
-- `Pre-commit`
-- `Plugin Contracts`
-- `Unit & utils tests`
+The default PR path is intentionally cheap; GPU validation is explicit and
+targeted. (This is the Buildkite port of `.github/workflows/pr-test.yml`.)
 
-PR labels and matching environment overrides:
+## Trigger model
 
-- `run-ci-short` / `RUN_CI_SHORT=1`
-- `run-ci-vllm-config` / `RUN_CI_VLLM_CONFIG=1`
-- `run-ci-megatron` / `RUN_CI_MEGATRON=1`
-- `run-ci-precision` / `RUN_CI_PRECISION=1`
-- `run-ci-ckpt` / `RUN_CI_CKPT=1`
-- `run-ci-image` / `RUN_CI_IMAGE=1`
-- `run-ci-changed` / `RUN_CI_CHANGED=1`
-- `run-ci-all` / `RUN_ALL=1` or `VIME_RUN_ALL=1`
+| GitHub Actions concept | Buildkite equivalent |
+|---|---|
+| `pull_request` (`synchronize`, `labeled`) on `main` | Pipeline GitHub settings: build PRs, and rebuild on label change |
+| Add a `run-ci-*` label | Normal PR path — gates the matching suite via `build.pull_request.labels includes "..."` |
+| `workflow_dispatch` (manual "Run workflow", debug/override) | Manual **New Build** with `RUN_CI_*` / `RUN_ALL` env vars (broader than one label) |
 
-The static test matrix is defined in `.buildkite/scripts/upload_suite.py`.
+Adding a label such as `run-ci-short` is the normal way to request a GPU suite
+on a PR. A manual build with env overrides is the debug/override path.
 
-All GPU jobs (4- and 8-GPU) run on the shared H100 Kubernetes pool
-(`mithril-h100-pool`); each job gets its own pod sized to its GPU count
-(`nvidia.com/gpu: <num_gpus>`, up to 8), and `tests/ci/gpu_lock_exec.py` locks
-the pod's visible GPUs. CPU jobs (pre-commit / plugin-contracts / unit) run the
-CI image on `small_cpu_queue_premerge` via the docker plugin.
+## Always-on jobs (every PR, no label)
 
-Cluster prerequisites:
+| Job | Runner | Image | Runs |
+|---|---|---|---|
+| `Pre-commit` | CPU (`small_cpu_queue_premerge`) | `python:3.10` (lightweight) | `pre-commit run --all-files` |
+| `Plugin Contracts` | CPU (`small_cpu_queue_premerge`) | `python:3.10` (lightweight, **0 GPU**) | each contract file as `python tests/<file>.py` (installs CPU deps first) |
+| `Unit & utils tests` | CPU (`small_cpu_queue_premerge`) | `inferactinc/public:vime-vllm-cu129-latest` (**in-image**) | `python -m pytest tests/unit tests/utils` |
 
-- Nodes must be able to pull the public image
-  `inferactinc/public:vime-vllm-cu129-latest`.
+Plugin contracts are the *lightweight* CPU path (no CUDA image), matching
+GitHub-hosted `ubuntu-latest`. Unit/utils run **in the CI image** because the
+`tests/unit/backends/megatron_utils` tests need megatron + torch at import time.
+
+## Label-gated GPU suites
+
+Run only when the PR carries the label (or via a manual build with the env
+override). The static matrix lives in `.buildkite/scripts/upload_suite.py`.
+
+| Label / env override | Suite | GPU | Matrix |
+|---|---|---:|---:|
+| `run-ci-short` / `RUN_CI_SHORT=1` | Short | 4 | 4 |
+| `run-ci-vllm-config` / `RUN_CI_VLLM_CONFIG=1` | vLLM config | 8 | 4 |
+| `run-ci-megatron` / `RUN_CI_MEGATRON=1` | Megatron e2e | 8 | 13 |
+| `run-ci-precision` / `RUN_CI_PRECISION=1` | Precision/parallel check | 8 | 1 |
+| `run-ci-ckpt` / `RUN_CI_CKPT=1` | Checkpoint (incl. `--async-save`) | 8 | 2 |
+| `run-ci-image` / `RUN_CI_IMAGE=1` | Image-validation subset | 4 or 8 | 13 |
+| `run-ci-changed` / `RUN_CI_CHANGED=1` | Changed test files | dynamic | dynamic |
+| `run-ci-all` / `RUN_ALL=1` (or `VIME_RUN_ALL=1`) | All GPU suites | — | — |
+
+All GPU jobs run on the shared H100 Kubernetes pool (`mithril-h100-pool`); each
+job gets its own pod sized to its GPU count (`nvidia.com/gpu: <num_gpus>`, up to
+8), and `tests/ci/gpu_lock_exec.py` locks the pod's visible GPUs.
+
+### `run-ci-changed` behavior
+
+File-based (not dependency-based). It diffs the PR branch against `origin/main`
+with `git diff --diff-filter=AM` and matches only added/modified
+`tests/test_*.py` and `tests/plugin_contracts/test_*.py`. For each file it reads
+the top-level `NUM_GPUS = <N>` (default `8`); `0` runs CPU-only with no GPU lock,
+otherwise it runs via `gpu_lock_exec.py --count <N>`. Changing *application* code
+does not infer which suites to run — add the relevant fixed `run-ci-*` label for
+that.
+
+## Pipeline mechanics
+
+Buildkite loads `.buildkite/pipeline.yml` (two-document layout). Document 1 runs
+`scripts/upload_pipeline_with_skip_ci.sh`, which resolves docs-only skip-CI and
+substitutes the `__UPLOAD_*_IF__` placeholders in document 2 with the trigger
+conditions above, then uploads them. Each upload step calls
+`scripts/upload_suite.py <suite>` to emit that suite's steps;
+`scripts/run_test.sh` installs vime editable and runs each test.
+
+## Cluster prerequisites
+
+- Nodes able to pull `inferactinc/public:vime-vllm-cu129-latest` (GPU/unit jobs)
+  and `python:3.10` (lightweight CPU jobs).
 - Secret `hf-token-secret` (key `token`) for gated HF model downloads.
 - Optional secret `wandb-api-key-secret` (key `api-key`) for wandb logging; if
   absent, wandb runs unauthenticated.
-- vime models/datasets must be reachable inside the pod at `/root/models` and
+- vime models/datasets reachable inside the pod at `/root/models` and
   `/root/datasets` (hostPath under `/mnt/hf-cache/vime` on the H100 nodes), or
   resolvable via HF using `HF_HOME=/root/.cache/huggingface`.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,82 @@
+# Document 1 is the bootstrap loaded by Buildkite. It resolves docs-only
+# skip-ci, then uploads document 2 with concrete upload-step conditions.
+steps:
+  - label: ":github: Resolve skip-ci & upload vime pipeline"
+    key: upload-ci-pipeline
+    commands:
+      - "bash .buildkite/scripts/upload_pipeline_with_skip_ci.sh"
+    agents:
+      queue: "cpu_queue_premerge"
+
+---
+steps:
+  - label: "Upload Core Pipeline"
+    key: upload-core-pipeline
+    if: __UPLOAD_CORE_IF__
+    commands:
+      - "python3 .buildkite/scripts/upload_suite.py core | buildkite-agent pipeline upload"
+    agents:
+      queue: "cpu_queue_premerge"
+
+  - label: "Upload Short Pipeline"
+    key: upload-short-pipeline
+    depends_on: upload-core-pipeline
+    if: __UPLOAD_SHORT_IF__
+    commands:
+      - "python3 .buildkite/scripts/upload_suite.py short | buildkite-agent pipeline upload"
+    agents:
+      queue: "cpu_queue_premerge"
+
+  - label: "Upload vLLM Config Pipeline"
+    key: upload-vllm-config-pipeline
+    depends_on: upload-core-pipeline
+    if: __UPLOAD_VLLM_CONFIG_IF__
+    commands:
+      - "python3 .buildkite/scripts/upload_suite.py vllm-config | buildkite-agent pipeline upload"
+    agents:
+      queue: "cpu_queue_premerge"
+
+  - label: "Upload Megatron Pipeline"
+    key: upload-megatron-pipeline
+    depends_on: upload-core-pipeline
+    if: __UPLOAD_MEGATRON_IF__
+    commands:
+      - "python3 .buildkite/scripts/upload_suite.py megatron | buildkite-agent pipeline upload"
+    agents:
+      queue: "cpu_queue_premerge"
+
+  - label: "Upload Precision Pipeline"
+    key: upload-precision-pipeline
+    depends_on: upload-core-pipeline
+    if: __UPLOAD_PRECISION_IF__
+    commands:
+      - "python3 .buildkite/scripts/upload_suite.py precision | buildkite-agent pipeline upload"
+    agents:
+      queue: "cpu_queue_premerge"
+
+  - label: "Upload Checkpoint Pipeline"
+    key: upload-ckpt-pipeline
+    depends_on: upload-core-pipeline
+    if: __UPLOAD_CKPT_IF__
+    commands:
+      - "python3 .buildkite/scripts/upload_suite.py ckpt | buildkite-agent pipeline upload"
+    agents:
+      queue: "cpu_queue_premerge"
+
+  - label: "Upload Image Release Pipeline"
+    key: upload-image-pipeline
+    depends_on: upload-core-pipeline
+    if: __UPLOAD_IMAGE_IF__
+    commands:
+      - "python3 .buildkite/scripts/upload_suite.py image | buildkite-agent pipeline upload"
+    agents:
+      queue: "cpu_queue_premerge"
+
+  - label: "Upload Changed Tests Pipeline"
+    key: upload-changed-pipeline
+    depends_on: upload-core-pipeline
+    if: __UPLOAD_CHANGED_IF__
+    commands:
+      - "python3 .buildkite/scripts/upload_suite.py changed | buildkite-agent pipeline upload"
+    agents:
+      queue: "cpu_queue_premerge"

--- a/.buildkite/scripts/run_test.sh
+++ b/.buildkite/scripts/run_test.sh
@@ -19,6 +19,14 @@ export VIME_TEST_USE_DEEPEP="${VIME_TEST_USE_DEEPEP:-0}"
 export VIME_TEST_USE_FP8_ROLLOUT="${VIME_TEST_USE_FP8_ROLLOUT:-0}"
 export VIME_TEST_ENABLE_EVAL="${VIME_TEST_ENABLE_EVAL:-1}"
 
+# Lightweight CPU runner (plugin contracts) starts from a bare python image, so
+# install the CPU wheel set first. Mirrors the cpu path in pr-test.yml.
+if [[ "${VIME_INSTALL_CPU_DEPS:-0}" == "1" ]]; then
+  echo "--- :python: Install CPU test deps"
+  python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+  python -m pip install pytest numpy packaging pyyaml omegaconf tqdm httpx pybase64 pylatexenc sympy aiohttp pillow
+fi
+
 echo "--- :python: Install vime editable"
 python -m pip install -e . --no-deps --break-system-packages || python -m pip install -e . --no-deps
 

--- a/.buildkite/scripts/run_test.sh
+++ b/.buildkite/scripts/run_test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TEST_FILE:?TEST_FILE is required}"
+
+NUM_GPUS="${NUM_GPUS:-0}"
+TEST_ARGS="${TEST_ARGS:-}"
+TOTAL_GPUS="${TOTAL_GPUS:-${NUM_GPUS}}"
+
+if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false" || -z "${BUILDKITE_PULL_REQUEST:-}" ]]; then
+  pr_suffix="non-pr"
+else
+  pr_suffix="${BUILDKITE_PULL_REQUEST}"
+fi
+
+export GITHUB_COMMIT_NAME="${GITHUB_COMMIT_NAME:-${BUILDKITE_COMMIT:-local}_${pr_suffix}}"
+export VIME_TEST_ENABLE_INFINITE_RUN="${VIME_TEST_ENABLE_INFINITE_RUN:-false}"
+export VIME_TEST_USE_DEEPEP="${VIME_TEST_USE_DEEPEP:-0}"
+export VIME_TEST_USE_FP8_ROLLOUT="${VIME_TEST_USE_FP8_ROLLOUT:-0}"
+export VIME_TEST_ENABLE_EVAL="${VIME_TEST_ENABLE_EVAL:-1}"
+
+echo "--- :python: Install vime editable"
+python -m pip install -e . --no-deps --break-system-packages || python -m pip install -e . --no-deps
+
+test_path="${TEST_FILE}"
+if [[ "${test_path}" != tests/* ]]; then
+  test_path="tests/${test_path}"
+fi
+
+if [[ -n "${TEST_ARGS}" ]]; then
+  read -r -a test_args_array < <(printf "%s\n" "${TEST_ARGS}")
+else
+  test_args_array=()
+fi
+
+echo "--- :test_tube: Run ${test_path}"
+echo "NUM_GPUS=${NUM_GPUS}"
+echo "VIME_TEST_USE_DEEPEP=${VIME_TEST_USE_DEEPEP}"
+echo "VIME_TEST_USE_FP8_ROLLOUT=${VIME_TEST_USE_FP8_ROLLOUT}"
+echo "VIME_TEST_ENABLE_EVAL=${VIME_TEST_ENABLE_EVAL}"
+
+if [[ "${NUM_GPUS}" == "0" ]]; then
+  if [[ "${test_path}" == *.sh ]]; then
+    bash "${test_path}" "${test_args_array[@]}"
+  else
+    python "${test_path}" "${test_args_array[@]}"
+  fi
+else
+  if [[ "${test_path}" == *.sh ]]; then
+    python tests/ci/gpu_lock_exec.py --count "${NUM_GPUS}" --total-gpus "${TOTAL_GPUS}" -- bash "${test_path}" "${test_args_array[@]}"
+  else
+    python tests/ci/gpu_lock_exec.py --count "${NUM_GPUS}" --total-gpus "${TOTAL_GPUS}" -- python "${test_path}" "${test_args_array[@]}"
+  fi
+fi

--- a/.buildkite/scripts/upload_pipeline_with_skip_ci.sh
+++ b/.buildkite/scripts/upload_pipeline_with_skip_ci.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PIPELINE_YML="${ROOT}/${1:-.buildkite/pipeline.yml}"
+
+is_docs_only_change() {
+  local file_path
+  local has_any=0
+
+  while IFS= read -r file_path; do
+    [[ -z "${file_path}" ]] && continue
+    has_any=1
+
+    if [[ "${file_path}" == docs/* ]]; then
+      continue
+    fi
+    if [[ "${file_path}" == *.md ]]; then
+      continue
+    fi
+    if [[ "${file_path}" == "README_zh.md" ]]; then
+      continue
+    fi
+    return 1
+  done
+
+  [[ "${has_any}" -eq 1 ]]
+}
+
+changed_files() {
+  local base_branch base_ref
+
+  if [[ "${BUILDKITE_PULL_REQUEST:-false}" != "false" && -n "${BUILDKITE_PULL_REQUEST:-}" ]]; then
+    base_branch="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-main}"
+    if ! git rev-parse --verify "origin/${base_branch}" >/dev/null 2>&1; then
+      git fetch --depth=200 origin "${base_branch}" >/dev/null 2>&1 || true
+    fi
+
+    if git rev-parse --verify "origin/${base_branch}" >/dev/null 2>&1; then
+      base_ref="origin/${base_branch}"
+    elif git rev-parse --verify "${base_branch}" >/dev/null 2>&1; then
+      base_ref="${base_branch}"
+    else
+      return 1
+    fi
+
+    git diff --name-only "${base_ref}...${BUILDKITE_COMMIT}"
+    return
+  fi
+
+  if [[ "${BUILDKITE_BRANCH:-}" == "main" ]] && git rev-parse --verify "${BUILDKITE_COMMIT}^" >/dev/null 2>&1; then
+    git diff --name-only "${BUILDKITE_COMMIT}^..${BUILDKITE_COMMIT}"
+    return
+  fi
+
+  return 1
+}
+
+skip_ci=0
+if files="$(changed_files 2>/dev/null)" && is_docs_only_change <<< "${files}"; then
+  skip_ci=1
+  buildkite-agent annotate ":memo: vime CI skipped - docs-only change" --style info || true
+fi
+
+if [[ ! -f "${PIPELINE_YML}" ]]; then
+  echo "Missing ${PIPELINE_YML}" >&2
+  exit 1
+fi
+
+export PIPELINE_YML skip_ci
+python3 <<'PY' | buildkite-agent pipeline upload
+import os
+from pathlib import Path
+
+text = Path(os.environ["PIPELINE_YML"]).read_text(encoding="utf-8")
+sep = "\n---\n"
+_, continuation = text.split(sep, 1) if sep in text else ("", text)
+
+run_all = (
+    'build.env("RUN_ALL") == "1" || '
+    'build.env("VIME_RUN_ALL") == "1" || '
+    '(build.branch != "main" && build.pull_request.labels includes "run-ci-all")'
+)
+
+conditions = {
+    "__UPLOAD_CORE_IF__": "'true'",
+    "__UPLOAD_SHORT_IF__": f"'({run_all}) || build.env(\"RUN_CI_SHORT\") == \"1\" || (build.branch != \"main\" && build.pull_request.labels includes \"run-ci-short\")'",
+    "__UPLOAD_VLLM_CONFIG_IF__": f"'({run_all}) || build.env(\"RUN_CI_VLLM_CONFIG\") == \"1\" || (build.branch != \"main\" && build.pull_request.labels includes \"run-ci-vllm-config\")'",
+    "__UPLOAD_MEGATRON_IF__": f"'({run_all}) || build.env(\"RUN_CI_MEGATRON\") == \"1\" || (build.branch != \"main\" && build.pull_request.labels includes \"run-ci-megatron\")'",
+    "__UPLOAD_PRECISION_IF__": f"'({run_all}) || build.env(\"RUN_CI_PRECISION\") == \"1\" || (build.branch != \"main\" && build.pull_request.labels includes \"run-ci-precision\")'",
+    "__UPLOAD_CKPT_IF__": f"'({run_all}) || build.env(\"RUN_CI_CKPT\") == \"1\" || (build.branch != \"main\" && build.pull_request.labels includes \"run-ci-ckpt\")'",
+    "__UPLOAD_IMAGE_IF__": f"'({run_all}) || build.env(\"RUN_CI_IMAGE\") == \"1\" || (build.branch != \"main\" && build.pull_request.labels includes \"run-ci-image\")'",
+    "__UPLOAD_CHANGED_IF__": f"'build.env(\"RUN_CI_CHANGED\") == \"1\" || (build.branch != \"main\" && build.pull_request.labels includes \"run-ci-changed\")'",
+}
+
+if os.environ.get("skip_ci") == "1":
+    conditions = {key: "'false'" for key in conditions}
+
+for key, value in conditions.items():
+    continuation = continuation.replace(key, value)
+
+print(continuation, end="")
+PY

--- a/.buildkite/scripts/upload_suite.py
+++ b/.buildkite/scripts/upload_suite.py
@@ -12,6 +12,10 @@ from typing import Any
 
 
 IMAGE = "inferactinc/public:vime-vllm-cu129-latest"
+# Lightweight image for the always-on CPU checks (pre-commit, plugin contracts):
+# the Buildkite equivalent of a GitHub-hosted ubuntu-latest runner, so these
+# don't pull the heavy CUDA training image.
+CPU_IMAGE = "python:3.10"
 CPU_QUEUE = "small_cpu_queue_premerge"
 # All GPU jobs (4- and 8-GPU) run on the shared H100 Kubernetes pool; each job
 # gets its own pod sized to its GPU count (the pool supports up to 8 GPUs/pod).
@@ -130,7 +134,7 @@ def core_steps() -> list[dict[str, Any]]:
                 "python -m pre_commit run --all-files --show-diff-on-failure --color=always",
             ],
             "agents": {"queue": CPU_QUEUE},
-            "plugins": [docker_plugin()],
+            "plugins": [lite_docker_plugin()],
             "retry": retry_agent_lost(),
         },
         {
@@ -142,6 +146,7 @@ def core_steps() -> list[dict[str, Any]]:
                     TestJob(test_file, 0, timeout_in_minutes=30),
                     group_label="Plugin Contracts",
                     depends_on=["pre-commit"],
+                    cpu_lite=True,
                 )
                 for test_file in PLUGIN_CONTRACTS
             ],
@@ -211,16 +216,26 @@ def changed_steps() -> list[dict[str, Any]]:
     ]
 
 
-def test_step(suite: str, job: TestJob, *, group_label: str, depends_on: list[str]) -> dict[str, Any]:
+def test_step(
+    suite: str,
+    job: TestJob,
+    *,
+    group_label: str,
+    depends_on: list[str],
+    cpu_lite: bool = False,
+) -> dict[str, Any]:
+    # cpu_lite -> always-on lightweight CPU runner (plugin contracts): a plain
+    # python image on the CPU queue that pip-installs CPU deps, instead of the
+    # heavy CUDA image / H100 pod used by GPU and in-image jobs.
     key = step_key(suite, job)
     step = {
         "label": f"{group_label} - {display_name(job)}",
         "key": key,
         "depends_on": depends_on,
         "commands": [".buildkite/scripts/run_test.sh"],
-        "agents": {"queue": agent_queue(job.num_gpus)},
-        "env": test_env(job),
-        "plugins": [plugin_for(job)],
+        "agents": {"queue": CPU_QUEUE if cpu_lite else agent_queue(job.num_gpus)},
+        "env": test_env(job, cpu_lite=cpu_lite),
+        "plugins": [lite_docker_plugin() if cpu_lite else plugin_for(job)],
         "retry": retry_agent_lost(),
     }
     if job.timeout_in_minutes:
@@ -228,8 +243,8 @@ def test_step(suite: str, job: TestJob, *, group_label: str, depends_on: list[st
     return step
 
 
-def test_env(job: TestJob) -> dict[str, str]:
-    return {
+def test_env(job: TestJob, *, cpu_lite: bool = False) -> dict[str, str]:
+    env = {
         "TEST_FILE": job.test_file,
         "TEST_ARGS": job.test_args,
         "NUM_GPUS": str(job.num_gpus),
@@ -240,6 +255,11 @@ def test_env(job: TestJob) -> dict[str, str]:
         "VIME_TEST_USE_FP8_ROLLOUT": job.use_fp8_rollout,
         "VIME_TEST_ENABLE_EVAL": job.enable_eval,
     }
+    if cpu_lite:
+        # Lightweight image has no torch/deps baked in; run_test.sh installs the
+        # CPU wheel set before running the contract file.
+        env["VIME_INSTALL_CPU_DEPS"] = "1"
+    return env
 
 
 def plugin_for(job: TestJob) -> dict[str, Any]:
@@ -250,9 +270,27 @@ def plugin_for(job: TestJob) -> dict[str, Any]:
     return docker_plugin(image=job.image)
 
 
+def lite_docker_plugin(image: str = CPU_IMAGE) -> dict[str, Any]:
+    # Lightweight CPU runner (no CUDA image) for pre-commit and plugin
+    # contracts -- the Buildkite equivalent of GitHub-hosted ubuntu-latest.
+    return {
+        "docker#v5.2.0": {
+            "image": image,
+            "always-pull": True,
+            "propagate-environment": True,
+            "environment": [
+                "http_proxy",
+                "https_proxy",
+                "HTTP_PROXY",
+                "HTTPS_PROXY",
+            ],
+        }
+    }
+
+
 def docker_plugin(*, image: str = IMAGE) -> dict[str, Any]:
-    # CPU-only, in-image runner for pre-commit / plugin-contracts / unit tests.
-    # GPU work goes through h100_k8s_plugin instead.
+    # In-image CPU runner for the unit/utils suite (needs megatron + torch from
+    # the CUDA image). GPU work goes through h100_k8s_plugin instead.
     config: dict[str, Any] = {
         "image": image,
         "always-pull": True,

--- a/.buildkite/scripts/upload_suite.py
+++ b/.buildkite/scripts/upload_suite.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any
+
+
+IMAGE = "inferactinc/public:vime-vllm-cu129-latest"
+CPU_QUEUE = "small_cpu_queue_premerge"
+# All GPU jobs (4- and 8-GPU) run on the shared H100 Kubernetes pool; each job
+# gets its own pod sized to its GPU count (the pool supports up to 8 GPUs/pod).
+H100_QUEUE = "mithril-h100-pool"
+
+HF_CACHE = "/fsx/hf_cache"   # HF cache on the CPU (docker-plugin) agents
+K8S_CACHE = "/mnt/hf-cache"  # hostPath cache root on the H100 nodes
+
+
+@dataclass(frozen=True)
+class TestJob:
+    test_file: str
+    num_gpus: int
+    test_args: str = ""
+    use_deepep: str = "0"
+    use_fp8_rollout: str = "0"
+    enable_eval: str = "1"
+    timeout_in_minutes: int | None = None
+    image: str = IMAGE
+
+
+SUITES: dict[str, list[TestJob]] = {
+    "short": [
+        TestJob("test_qwen3.5_0.8B_gsm8k_async_short.py", 4, timeout_in_minutes=120),
+        TestJob("test_qwen3.5_0.8B_gsm8k_short.py", 4, timeout_in_minutes=120),
+        TestJob("test_qwen2.5_0.5B_ppo_critic_only_short.py", 4, timeout_in_minutes=120),
+        TestJob("test_qwen2.5_0.5B_fully_async_short.py", 4, timeout_in_minutes=120),
+    ],
+    "vllm-config": [
+        TestJob("test_qwen2.5_0.5B_vllm_config.py", 8, timeout_in_minutes=180),
+        TestJob("test_qwen2.5_0.5B_vllm_config_distributed.py", 8, timeout_in_minutes=180),
+        TestJob("test_vllm_config_mixed_offload.py", 8, timeout_in_minutes=180),
+        TestJob("test_vllm_config_mixed_offload_ft.py", 8, timeout_in_minutes=180),
+    ],
+    "megatron": [
+        TestJob("test_quick_start_glm4_9B.py", 8, timeout_in_minutes=240),
+        TestJob("test_glm4.7_30B_A3B_pd_mooncake.py", 8, timeout_in_minutes=240),
+        TestJob("test_qwen3_30B_A3B.py", 8, use_deepep="1", use_fp8_rollout="1", timeout_in_minutes=240),
+        TestJob("test_qwen3.6_35B_A3B_pd_mooncake.py", 8, use_deepep="1", timeout_in_minutes=240),
+        TestJob(
+            "test_qwen3_30B_A3B_r3.py",
+            8,
+            use_deepep="1",
+            use_fp8_rollout="1",
+            enable_eval="0",
+            timeout_in_minutes=240,
+        ),
+        TestJob("test_qwen3_30B_A3B_r3.py", 8, enable_eval="0", timeout_in_minutes=240),
+        TestJob("test_qwen3_4B_ppo.py", 8, timeout_in_minutes=240),
+        TestJob("test_qwen3_4B_ppo_disaggregate.py", 8, timeout_in_minutes=240),
+        TestJob("test_qwen3_4B_ppo_train_critic_only.py", 8, timeout_in_minutes=240),
+        TestJob("test_moonlight_16B_A3B.py", 8, timeout_in_minutes=240),
+        TestJob("test_moonlight_16B_A3B_r3.py", 8, enable_eval="0", timeout_in_minutes=240),
+        TestJob("test_qwen2.5_0.5B_debug_rollout_then_train.py", 8, timeout_in_minutes=240),
+        TestJob("test_qwen2.5_0.5B_opd_vllm.py", 8, timeout_in_minutes=240),
+    ],
+    "precision": [
+        TestJob("test_qwen3_0.6B_parallel_check.py", 8, timeout_in_minutes=180),
+    ],
+    "ckpt": [
+        TestJob("test_qwen3_4B_ckpt.py", 8, timeout_in_minutes=180),
+        TestJob("test_qwen3_4B_ckpt.py", 8, test_args="--async-save", timeout_in_minutes=180),
+    ],
+    "image": [
+        TestJob("test_qwen3.5_0.8B_gsm8k_async_short.py", 4, timeout_in_minutes=120),
+        TestJob("test_qwen3.5_0.8B_gsm8k_short.py", 4, timeout_in_minutes=120),
+        TestJob("test_quick_start_glm4_9B.py", 8, timeout_in_minutes=240),
+        TestJob("test_glm4.7_30B_A3B_pd_mooncake.py", 8, timeout_in_minutes=240),
+        TestJob("test_qwen3_30B_A3B.py", 8, timeout_in_minutes=240),
+        TestJob("test_qwen3.6_35B_A3B_pd_mooncake.py", 8, use_deepep="1", timeout_in_minutes=240),
+        TestJob("test_qwen3_4B_ppo.py", 8, timeout_in_minutes=240),
+        TestJob("test_moonlight_16B_A3B.py", 8, timeout_in_minutes=240),
+        TestJob("test_qwen3_0.6B_parallel_check.py", 8, timeout_in_minutes=180),
+        TestJob("test_qwen3_4B_ckpt.py", 8, timeout_in_minutes=180),
+        TestJob("test_qwen3_4B_ckpt.py", 8, test_args="--async-save", timeout_in_minutes=180),
+        TestJob("test_qwen2.5_0.5B_debug_rollout_then_train.py", 8, timeout_in_minutes=240),
+        TestJob("test_qwen2.5_0.5B_opd_vllm.py", 8, timeout_in_minutes=240),
+    ],
+}
+
+PLUGIN_CONTRACTS = [
+    "test_megatron_argument_validation.py",
+    "plugin_contracts/test_plugin_rollout_contracts.py",
+    "plugin_contracts/test_plugin_runtime_hook_contracts.py",
+    "plugin_contracts/test_plugin_path_loading_contracts.py",
+    "plugin_contracts/test_plugin_generate_contracts.py",
+]
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: upload_suite.py <core|short|vllm-config|megatron|precision|ckpt|image|changed>")
+
+    suite = sys.argv[1]
+    if suite == "core":
+        pipeline = {"steps": core_steps()}
+    elif suite == "changed":
+        pipeline = {"steps": changed_steps()}
+    elif suite in SUITES:
+        pipeline = {"steps": suite_group(suite, SUITES[suite])}
+    else:
+        raise SystemExit(f"unknown suite: {suite}")
+
+    json.dump(pipeline, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+def core_steps() -> list[dict[str, Any]]:
+    return [
+        {
+            "label": "Pre-commit",
+            "key": "pre-commit",
+            "timeout_in_minutes": 30,
+            "commands": [
+                "python -m pip install -q pre-commit --break-system-packages || python -m pip install -q pre-commit",
+                "python -m pre_commit run --all-files --show-diff-on-failure --color=always",
+            ],
+            "agents": {"queue": CPU_QUEUE},
+            "plugins": [docker_plugin()],
+            "retry": retry_agent_lost(),
+        },
+        {
+            "group": "Plugin Contracts",
+            "depends_on": "pre-commit",
+            "steps": [
+                test_step(
+                    "plugin-contracts",
+                    TestJob(test_file, 0, timeout_in_minutes=30),
+                    group_label="Plugin Contracts",
+                    depends_on=["pre-commit"],
+                )
+                for test_file in PLUGIN_CONTRACTS
+            ],
+        },
+        {
+            "label": "Unit & utils tests",
+            "key": "unit-utils-tests",
+            "depends_on": ["pre-commit"],
+            "timeout_in_minutes": 45,
+            "commands": [
+                "python -m pip install -e . --no-deps --break-system-packages || python -m pip install -e . --no-deps",
+                "python -m pip install -q pytest --break-system-packages || python -m pip install -q pytest",
+                "python -m pytest tests/unit tests/utils",
+            ],
+            "agents": {"queue": CPU_QUEUE},
+            "plugins": [docker_plugin()],
+            "retry": retry_agent_lost(),
+        },
+    ]
+
+
+def suite_group(suite: str, jobs: list[TestJob]) -> list[dict[str, Any]]:
+    title = {
+        "short": "Short Tests",
+        "vllm-config": "vLLM Config Tests",
+        "megatron": "Megatron Tests",
+        "precision": "Precision Tests",
+        "ckpt": "Checkpoint Tests",
+        "image": "Image Release Tests",
+    }[suite]
+
+    return [
+        {
+            "group": title,
+            "steps": [
+                test_step(suite, job, group_label=title, depends_on=["pre-commit"])
+                for job in jobs
+            ],
+        }
+    ]
+
+
+def changed_steps() -> list[dict[str, Any]]:
+    files = changed_test_files()
+    if not files:
+        return [
+            {
+                "label": "Changed tests - none",
+                "commands": ["echo 'No changed tests found.'"],
+                "agents": {"queue": CPU_QUEUE},
+            }
+        ]
+
+    jobs = []
+    for file_path in files:
+        num_gpus = parse_num_gpus(Path(file_path))
+        jobs.append(TestJob(file_path, num_gpus, timeout_in_minutes=240 if num_gpus >= 8 else 120))
+
+    return [
+        {
+            "group": "Changed Tests",
+            "steps": [
+                test_step("changed", job, group_label="Changed Tests", depends_on=["pre-commit"])
+                for job in jobs
+            ],
+        }
+    ]
+
+
+def test_step(suite: str, job: TestJob, *, group_label: str, depends_on: list[str]) -> dict[str, Any]:
+    key = step_key(suite, job)
+    step = {
+        "label": f"{group_label} - {display_name(job)}",
+        "key": key,
+        "depends_on": depends_on,
+        "commands": [".buildkite/scripts/run_test.sh"],
+        "agents": {"queue": agent_queue(job.num_gpus)},
+        "env": test_env(job),
+        "plugins": [plugin_for(job)],
+        "retry": retry_agent_lost(),
+    }
+    if job.timeout_in_minutes:
+        step["timeout_in_minutes"] = job.timeout_in_minutes
+    return step
+
+
+def test_env(job: TestJob) -> dict[str, str]:
+    return {
+        "TEST_FILE": job.test_file,
+        "TEST_ARGS": job.test_args,
+        "NUM_GPUS": str(job.num_gpus),
+        # Each k8s pod is sized to exactly NUM_GPUS, so the GPU lock should see
+        # that many devices.
+        "TOTAL_GPUS": str(job.num_gpus),
+        "VIME_TEST_USE_DEEPEP": job.use_deepep,
+        "VIME_TEST_USE_FP8_ROLLOUT": job.use_fp8_rollout,
+        "VIME_TEST_ENABLE_EVAL": job.enable_eval,
+    }
+
+
+def plugin_for(job: TestJob) -> dict[str, Any]:
+    # Every GPU job runs as its own H100 k8s pod; only CPU jobs use the
+    # in-image docker plugin.
+    if job.num_gpus >= 1:
+        return h100_k8s_plugin(job)
+    return docker_plugin(image=job.image)
+
+
+def docker_plugin(*, image: str = IMAGE) -> dict[str, Any]:
+    # CPU-only, in-image runner for pre-commit / plugin-contracts / unit tests.
+    # GPU work goes through h100_k8s_plugin instead.
+    config: dict[str, Any] = {
+        "image": image,
+        "always-pull": True,
+        "propagate-environment": True,
+        "network": "host",
+        "ipc": "host",
+        "shm-size": "16g",
+        "environment": [
+            "http_proxy",
+            "https_proxy",
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "WANDB_API_KEY",
+            "HF_TOKEN",
+            f"HF_HOME={HF_CACHE}",
+        ],
+        "volumes": [
+            f"{HF_CACHE}:{HF_CACHE}",
+        ],
+    }
+    return {"docker#v5.2.0": config}
+
+
+def h100_k8s_plugin(job: TestJob) -> dict[str, Any]:
+    env = [
+        {"name": "HF_HOME", "value": "/root/.cache/huggingface"},
+        {"name": "VIME_TEST_USE_DEEPEP", "value": job.use_deepep},
+        {"name": "VIME_TEST_USE_FP8_ROLLOUT", "value": job.use_fp8_rollout},
+        {"name": "VIME_TEST_ENABLE_EVAL", "value": job.enable_eval},
+        {"name": "TEST_FILE", "value": job.test_file},
+        {"name": "TEST_ARGS", "value": job.test_args},
+        {"name": "NUM_GPUS", "value": str(job.num_gpus)},
+        {"name": "TOTAL_GPUS", "value": "8"},
+        {
+            "name": "HF_TOKEN",
+            "valueFrom": {
+                "secretKeyRef": {
+                    "name": "hf-token-secret",
+                    "key": "token",
+                }
+            },
+        },
+        {
+            # Optional: if `wandb-api-key-secret` is absent the var is simply
+            # left unset (wandb runs unauthenticated) instead of failing the pod.
+            "name": "WANDB_API_KEY",
+            "valueFrom": {
+                "secretKeyRef": {
+                    "name": "wandb-api-key-secret",
+                    "key": "api-key",
+                    "optional": True,
+                }
+            },
+        },
+    ]
+
+    return {
+        "kubernetes": {
+            "podSpec": {
+                "containers": [
+                    {
+                        "image": job.image,
+                        "imagePullPolicy": "Always",
+                        "resources": {"limits": {"nvidia.com/gpu": job.num_gpus}},
+                        "volumeMounts": [
+                            {"name": "devshm", "mountPath": "/dev/shm"},
+                            {"name": "hf-cache", "mountPath": "/root/.cache/huggingface"},
+                            {"name": "vime-cache", "mountPath": "/data/vime_ci"},
+                            {"name": "vime-models", "mountPath": "/root/models"},
+                            {"name": "vime-datasets", "mountPath": "/root/datasets"},
+                        ],
+                        "env": env,
+                    }
+                ],
+                "nodeSelector": {"node.kubernetes.io/instance-type": "gpu-h100-sxm"},
+                "volumes": [
+                    {"name": "devshm", "emptyDir": {"medium": "Memory"}},
+                    {
+                        "name": "hf-cache",
+                        "hostPath": {"path": K8S_CACHE, "type": "DirectoryOrCreate"},
+                    },
+                    {
+                        "name": "vime-cache",
+                        "hostPath": {"path": f"{K8S_CACHE}/vime", "type": "DirectoryOrCreate"},
+                    },
+                    {
+                        "name": "vime-models",
+                        "hostPath": {"path": f"{K8S_CACHE}/vime/models", "type": "DirectoryOrCreate"},
+                    },
+                    {
+                        "name": "vime-datasets",
+                        "hostPath": {"path": f"{K8S_CACHE}/vime/datasets", "type": "DirectoryOrCreate"},
+                    },
+                ],
+            }
+        }
+    }
+
+
+def agent_queue(num_gpus: int) -> str:
+    if num_gpus == 0:
+        return CPU_QUEUE
+    # 4- and 8-GPU jobs both run on the H100 pool, sized per-pod.
+    return H100_QUEUE
+
+
+def retry_agent_lost() -> dict[str, Any]:
+    return {
+        "automatic": [
+            {"exit_status": -1, "limit": 1},
+            {"exit_status": -10, "limit": 1},
+        ]
+    }
+
+
+def display_name(job: TestJob) -> str:
+    name = job.test_file.removeprefix("tests/")
+    flags = []
+    if job.test_args:
+        flags.append(job.test_args)
+    if job.use_deepep == "1":
+        flags.append("deepep")
+    if job.use_fp8_rollout == "1":
+        flags.append("fp8-rollout")
+    if job.enable_eval == "0":
+        flags.append("no-eval")
+    if flags:
+        return f"{name} ({', '.join(flags)})"
+    return name
+
+
+def step_key(suite: str, job: TestJob) -> str:
+    raw = "-".join(
+        [
+            suite,
+            job.test_file,
+            job.test_args,
+            f"deepep-{job.use_deepep}",
+            f"fp8-{job.use_fp8_rollout}",
+            f"eval-{job.enable_eval}",
+        ]
+    )
+    return re.sub(r"[^a-zA-Z0-9_-]+", "-", raw).strip("-").lower()[:180]
+
+
+def changed_test_files() -> list[str]:
+    base_branch = os.environ.get("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "main")
+    commit = os.environ.get("BUILDKITE_COMMIT", "HEAD")
+    base_ref = resolve_base_ref(base_branch)
+    if not base_ref:
+        return []
+
+    proc = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=AM",
+            f"{base_ref}...{commit}",
+            "--",
+            "tests/test_*.py",
+            "tests/plugin_contracts/test_*.py",
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        return []
+    return [line for line in proc.stdout.splitlines() if line]
+
+
+def resolve_base_ref(base_branch: str) -> str | None:
+    candidates = [f"origin/{base_branch}", base_branch]
+    for candidate in candidates:
+        if rev_parse(candidate):
+            return candidate
+
+    subprocess.run(["git", "fetch", "--depth=200", "origin", base_branch], check=False)
+    for candidate in candidates:
+        if rev_parse(candidate):
+            return candidate
+    return None
+
+
+def rev_parse(ref: str) -> bool:
+    return subprocess.run(
+        ["git", "rev-parse", "--verify", ref],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    ).returncode == 0
+
+
+def parse_num_gpus(path: Path) -> int:
+    if "plugin_contracts" in path.parts:
+        default = 0
+    else:
+        default = 8
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return default
+
+    match = re.search(r"^NUM_GPUS\s*=\s*(\d+)\s*$", text, re.MULTILINE)
+    if not match:
+        return default
+    return int(match.group(1))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a Buildkite CI pipeline for vime, porting `.github/workflows/pr-test.yml` to Buildkite using the lightweight `vllm-omni` pattern.

- **Bootstrap** (`.buildkite/pipeline.yml`): two-document layout — Buildkite loads doc 1, which runs `upload_pipeline_with_skip_ci.sh` to resolve docs-only skip-CI and substitute label/env conditions into the upload steps in doc 2.
- **Generator** (`.buildkite/scripts/upload_suite.py`): single source-of-truth test matrix; emits each suite as Buildkite steps on demand.
- **Runner** (`.buildkite/scripts/run_test.sh`): installs vime editable, then runs each test via `gpu_lock_exec.py` (GPU) or directly (CPU).

### Jobs

**Always-on (every PR):** pre-commit gate, Plugin Contracts (5 files, CPU in-image), Unit & utils (`pytest tests/unit tests/utils`, CPU in-image).

**Label-gated GPU suites** — run on `mithril-h100-pool`, each job its own pod sized `nvidia.com/gpu: <4|8>`:

| Label | Jobs |
|---|---|
| `run-ci-short` | 4 × 4-GPU |
| `run-ci-vllm-config` | 4 × 8-GPU |
| `run-ci-megatron` | 13 × 8-GPU (deepep/fp8/eval flags per entry) |
| `run-ci-precision` | 1 × 8-GPU |
| `run-ci-ckpt` | 2 × 8-GPU (incl. `--async-save`) |
| `run-ci-image` | 13-entry image-regression subset |
| `run-ci-changed` | dynamic — added/modified `tests/test_*.py` (greps `NUM_GPUS`) |

Also supports `RUN_CI_*` env gates, `run-ci-all`, and docs-only skip-CI.

### Cluster prerequisites (not provisioned by this PR)

- Buildkite pipeline pointing at `.buildkite/pipeline.yml`, building PRs (incl. on label changes).
- Nodes able to pull `inferactinc/public:vime-vllm-cu129-latest`.
- Secret `hf-token-secret` (key `token`); optional `wandb-api-key-secret` (key `api-key`).
- vime models/datasets reachable at `/root/models` + `/root/datasets`, or resolvable via HF download.

## Test plan

- `upload_suite.py` generates valid Buildkite YAML for all suites (core 7, short 4, vllm-config 4, megatron 13, precision 1, ckpt 2, image 13; `changed` handles the empty case).
- Bootstrap doc-1 parses standalone; placeholder substitution leaves no `__UPLOAD_*__` behind; all 8 upload steps present.
- Scripts pass `bash -n` / `python` parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
