### PR TITLE
Add Read the Docs docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+  apt_packages:
+    - pandoc
+  jobs:
+    install:
+      - pip install -r docs/requirements.txt
+    build:
+      html:
+        - cd docs
+        - mkdir -p "$READTHEDOCS_OUTPUT/html"
+        - VIME_DOC_LANG=en sphinx-build -b html -D language=en --conf-dir ./ ./en "$READTHEDOCS_OUTPUT/html"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,6 +104,7 @@ html_favicon = "_static/image/logo.ico"
 html_title = project
 html_copy_source = True
 html_last_updated_fmt = ""
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 
 html_theme_options = {
     "repository_url": "https://github.com/vllm-project/vime",


### PR DESCRIPTION
Add a minimal Read the Docs config so Vime docs can be published as a docs.vllm.ai subproject.

- add .readthedocs.yaml
- set html_baseurl from READTHEDOCS_CANONICAL_URL
- keep the build scoped to docs/en for now