### PR TITLE
[Docker] normalize published image tag to vime-cu129-{latest,nightly-<date>}

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -108,7 +108,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-vllm-cu129-latest \
+            inferactinc/public:vime-cu129-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -192,7 +192,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-vllm-cu129-latest \
+            inferactinc/public:vime-cu129-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -276,7 +276,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-vllm-cu129-latest \
+            inferactinc/public:vime-cu129-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -360,7 +360,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-vllm-cu129-latest \
+            inferactinc/public:vime-cu129-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -444,7 +444,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-vllm-cu129-latest \
+            inferactinc/public:vime-cu129-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -594,7 +594,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-vllm-cu129-latest \
+            inferactinc/public:vime-cu129-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -646,7 +646,7 @@ jobs:
             -e HTTPS_PROXY \
             -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-vllm-cu129-latest \
+            inferactinc/public:vime-cu129-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -749,7 +749,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-vllm-cu129-latest \
+            inferactinc/public:vime-cu129-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -108,7 +108,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-cu129-latest \
+            inferactinc/public:vime-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -192,7 +192,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-cu129-latest \
+            inferactinc/public:vime-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -276,7 +276,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-cu129-latest \
+            inferactinc/public:vime-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -360,7 +360,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-cu129-latest \
+            inferactinc/public:vime-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -444,7 +444,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-cu129-latest \
+            inferactinc/public:vime-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -594,7 +594,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-cu129-test-latest \
+            inferactinc/public:vime-test-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -646,7 +646,7 @@ jobs:
             -e HTTPS_PROXY \
             -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-cu129-latest \
+            inferactinc/public:vime-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -749,7 +749,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-cu129-latest \
+            inferactinc/public:vime-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -594,7 +594,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-cu129-latest \
+            inferactinc/public:vime-cu129-test-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -64,7 +64,7 @@
 
     'e2e-test-image': {
       'label': 'run-ci-image',
-      'image': 'inferactinc/public:vime-cu129-test-latest',
+      'image': 'inferactinc/public:vime-test-latest',
       'tests': [
         {'test_file': 'test_qwen3.5_0.8B_gsm8k_async_short.py', 'num_gpus': 4},
         {'test_file': 'test_qwen3.5_0.8B_gsm8k_short.py', 'num_gpus': 4},
@@ -225,7 +225,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            << config.image if config.image else 'inferactinc/public:vime-cu129-latest' >> \
+            << config.image if config.image else 'inferactinc/public:vime-latest' >> \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -277,7 +277,7 @@ jobs:
             -e HTTPS_PROXY \
             -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-cu129-latest \
+            inferactinc/public:vime-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -380,7 +380,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-cu129-latest \
+            inferactinc/public:vime-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -64,7 +64,7 @@
 
     'e2e-test-image': {
       'label': 'run-ci-image',
-      'image': 'inferactinc/public:vime-vllm-cu129-latest',
+      'image': 'inferactinc/public:vime-cu129-latest',
       'tests': [
         {'test_file': 'test_qwen3.5_0.8B_gsm8k_async_short.py', 'num_gpus': 4},
         {'test_file': 'test_qwen3.5_0.8B_gsm8k_short.py', 'num_gpus': 4},
@@ -225,7 +225,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            << config.image if config.image else 'inferactinc/public:vime-vllm-cu129-latest' >> \
+            << config.image if config.image else 'inferactinc/public:vime-cu129-latest' >> \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -277,7 +277,7 @@ jobs:
             -e HTTPS_PROXY \
             -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-vllm-cu129-latest \
+            inferactinc/public:vime-cu129-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages
@@ -380,7 +380,7 @@ jobs:
             -v /mnt/nvme0n1/vime_ci/models:/root/models \
             -v /mnt/nvme0n1/vime_ci/datasets:/root/datasets \
             -w "$GITHUB_WORKSPACE" \
-            inferactinc/public:vime-vllm-cu129-latest \
+            inferactinc/public:vime-cu129-latest \
             bash -lc '
               set -euo pipefail
               pip install -e . --no-deps --break-system-packages

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -64,7 +64,7 @@
 
     'e2e-test-image': {
       'label': 'run-ci-image',
-      'image': 'inferactinc/public:vime-cu129-latest',
+      'image': 'inferactinc/public:vime-cu129-test-latest',
       'tests': [
         {'test_file': 'test_qwen3.5_0.8B_gsm8k_async_short.py', 'num_gpus': 4},
         {'test_file': 'test_qwen3.5_0.8B_gsm8k_short.py', 'num_gpus': 4},

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,13 +3,13 @@
 vime ships one image based on the official vllm image, published to
 `inferactinc/public`:
 
-- `vime-cu129-latest` — rolling pointer to the current image
-- `vime-cu129-nightly-<date>` — immutable dated snapshot (e.g. `vime-cu129-nightly-20260603a`)
+- `vime-latest` — rolling pointer to the current image
+- `vime-nightly-<date>` — immutable dated snapshot (e.g. `vime-nightly-20260603a`)
 
 Build locally:
 
 ```bash
-docker build -f docker/Dockerfile -t vime-cu129 .
+docker build -f docker/Dockerfile -t vime .
 ```
 
 ## Release matrix

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,10 +1,7 @@
 # Docker release rule
 
-vime ships one image based on the official vllm image, published to
-`inferactinc/public`:
-
-- `vime-latest` — rolling pointer to the current image
-- `vime-nightly-<date>` — immutable dated snapshot (e.g. `vime-nightly-20260603a`)
+vime ships one image based on the official vllm image, published as
+`inferactinc/public:vime-latest`.
 
 Build locally:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,12 +1,15 @@
 # Docker release rule
 
-vime ships one image based on the official vllm image, published as
-`aosheninferact/vime-vllm:cu129` (also `latest`).
+vime ships one image based on the official vllm image, published to
+`inferactinc/public`:
+
+- `vime-cu129-latest` — rolling pointer to the current image
+- `vime-cu129-nightly-<date>` — immutable dated snapshot (e.g. `vime-cu129-nightly-20260603a`)
 
 Build locally:
 
 ```bash
-docker build -f docker/Dockerfile -t vime/pr-9-vllm:cu129 .
+docker build -f docker/Dockerfile -t vime-cu129 .
 ```
 
 ## Release matrix

--- a/docker/justfile
+++ b/docker/justfile
@@ -53,14 +53,18 @@ manifest VARIANT:
         docker manifest push "$TAG"
     done
 
-debug:
+# ---- test/debug image used by the `run-ci-image` validation job ----
+# Analogous to slime's `slimerl/slime-test`: the `e2e-test-image` CI job pulls
+# `inferactinc/public:vime-cu129-test-latest`. Built single-arch (the image-
+# validation runner is x86).
+build-test:
     #!/bin/bash
     set -euxo pipefail
     cd ..
 
     VERSION="$(cat docker/version.txt | tr -d '\n')"
-    ARCH="$(uname -m)"
-    TAG="{{IMAGE}}:vime-debug-${VERSION}-${ARCH}"
+    docker build -f docker/Dockerfile . --build-arg HTTP_PROXY="$http_proxy" --build-arg HTTPS_PROXY="$https_proxy" --build-arg NO_PROXY="localhost,127.0.0.1" -t "{{IMAGE}}:vime-cu129-test-${VERSION}"
+    docker push "{{IMAGE}}:vime-cu129-test-${VERSION}"
 
-    docker build -f docker/Dockerfile . --build-arg HTTP_PROXY="$http_proxy" --build-arg HTTPS_PROXY="$https_proxy" --build-arg NO_PROXY="localhost,127.0.0.1" -t "$TAG"
-    docker push "$TAG"
+    docker tag "{{IMAGE}}:vime-cu129-test-${VERSION}" "{{IMAGE}}:vime-cu129-test-latest"
+    docker push "{{IMAGE}}:vime-cu129-test-latest"

--- a/docker/justfile
+++ b/docker/justfile
@@ -3,55 +3,64 @@
 # both the linux/amd64 and linux/arm64 digests and `docker pull` auto-selects
 # the platform. No arch suffix is ever published as a tag.
 #
+# CUDA 12.9 is the default, so it carries NO cu marker in the tag (like
+# slimerl/slime). Only the non-default cu13 variant is suffixed.
+#
 # The CUDA + source-built FA/TE images can't be cross-emulated, so each arch is
 # built on its own native host and pushed BY DIGEST (no tag lands in the hub),
 # then the two digests are fused into the final tag with `just manifest`.
 #
 # Tag scheme (mirrors slime's `nightly-dev-<date>` + `latest`):
-#   inferactinc/public:vime-<variant>-<version>   immutable, multi-arch
-#   inferactinc/public:vime-<variant>-latest      rolling,   multi-arch
-# <version> comes from docker/version.txt; <variant> is cu129 / cu13.
+#   inferactinc/public:vime-<version>        immutable, multi-arch (cu12.9)
+#   inferactinc/public:vime-latest           rolling,   multi-arch (cu12.9)
+#   inferactinc/public:vime-cu13-<version>   immutable, multi-arch (cu13 variant)
+#   inferactinc/public:vime-cu13-latest      rolling,   multi-arch (cu13 variant)
+# <version> comes from docker/version.txt.
 
 IMAGE := "inferactinc/public"
 BUILDER := "vime-builder"
 
 # ---- per-arch build, pushed BY DIGEST (run once on an amd64 host, once on an arm64 host) ----
 
-# cu129 — default vLLM base.
-build-cu129:
-    ARG_VARIANT="cu129" ARG_BUILD_EXTRA_ARGS="" just _build-digest
+# Default — cu12.9, no cu marker in the tag.
+build:
+    ARG_TAG_SUFFIX="" ARG_BUILD_EXTRA_ARGS="" just _build-digest
 
-# cu13 — vLLM default-CUDA base; ENABLE_CUDA_13 builds the CUDA-13
+# cu13 variant — vLLM default-CUDA base; ENABLE_CUDA_13 builds the CUDA-13
 # TransformerEngine/Triton on top.
 build-cu13:
-    ARG_VARIANT="cu13" ARG_BUILD_EXTRA_ARGS='--build-arg BASE_IMAGE=vllm/vllm-openai:v0.22.0-ubuntu2404 --build-arg ENABLE_CUDA_13=1' just _build-digest
+    ARG_TAG_SUFFIX="-cu13" ARG_BUILD_EXTRA_ARGS='--build-arg BASE_IMAGE=vllm/vllm-openai:v0.22.0-ubuntu2404 --build-arg ENABLE_CUDA_13=1' just _build-digest
 
 _build-digest:
     #!/bin/bash
     set -euxo pipefail
     cd ..
 
-    VERSION="$(cat docker/version.txt | tr -d '\n')"
     PLATFORM="linux/$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')"
-    META="/tmp/vime-${ARG_VARIANT}-$(uname -m).json"
+    META="/tmp/vime${ARG_TAG_SUFFIX}-$(uname -m).json"
 
     # push-by-digest requires the docker-container buildx driver.
     docker buildx inspect {{BUILDER}} >/dev/null 2>&1 || docker buildx create --name {{BUILDER}} --driver docker-container
 
     docker buildx build --builder {{BUILDER}} --platform "$PLATFORM" -f docker/Dockerfile $ARG_BUILD_EXTRA_ARGS --build-arg HTTP_PROXY="$http_proxy" --build-arg HTTPS_PROXY="$https_proxy" --build-arg NO_PROXY="localhost,127.0.0.1" -o "type=image,name={{IMAGE}},push-by-digest=true,push=true" --metadata-file "$META" .
 
-    echo "Pushed ${ARG_VARIANT} ${PLATFORM} by digest — pass this to \`just manifest\`:"
+    echo "Pushed vime${ARG_TAG_SUFFIX} ${PLATFORM} by digest — pass this to \`just manifest\`:"
     jq -r '."containerimage.digest"' "$META"
 
 # ---- fuse the two per-arch digests into one multi-arch tag ----
-# Run once after `build-<variant>` has pushed on BOTH hosts, passing the digests
-# it printed:  just manifest cu129 sha256:<amd64> sha256:<arm64>
+# Run once after `build` (or `build-cu13`) has pushed on BOTH hosts, passing the
+# digests it printed. For the default cu12.9 image leave VARIANT empty:
+#   just manifest "" sha256:<amd64> sha256:<arm64>     -> vime-<version> + vime-latest
+#   just manifest cu13 sha256:<amd64> sha256:<arm64>   -> vime-cu13-<version> + vime-cu13-latest
 manifest VARIANT AMD_DIGEST ARM_DIGEST:
     #!/bin/bash
     set -euxo pipefail
+    cd ..
 
     VERSION="$(cat docker/version.txt | tr -d '\n')"
-    docker buildx imagetools create -t "{{IMAGE}}:vime-{{VARIANT}}-${VERSION}" -t "{{IMAGE}}:vime-{{VARIANT}}-latest" "{{IMAGE}}@{{AMD_DIGEST}}" "{{IMAGE}}@{{ARM_DIGEST}}"
+    SUFFIX=""
+    [ -n "{{VARIANT}}" ] && SUFFIX="-{{VARIANT}}"
+    docker buildx imagetools create -t "{{IMAGE}}:vime${SUFFIX}-${VERSION}" -t "{{IMAGE}}:vime${SUFFIX}-latest" "{{IMAGE}}@{{AMD_DIGEST}}" "{{IMAGE}}@{{ARM_DIGEST}}"
 
 # ---- single-arch test/debug image for the run-ci-image validation job ----
 # slime-test analog; the e2e-test-image runner is x86, so this is amd64-only and
@@ -62,8 +71,8 @@ build-test:
     cd ..
 
     VERSION="$(cat docker/version.txt | tr -d '\n')"
-    docker build -f docker/Dockerfile . --build-arg HTTP_PROXY="$http_proxy" --build-arg HTTPS_PROXY="$https_proxy" --build-arg NO_PROXY="localhost,127.0.0.1" -t "{{IMAGE}}:vime-cu129-test-${VERSION}"
-    docker push "{{IMAGE}}:vime-cu129-test-${VERSION}"
+    docker build -f docker/Dockerfile . --build-arg HTTP_PROXY="$http_proxy" --build-arg HTTPS_PROXY="$https_proxy" --build-arg NO_PROXY="localhost,127.0.0.1" -t "{{IMAGE}}:vime-test-${VERSION}"
+    docker push "{{IMAGE}}:vime-test-${VERSION}"
 
-    docker tag "{{IMAGE}}:vime-cu129-test-${VERSION}" "{{IMAGE}}:vime-cu129-test-latest"
-    docker push "{{IMAGE}}:vime-cu129-test-latest"
+    docker tag "{{IMAGE}}:vime-test-${VERSION}" "{{IMAGE}}:vime-test-latest"
+    docker push "{{IMAGE}}:vime-test-latest"

--- a/docker/justfile
+++ b/docker/justfile
@@ -1,62 +1,61 @@
-# Release images publish to the company hub `inferactinc/public`.
+# Release images publish to the company hub `inferactinc/public` as multi-arch
+# manifests, exactly like upstream `vllm/vllm-openai:nightly`: ONE tag carries
+# both the linux/amd64 and linux/arm64 digests and `docker pull` auto-selects
+# the platform. No arch suffix is ever published as a tag.
 #
-# Platform (amd64 / arm64) is selected automatically by a multi-arch manifest —
-# there is intentionally NO arch suffix on the consumed tag, mirroring how the
-# upstream `vllm/vllm-openai` tags work. Build on each arch's native host, then
-# fuse the per-arch images into one tag with `just manifest <variant>`.
+# The CUDA + source-built FA/TE images can't be cross-emulated, so each arch is
+# built on its own native host and pushed BY DIGEST (no tag lands in the hub),
+# then the two digests are fused into the final tag with `just manifest`.
 #
 # Tag scheme (mirrors slime's `nightly-dev-<date>` + `latest`):
 #   inferactinc/public:vime-<variant>-<version>   immutable, multi-arch
-#   inferactinc/public:vime-<variant>-latest      rolling, multi-arch
-# where <version> comes from docker/version.txt and <variant> is cu129 / cu13.
+#   inferactinc/public:vime-<variant>-latest      rolling,   multi-arch
+# <version> comes from docker/version.txt; <variant> is cu129 / cu13.
 
 IMAGE := "inferactinc/public"
+BUILDER := "vime-builder"
 
-# ---- per-arch build + push (run on a host of the target arch) ----
+# ---- per-arch build, pushed BY DIGEST (run once on an amd64 host, once on an arm64 host) ----
 
 # cu129 — default vLLM base.
 build-cu129:
-    ARG_VARIANT="cu129" ARG_BUILD_EXTRA_ARGS="" just _build-arch
+    ARG_VARIANT="cu129" ARG_BUILD_EXTRA_ARGS="" just _build-digest
 
 # cu13 — vLLM default-CUDA base; ENABLE_CUDA_13 builds the CUDA-13
 # TransformerEngine/Triton on top.
 build-cu13:
-    ARG_VARIANT="cu13" ARG_BUILD_EXTRA_ARGS='--build-arg BASE_IMAGE=vllm/vllm-openai:v0.22.0-ubuntu2404 --build-arg ENABLE_CUDA_13=1' just _build-arch
+    ARG_VARIANT="cu13" ARG_BUILD_EXTRA_ARGS='--build-arg BASE_IMAGE=vllm/vllm-openai:v0.22.0-ubuntu2404 --build-arg ENABLE_CUDA_13=1' just _build-digest
 
-_build-arch:
+_build-digest:
     #!/bin/bash
     set -euxo pipefail
     cd ..
 
     VERSION="$(cat docker/version.txt | tr -d '\n')"
-    ARCH="$(uname -m)"   # x86_64 | aarch64 — staging tag only, fused away by `manifest`
-    STAGING="{{IMAGE}}:vime-${ARG_VARIANT}-${VERSION}-${ARCH}"
+    PLATFORM="linux/$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')"
+    META="/tmp/vime-${ARG_VARIANT}-$(uname -m).json"
 
-    docker build -f docker/Dockerfile . --build-arg HTTP_PROXY="$http_proxy" --build-arg HTTPS_PROXY="$https_proxy" --build-arg NO_PROXY="localhost,127.0.0.1" $ARG_BUILD_EXTRA_ARGS -t "$STAGING"
-    docker push "$STAGING"
+    # push-by-digest requires the docker-container buildx driver.
+    docker buildx inspect {{BUILDER}} >/dev/null 2>&1 || docker buildx create --name {{BUILDER}} --driver docker-container
 
-# ---- fuse the per-arch images into one multi-arch tag ----
-# Run once after the matching `build-<variant>` has pushed on BOTH arch hosts.
-# `just manifest cu129` produces vime-cu129-<version> (immutable) and
-# vime-cu129-latest (rolling), each a multi-arch manifest.
-manifest VARIANT:
+    docker buildx build --builder {{BUILDER}} --platform "$PLATFORM" -f docker/Dockerfile $ARG_BUILD_EXTRA_ARGS --build-arg HTTP_PROXY="$http_proxy" --build-arg HTTPS_PROXY="$https_proxy" --build-arg NO_PROXY="localhost,127.0.0.1" -o "type=image,name={{IMAGE}},push-by-digest=true,push=true" --metadata-file "$META" .
+
+    echo "Pushed ${ARG_VARIANT} ${PLATFORM} by digest — pass this to \`just manifest\`:"
+    jq -r '."containerimage.digest"' "$META"
+
+# ---- fuse the two per-arch digests into one multi-arch tag ----
+# Run once after `build-<variant>` has pushed on BOTH hosts, passing the digests
+# it printed:  just manifest cu129 sha256:<amd64> sha256:<arm64>
+manifest VARIANT AMD_DIGEST ARM_DIGEST:
     #!/bin/bash
     set -euxo pipefail
 
     VERSION="$(cat docker/version.txt | tr -d '\n')"
-    SRC_X86="{{IMAGE}}:vime-{{VARIANT}}-${VERSION}-x86_64"
-    SRC_ARM="{{IMAGE}}:vime-{{VARIANT}}-${VERSION}-aarch64"
+    docker buildx imagetools create -t "{{IMAGE}}:vime-{{VARIANT}}-${VERSION}" -t "{{IMAGE}}:vime-{{VARIANT}}-latest" "{{IMAGE}}@{{AMD_DIGEST}}" "{{IMAGE}}@{{ARM_DIGEST}}"
 
-    for TAG in "{{IMAGE}}:vime-{{VARIANT}}-${VERSION}" "{{IMAGE}}:vime-{{VARIANT}}-latest"; do
-        docker manifest rm "$TAG" 2>/dev/null || true
-        docker manifest create "$TAG" "$SRC_X86" "$SRC_ARM"
-        docker manifest push "$TAG"
-    done
-
-# ---- test/debug image used by the `run-ci-image` validation job ----
-# Analogous to slime's `slimerl/slime-test`: the `e2e-test-image` CI job pulls
-# `inferactinc/public:vime-cu129-test-latest`. Built single-arch (the image-
-# validation runner is x86).
+# ---- single-arch test/debug image for the run-ci-image validation job ----
+# slime-test analog; the e2e-test-image runner is x86, so this is amd64-only and
+# needs no manifest.
 build-test:
     #!/bin/bash
     set -euxo pipefail

--- a/docker/justfile
+++ b/docker/justfile
@@ -1,33 +1,57 @@
-release-primary:
-    ARG_TAG_POSTFIX="" ARG_BUILD_EXTRA_ARGS="" just _release-raw
+# Release images publish to the company hub `inferactinc/public`.
+#
+# Platform (amd64 / arm64) is selected automatically by a multi-arch manifest —
+# there is intentionally NO arch suffix on the consumed tag, mirroring how the
+# upstream `vllm/vllm-openai` tags work. Build on each arch's native host, then
+# fuse the per-arch images into one tag with `just manifest <variant>`.
+#
+# Tag scheme (mirrors slime's `nightly-dev-<date>` + `latest`):
+#   inferactinc/public:vime-<variant>-<version>   immutable, multi-arch
+#   inferactinc/public:vime-<variant>-latest      rolling, multi-arch
+# where <version> comes from docker/version.txt and <variant> is cu129 / cu13.
 
-# Should be executed on ARM machines.
-# Inherits the Dockerfile's default cu129 BASE_IMAGE; that tag is a multi-arch
-# manifest, so docker selects the arm64 image automatically on an ARM host.
-release-cu129-arm64:
-    ARG_TAG_POSTFIX="-cu129-arm64" ARG_BUILD_EXTRA_ARGS="" just _release-raw
+IMAGE := "inferactinc/public"
 
-# Should be executed on ARM machines.
-# The default-CUDA vLLM tag (no cuXXX suffix) already ships CUDA 13.0;
-# ENABLE_CUDA_13 then builds the CUDA-13 TransformerEngine/Triton on top.
-release-cu13-arm64:
-    ARG_TAG_POSTFIX="-cu13-arm64" ARG_BUILD_EXTRA_ARGS='--build-arg BASE_IMAGE=vllm/vllm-openai:v0.22.0-ubuntu2404 --build-arg ENABLE_CUDA_13=1' just _release-raw
+# ---- per-arch build + push (run on a host of the target arch) ----
 
-_release-raw:
+# cu129 — default vLLM base.
+build-cu129:
+    ARG_VARIANT="cu129" ARG_BUILD_EXTRA_ARGS="" just _build-arch
+
+# cu13 — vLLM default-CUDA base; ENABLE_CUDA_13 builds the CUDA-13
+# TransformerEngine/Triton on top.
+build-cu13:
+    ARG_VARIANT="cu13" ARG_BUILD_EXTRA_ARGS='--build-arg BASE_IMAGE=vllm/vllm-openai:v0.22.0-ubuntu2404 --build-arg ENABLE_CUDA_13=1' just _build-arch
+
+_build-arch:
     #!/bin/bash
     set -euxo pipefail
     cd ..
 
     VERSION="$(cat docker/version.txt | tr -d '\n')"
-    IMAGE_TAG=${VERSION}${ARG_TAG_POSTFIX}
+    ARCH="$(uname -m)"   # x86_64 | aarch64 — staging tag only, fused away by `manifest`
+    STAGING="{{IMAGE}}:vime-${ARG_VARIANT}-${VERSION}-${ARCH}"
 
-    docker build -f docker/Dockerfile . --build-arg HTTP_PROXY="$http_proxy" --build-arg HTTPS_PROXY="$https_proxy" --build-arg NO_PROXY="localhost,127.0.0.1" $ARG_BUILD_EXTRA_ARGS -t aosheninferact/vime-vllm:$IMAGE_TAG
-    docker push aosheninferact/vime-vllm:$IMAGE_TAG
+    docker build -f docker/Dockerfile . --build-arg HTTP_PROXY="$http_proxy" --build-arg HTTPS_PROXY="$https_proxy" --build-arg NO_PROXY="localhost,127.0.0.1" $ARG_BUILD_EXTRA_ARGS -t "$STAGING"
+    docker push "$STAGING"
 
-    if [ -z "${ARG_TAG_POSTFIX}" ]; then
-        docker tag aosheninferact/vime-vllm:$IMAGE_TAG aosheninferact/vime-vllm:latest
-        docker push aosheninferact/vime-vllm:latest
-    fi
+# ---- fuse the per-arch images into one multi-arch tag ----
+# Run once after the matching `build-<variant>` has pushed on BOTH arch hosts.
+# `just manifest cu129` produces vime-cu129-<version> (immutable) and
+# vime-cu129-latest (rolling), each a multi-arch manifest.
+manifest VARIANT:
+    #!/bin/bash
+    set -euxo pipefail
+
+    VERSION="$(cat docker/version.txt | tr -d '\n')"
+    SRC_X86="{{IMAGE}}:vime-{{VARIANT}}-${VERSION}-x86_64"
+    SRC_ARM="{{IMAGE}}:vime-{{VARIANT}}-${VERSION}-aarch64"
+
+    for TAG in "{{IMAGE}}:vime-{{VARIANT}}-${VERSION}" "{{IMAGE}}:vime-{{VARIANT}}-latest"; do
+        docker manifest rm "$TAG" 2>/dev/null || true
+        docker manifest create "$TAG" "$SRC_X86" "$SRC_ARM"
+        docker manifest push "$TAG"
+    done
 
 debug:
     #!/bin/bash
@@ -35,10 +59,8 @@ debug:
     cd ..
 
     VERSION="$(cat docker/version.txt | tr -d '\n')"
-    IMAGE_TAG=${VERSION}
+    ARCH="$(uname -m)"
+    TAG="{{IMAGE}}:vime-debug-${VERSION}-${ARCH}"
 
-    docker build -f docker/Dockerfile . --build-arg HTTP_PROXY="$http_proxy" --build-arg HTTPS_PROXY="$https_proxy" --build-arg NO_PROXY="localhost,127.0.0.1" -t aosheninferact/vime-vllm-test:$IMAGE_TAG
-    docker push aosheninferact/vime-vllm-test:$IMAGE_TAG
-
-    docker tag aosheninferact/vime-vllm-test:$IMAGE_TAG aosheninferact/vime-vllm-test:latest
-    docker push aosheninferact/vime-vllm-test:latest
+    docker build -f docker/Dockerfile . --build-arg HTTP_PROXY="$http_proxy" --build-arg HTTPS_PROXY="$https_proxy" --build-arg NO_PROXY="localhost,127.0.0.1" -t "$TAG"
+    docker push "$TAG"

--- a/docs/en/developer_guide/ci.md
+++ b/docs/en/developer_guide/ci.md
@@ -6,7 +6,7 @@ vime uses GitHub Actions for CI. Tests are triggered by **PR labels** — adding
 
 The workflow is defined in `.github/workflows/pr-test.yml` (auto-generated from `pr-test.yml.j2`). Each CI job:
 
-1. Runs on a self-hosted GPU runner via `docker run` using the `inferactinc/public:vime-cu129-latest` image.
+1. Runs on a self-hosted GPU runner via `docker run`; most tests use `inferactinc/public:vime-cu129-latest`, while image validation uses `inferactinc/public:vime-cu129-test-latest`.
 2. Installs vime with `pip install -e . --no-deps`.
 3. Acquires the required GPUs via `tests/ci/gpu_lock_exec.py --count <num_gpus>`.
 4. Executes the test file: `python <test_path>.py` or `python tests/<test_file>.py`, depending on whether the test lives under `tests/` or a subdirectory such as `tests/plugin_contracts/`.
@@ -23,7 +23,7 @@ Add a label to your PR to trigger the corresponding test suite:
 | `run-ci-megatron` | `e2e-test-megatron` | Core Megatron training tests covering dense, MoE, PPO, MTP, etc. |
 | `run-ci-precision` | `e2e-test-precision` | Numerical precision validation (parallel check). |
 | `run-ci-ckpt` | `e2e-test-ckpt` | Checkpoint save/load correctness (sync and async-save). |
-| `run-ci-image` | `e2e-test-image` | Full test suite run on `inferactinc/public:vime-cu129-latest` image (for image validation). |
+| `run-ci-image` | `e2e-test-image` | Full test suite run on `inferactinc/public:vime-cu129-test-latest` image (for image validation). |
 | `run-ci-changed` | `e2e-test-changed` | **Dynamically** detects new/modified test files in the PR and runs only those. |
 
 All labels also run when triggered via `workflow_dispatch` (manual run from the Actions tab).
@@ -44,7 +44,7 @@ This means you don't need to manually register your new test in the workflow —
 
 ### `run-ci-image` — Full Suite on Test Image
 
-This runs **all** registered tests on the `inferactinc/public:vime-cu129-latest` Docker image. Use this label to:
+This runs **all** registered tests on the `inferactinc/public:vime-cu129-test-latest` Docker image. Use this label to:
 
 - Validate a newly built Docker image before release.
 - Run the entire test suite for a comprehensive pre-merge check.

--- a/docs/en/developer_guide/ci.md
+++ b/docs/en/developer_guide/ci.md
@@ -6,7 +6,7 @@ vime uses GitHub Actions for CI. Tests are triggered by **PR labels** — adding
 
 The workflow is defined in `.github/workflows/pr-test.yml` (auto-generated from `pr-test.yml.j2`). Each CI job:
 
-1. Runs on a self-hosted GPU runner via `docker run`; most tests use `inferactinc/public:vime-vllm-cu129-latest`, while image validation uses `inferactinc/public:vime-vllm-cu129-latest`.
+1. Runs on a self-hosted GPU runner via `docker run`; most tests use `inferactinc/public:vime-cu129-latest`, while image validation uses `inferactinc/public:vime-cu129-latest`.
 2. Installs vime with `pip install -e . --no-deps`.
 3. Acquires the required GPUs via `tests/ci/gpu_lock_exec.py --count <num_gpus>`.
 4. Executes the test file: `python <test_path>.py` or `python tests/<test_file>.py`, depending on whether the test lives under `tests/` or a subdirectory such as `tests/plugin_contracts/`.
@@ -23,7 +23,7 @@ Add a label to your PR to trigger the corresponding test suite:
 | `run-ci-megatron` | `e2e-test-megatron` | Core Megatron training tests covering dense, MoE, PPO, MTP, etc. |
 | `run-ci-precision` | `e2e-test-precision` | Numerical precision validation (parallel check). |
 | `run-ci-ckpt` | `e2e-test-ckpt` | Checkpoint save/load correctness (sync and async-save). |
-| `run-ci-image` | `e2e-test-image` | Full test suite run on `inferactinc/public:vime-vllm-cu129-latest` image (for image validation). |
+| `run-ci-image` | `e2e-test-image` | Full test suite run on `inferactinc/public:vime-cu129-latest` image (for image validation). |
 | `run-ci-changed` | `e2e-test-changed` | **Dynamically** detects new/modified test files in the PR and runs only those. |
 
 All labels also run when triggered via `workflow_dispatch` (manual run from the Actions tab).
@@ -44,7 +44,7 @@ This means you don't need to manually register your new test in the workflow —
 
 ### `run-ci-image` — Full Suite on Test Image
 
-This runs **all** registered tests on the `inferactinc/public:vime-vllm-cu129-latest` Docker image. Use this label to:
+This runs **all** registered tests on the `inferactinc/public:vime-cu129-latest` Docker image. Use this label to:
 
 - Validate a newly built Docker image before release.
 - Run the entire test suite for a comprehensive pre-merge check.

--- a/docs/en/developer_guide/ci.md
+++ b/docs/en/developer_guide/ci.md
@@ -6,7 +6,7 @@ vime uses GitHub Actions for CI. Tests are triggered by **PR labels** — adding
 
 The workflow is defined in `.github/workflows/pr-test.yml` (auto-generated from `pr-test.yml.j2`). Each CI job:
 
-1. Runs on a self-hosted GPU runner via `docker run`; most tests use `inferactinc/public:vime-cu129-latest`, while image validation uses `inferactinc/public:vime-cu129-latest`.
+1. Runs on a self-hosted GPU runner via `docker run` using the `inferactinc/public:vime-cu129-latest` image.
 2. Installs vime with `pip install -e . --no-deps`.
 3. Acquires the required GPUs via `tests/ci/gpu_lock_exec.py --count <num_gpus>`.
 4. Executes the test file: `python <test_path>.py` or `python tests/<test_file>.py`, depending on whether the test lives under `tests/` or a subdirectory such as `tests/plugin_contracts/`.

--- a/docs/en/developer_guide/ci.md
+++ b/docs/en/developer_guide/ci.md
@@ -6,7 +6,7 @@ vime uses GitHub Actions for CI. Tests are triggered by **PR labels** — adding
 
 The workflow is defined in `.github/workflows/pr-test.yml` (auto-generated from `pr-test.yml.j2`). Each CI job:
 
-1. Runs on a self-hosted GPU runner via `docker run`; most tests use `inferactinc/public:vime-cu129-latest`, while image validation uses `inferactinc/public:vime-cu129-test-latest`.
+1. Runs on a self-hosted GPU runner via `docker run`; most tests use `inferactinc/public:vime-latest`, while image validation uses `inferactinc/public:vime-test-latest`.
 2. Installs vime with `pip install -e . --no-deps`.
 3. Acquires the required GPUs via `tests/ci/gpu_lock_exec.py --count <num_gpus>`.
 4. Executes the test file: `python <test_path>.py` or `python tests/<test_file>.py`, depending on whether the test lives under `tests/` or a subdirectory such as `tests/plugin_contracts/`.
@@ -23,7 +23,7 @@ Add a label to your PR to trigger the corresponding test suite:
 | `run-ci-megatron` | `e2e-test-megatron` | Core Megatron training tests covering dense, MoE, PPO, MTP, etc. |
 | `run-ci-precision` | `e2e-test-precision` | Numerical precision validation (parallel check). |
 | `run-ci-ckpt` | `e2e-test-ckpt` | Checkpoint save/load correctness (sync and async-save). |
-| `run-ci-image` | `e2e-test-image` | Full test suite run on `inferactinc/public:vime-cu129-test-latest` image (for image validation). |
+| `run-ci-image` | `e2e-test-image` | Full test suite run on `inferactinc/public:vime-test-latest` image (for image validation). |
 | `run-ci-changed` | `e2e-test-changed` | **Dynamically** detects new/modified test files in the PR and runs only those. |
 
 All labels also run when triggered via `workflow_dispatch` (manual run from the Actions tab).
@@ -44,7 +44,7 @@ This means you don't need to manually register your new test in the workflow —
 
 ### `run-ci-image` — Full Suite on Test Image
 
-This runs **all** registered tests on the `inferactinc/public:vime-cu129-test-latest` Docker image. Use this label to:
+This runs **all** registered tests on the `inferactinc/public:vime-test-latest` Docker image. Use this label to:
 
 - Validate a newly built Docker image before release.
 - Run the entire test suite for a comprehensive pre-merge check.

--- a/docs/en/examples/qwen3-4B.md
+++ b/docs/en/examples/qwen3-4B.md
@@ -2,7 +2,7 @@
 
 ## Environment Setup
 
-After pulling the `inferactinc/public:vime-cu129-latest` image, initialize the image environment as follows:
+After pulling the `inferactinc/public:vime-latest` image, initialize the image environment as follows:
 
 ```bash
 cd /root/

--- a/docs/en/examples/qwen3-4B.md
+++ b/docs/en/examples/qwen3-4B.md
@@ -2,7 +2,7 @@
 
 ## Environment Setup
 
-After pulling the `inferactinc/public:vime-vllm-cu129-latest` image, initialize the image environment as follows:
+After pulling the `inferactinc/public:vime-cu129-latest` image, initialize the image environment as follows:
 
 ```bash
 cd /root/

--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -28,12 +28,12 @@ Please execute the following commands to pull the latest image and start an inte
 
 ```shell
 # Pull the latest image
-docker pull inferactinc/public:vime-vllm-cu129-latest
+docker pull inferactinc/public:vime-cu129-latest
 
 # Start the container
 docker run --rm --gpus all --ipc=host --shm-size=16g \
   --ulimit memlock=-1 --ulimit stack=67108864 \
-  -it inferactinc/public:vime-vllm-cu129-latest /bin/bash
+  -it inferactinc/public:vime-cu129-latest /bin/bash
 ```
 
 ### Install vime

--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -28,12 +28,12 @@ Please execute the following commands to pull the latest image and start an inte
 
 ```shell
 # Pull the latest image
-docker pull inferactinc/public:vime-cu129-latest
+docker pull inferactinc/public:vime-latest
 
 # Start the container
 docker run --rm --gpus all --ipc=host --shm-size=16g \
   --ulimit memlock=-1 --ulimit stack=67108864 \
-  -it inferactinc/public:vime-cu129-latest /bin/bash
+  -it inferactinc/public:vime-latest /bin/bash
 ```
 
 ### Install vime

--- a/docs/zh/developer_guide/ci.md
+++ b/docs/zh/developer_guide/ci.md
@@ -6,7 +6,7 @@ vime 使用 GitHub Actions 进行 CI。测试通过 **PR label** 触发——给
 
 工作流定义在 `.github/workflows/pr-test.yml`（由 `pr-test.yml.j2` 自动生成）。每个 CI 任务会：
 
-1. 在自托管 GPU runner 上通过 `docker run` 运行，使用 `inferactinc/public:vime-cu129-latest` 镜像。
+1. 在自托管 GPU runner 上通过 `docker run` 运行；大多数测试使用 `inferactinc/public:vime-cu129-latest`，镜像验证使用 `inferactinc/public:vime-cu129-test-latest`。
 2. 通过 `pip install -e . --no-deps` 安装 vime。
 3. 通过 `tests/ci/gpu_lock_exec.py --count <num_gpus>` 获取所需数量的 GPU。
 4. 执行测试文件：`python <test_path>.py` 或 `python tests/<test_file>.py`。如果测试位于 `tests/plugin_contracts/` 这样的子目录，CI 也会自动处理。
@@ -23,7 +23,7 @@ vime 使用 GitHub Actions 进行 CI。测试通过 **PR label** 触发——给
 | `run-ci-megatron` | `e2e-test-megatron` | 核心 Megatron 训练测试，覆盖 Dense、MoE、PPO、MTP 等。 |
 | `run-ci-precision` | `e2e-test-precision` | 数值精度校验（并行一致性检查）。 |
 | `run-ci-ckpt` | `e2e-test-ckpt` | Checkpoint 保存/加载正确性（同步和异步保存）。 |
-| `run-ci-image` | `e2e-test-image` | 在 `inferactinc/public:vime-cu129-latest` 镜像上运行**全部**测试（用于镜像验证）。 |
+| `run-ci-image` | `e2e-test-image` | 在 `inferactinc/public:vime-cu129-test-latest` 镜像上运行**全部**测试（用于镜像验证）。 |
 | `run-ci-changed` | `e2e-test-changed` | **动态**检测 PR 中新增或修改的测试文件，仅运行这些测试。 |
 
 所有 label 也可通过 `workflow_dispatch`（在 Actions 页面手动触发）来运行。
@@ -44,7 +44,7 @@ vime 使用 GitHub Actions 进行 CI。测试通过 **PR label** 触发——给
 
 ### `run-ci-image` — 在测试镜像上运行全部测试
 
-这会在 `inferactinc/public:vime-cu129-latest` Docker 镜像上运行**所有**已注册的测试。适用于：
+这会在 `inferactinc/public:vime-cu129-test-latest` Docker 镜像上运行**所有**已注册的测试。适用于：
 
 - 验证新构建的 Docker 镜像是否可用。
 - 在合并前做全面的测试检查。

--- a/docs/zh/developer_guide/ci.md
+++ b/docs/zh/developer_guide/ci.md
@@ -6,7 +6,7 @@ vime 使用 GitHub Actions 进行 CI。测试通过 **PR label** 触发——给
 
 工作流定义在 `.github/workflows/pr-test.yml`（由 `pr-test.yml.j2` 自动生成）。每个 CI 任务会：
 
-1. 在自托管 GPU runner 上通过 `docker run` 运行；大多数测试使用 `inferactinc/public:vime-cu129-latest`，镜像验证使用 `inferactinc/public:vime-cu129-test-latest`。
+1. 在自托管 GPU runner 上通过 `docker run` 运行；大多数测试使用 `inferactinc/public:vime-latest`，镜像验证使用 `inferactinc/public:vime-test-latest`。
 2. 通过 `pip install -e . --no-deps` 安装 vime。
 3. 通过 `tests/ci/gpu_lock_exec.py --count <num_gpus>` 获取所需数量的 GPU。
 4. 执行测试文件：`python <test_path>.py` 或 `python tests/<test_file>.py`。如果测试位于 `tests/plugin_contracts/` 这样的子目录，CI 也会自动处理。
@@ -23,7 +23,7 @@ vime 使用 GitHub Actions 进行 CI。测试通过 **PR label** 触发——给
 | `run-ci-megatron` | `e2e-test-megatron` | 核心 Megatron 训练测试，覆盖 Dense、MoE、PPO、MTP 等。 |
 | `run-ci-precision` | `e2e-test-precision` | 数值精度校验（并行一致性检查）。 |
 | `run-ci-ckpt` | `e2e-test-ckpt` | Checkpoint 保存/加载正确性（同步和异步保存）。 |
-| `run-ci-image` | `e2e-test-image` | 在 `inferactinc/public:vime-cu129-test-latest` 镜像上运行**全部**测试（用于镜像验证）。 |
+| `run-ci-image` | `e2e-test-image` | 在 `inferactinc/public:vime-test-latest` 镜像上运行**全部**测试（用于镜像验证）。 |
 | `run-ci-changed` | `e2e-test-changed` | **动态**检测 PR 中新增或修改的测试文件，仅运行这些测试。 |
 
 所有 label 也可通过 `workflow_dispatch`（在 Actions 页面手动触发）来运行。
@@ -44,7 +44,7 @@ vime 使用 GitHub Actions 进行 CI。测试通过 **PR label** 触发——给
 
 ### `run-ci-image` — 在测试镜像上运行全部测试
 
-这会在 `inferactinc/public:vime-cu129-test-latest` Docker 镜像上运行**所有**已注册的测试。适用于：
+这会在 `inferactinc/public:vime-test-latest` Docker 镜像上运行**所有**已注册的测试。适用于：
 
 - 验证新构建的 Docker 镜像是否可用。
 - 在合并前做全面的测试检查。

--- a/docs/zh/developer_guide/ci.md
+++ b/docs/zh/developer_guide/ci.md
@@ -6,7 +6,7 @@ vime 使用 GitHub Actions 进行 CI。测试通过 **PR label** 触发——给
 
 工作流定义在 `.github/workflows/pr-test.yml`（由 `pr-test.yml.j2` 自动生成）。每个 CI 任务会：
 
-1. 在自托管 GPU runner 上通过 `docker run` 运行；大多数测试使用 `inferactinc/public:vime-cu129-latest`，镜像验证使用 `inferactinc/public:vime-cu129-latest`。
+1. 在自托管 GPU runner 上通过 `docker run` 运行，使用 `inferactinc/public:vime-cu129-latest` 镜像。
 2. 通过 `pip install -e . --no-deps` 安装 vime。
 3. 通过 `tests/ci/gpu_lock_exec.py --count <num_gpus>` 获取所需数量的 GPU。
 4. 执行测试文件：`python <test_path>.py` 或 `python tests/<test_file>.py`。如果测试位于 `tests/plugin_contracts/` 这样的子目录，CI 也会自动处理。

--- a/docs/zh/developer_guide/ci.md
+++ b/docs/zh/developer_guide/ci.md
@@ -6,7 +6,7 @@ vime 使用 GitHub Actions 进行 CI。测试通过 **PR label** 触发——给
 
 工作流定义在 `.github/workflows/pr-test.yml`（由 `pr-test.yml.j2` 自动生成）。每个 CI 任务会：
 
-1. 在自托管 GPU runner 上通过 `docker run` 运行；大多数测试使用 `inferactinc/public:vime-vllm-cu129-latest`，镜像验证使用 `inferactinc/public:vime-vllm-cu129-latest`。
+1. 在自托管 GPU runner 上通过 `docker run` 运行；大多数测试使用 `inferactinc/public:vime-cu129-latest`，镜像验证使用 `inferactinc/public:vime-cu129-latest`。
 2. 通过 `pip install -e . --no-deps` 安装 vime。
 3. 通过 `tests/ci/gpu_lock_exec.py --count <num_gpus>` 获取所需数量的 GPU。
 4. 执行测试文件：`python <test_path>.py` 或 `python tests/<test_file>.py`。如果测试位于 `tests/plugin_contracts/` 这样的子目录，CI 也会自动处理。
@@ -23,7 +23,7 @@ vime 使用 GitHub Actions 进行 CI。测试通过 **PR label** 触发——给
 | `run-ci-megatron` | `e2e-test-megatron` | 核心 Megatron 训练测试，覆盖 Dense、MoE、PPO、MTP 等。 |
 | `run-ci-precision` | `e2e-test-precision` | 数值精度校验（并行一致性检查）。 |
 | `run-ci-ckpt` | `e2e-test-ckpt` | Checkpoint 保存/加载正确性（同步和异步保存）。 |
-| `run-ci-image` | `e2e-test-image` | 在 `inferactinc/public:vime-vllm-cu129-latest` 镜像上运行**全部**测试（用于镜像验证）。 |
+| `run-ci-image` | `e2e-test-image` | 在 `inferactinc/public:vime-cu129-latest` 镜像上运行**全部**测试（用于镜像验证）。 |
 | `run-ci-changed` | `e2e-test-changed` | **动态**检测 PR 中新增或修改的测试文件，仅运行这些测试。 |
 
 所有 label 也可通过 `workflow_dispatch`（在 Actions 页面手动触发）来运行。
@@ -44,7 +44,7 @@ vime 使用 GitHub Actions 进行 CI。测试通过 **PR label** 触发——给
 
 ### `run-ci-image` — 在测试镜像上运行全部测试
 
-这会在 `inferactinc/public:vime-vllm-cu129-latest` Docker 镜像上运行**所有**已注册的测试。适用于：
+这会在 `inferactinc/public:vime-cu129-latest` Docker 镜像上运行**所有**已注册的测试。适用于：
 
 - 验证新构建的 Docker 镜像是否可用。
 - 在合并前做全面的测试检查。

--- a/docs/zh/examples/qwen3-4B.md
+++ b/docs/zh/examples/qwen3-4B.md
@@ -2,7 +2,7 @@
 
 ## 环境准备
 
-拉取 `inferactinc/public:vime-cu129-latest` 镜像后，用如下方式初始化镜像环境：
+拉取 `inferactinc/public:vime-latest` 镜像后，用如下方式初始化镜像环境：
 
 ```bash
 cd /root/

--- a/docs/zh/examples/qwen3-4B.md
+++ b/docs/zh/examples/qwen3-4B.md
@@ -2,7 +2,7 @@
 
 ## 环境准备
 
-拉取 `inferactinc/public:vime-vllm-cu129-latest` 镜像后，用如下方式初始化镜像环境：
+拉取 `inferactinc/public:vime-cu129-latest` 镜像后，用如下方式初始化镜像环境：
 
 ```bash
 cd /root/

--- a/docs/zh/get_started/quick_start.md
+++ b/docs/zh/get_started/quick_start.md
@@ -27,12 +27,12 @@
 
 ```shell
 # 拉取最新镜像
-docker pull inferactinc/public:vime-vllm-cu129-latest
+docker pull inferactinc/public:vime-cu129-latest
 
 # 启动容器
 docker run --rm --gpus all --ipc=host --shm-size=16g \
   --ulimit memlock=-1 --ulimit stack=67108864 \
-  -it inferactinc/public:vime-vllm-cu129-latest /bin/bash
+  -it inferactinc/public:vime-cu129-latest /bin/bash
 ```
 
 ### 安装 vime

--- a/docs/zh/get_started/quick_start.md
+++ b/docs/zh/get_started/quick_start.md
@@ -27,12 +27,12 @@
 
 ```shell
 # 拉取最新镜像
-docker pull inferactinc/public:vime-cu129-latest
+docker pull inferactinc/public:vime-latest
 
 # 启动容器
 docker run --rm --gpus all --ipc=host --shm-size=16g \
   --ulimit memlock=-1 --ulimit stack=67108864 \
-  -it inferactinc/public:vime-cu129-latest /bin/bash
+  -it inferactinc/public:vime-latest /bin/bash
 ```
 
 ### 安装 vime


### PR DESCRIPTION
## What

Normalizes the published Docker image name and collapses the multiple
drifting `*-latest` pointers into a single rolling tag, mirroring slime's
`nightly-dev-<date>` + `latest` convention.

**New scheme** (published to `inferactinc/public`):

| tag | type |
|---|---|
| `vime-cu129-latest` | single rolling pointer to current image |
| `vime-cu129-nightly-<date>` | immutable dated snapshot (e.g. `vime-cu129-nightly-20260603a`) |

**Why drop `-vllm-`:** "vime" already means vllm+slime, so `vime-vllm-*` is
redundant. slime itself never encodes the rollout backend in the tag
(`slimerl/slime` uses sglang but tags are just `nightly-dev-<date>`). `cu129`
is kept as the real CUDA-ABI discriminator (slime splits this at the repo
level via `slime` vs `slime_b200`; we can't make new repos in the shared
`inferactinc/public`, so it stays in the tag).

## Changes (in-repo references only — names normalized to the canonical latest)

- `.github/workflows/pr-test.yml` — 8 job images → `inferactinc/public:vime-cu129-latest`
- `docs/{en,zh}/developer_guide/ci.md`, `docs/{en,zh}/get_started/quick_start.md`, `docs/{en,zh}/examples/qwen3-4B.md`
- `docker/README.md` — unified the stray personal-namespace `aosheninferact/vime-vllm:cu129` onto `inferactinc/public`, documented the two-tag scheme, build example `-t vime-cu129`

grep confirms 0 remaining `vime-vllm-cu129-latest` / `aosheninferact/vime-vllm` / `vime/pr-9-vllm` references.

## Registry side (already done, out of band)

`inferactinc/public:vime-cu129-latest` and `vime-cu129-nightly-20260603a`
are already pushed (digest `sha256:2028ebb7…`), so CI on this PR pulls a
valid tag. The old ambiguous `vime-vllm-cu129-latest` / `-r3-latest` /
`-sync1916` tags are pending deletion from DockerHub.

> ⚠️ The new `vime-cu129-latest` points at the current (sync-1916 / vllm-0.22-base)
> image, which differs from the digest the old `vime-vllm-cu129-latest` resolved
> to. CI on this PR is the validation gate for that content.

AI assistance (Claude Code) was used for this change.