### PR TITLE
[Sync][misc] #1975 engine-agnostic riders (data.py debug-assert widen + parallel_check sweep)

### DIFF
--- a/tests/test_qwen3_0.6B_parallel_check.py
+++ b/tests/test_qwen3_0.6B_parallel_check.py
@@ -101,17 +101,12 @@ def execute():
             num_gpus_per_node=NUM_GPUS,
             megatron_model_type=MODEL_TYPE,
         )
-        # 8 GPU CPU 1
+        parallel_sizes = [1, 2, 4]
         for num_gpus in [8, 4, 2]:
-            remaining_gpus = num_gpus
-            for tp_size in [1, 2, 4, 8]:
-                remaining_gpus /= tp_size
+            for tp_size in parallel_sizes:
                 for pp_size in [1, 2, 4]:
-                    if remaining_gpus < pp_size:
-                        continue
-                    remaining_gpus /= pp_size
-                    for cp_size in [1, 2, 4, 8]:
-                        if remaining_gpus < cp_size:
+                    for cp_size in parallel_sizes:
+                        if tp_size * pp_size * cp_size > num_gpus:
                             continue
                         args = train_args + (
                             f"--load-debug-rollout-data data-{i}.pt "

--- a/vime/backends/megatron_utils/data.py
+++ b/vime/backends/megatron_utils/data.py
@@ -472,9 +472,9 @@ def log_rollout_data(
                 # assert reduced_log_dict["rollout/log_probs"] == reduced_log_dict["rollout/ref_log_probs"]
                 assert abs(reduced_log_dict["rollout/log_probs"] - reduced_log_dict["rollout/ref_log_probs"]) < 1e-8
             if "rollout/log_probs" in reduced_log_dict:
-                assert -0.5 < reduced_log_dict["rollout/log_probs"] < 0
+                assert -1 < reduced_log_dict["rollout/log_probs"] < 0
             if "rollout/entropy" in reduced_log_dict:
-                assert 0 < reduced_log_dict["rollout/entropy"] < 0.5
+                assert 0 < reduced_log_dict["rollout/entropy"] < 1
 
     if args.log_multi_turn:
         log_multi_turn_data(rollout_id, args, rollout_data)


### PR DESCRIPTION
## Summary
The two **engine-agnostic riders** split out of slime #1975 (the rest — version.txt/build_conda/dead sglang patch-dirs — is N/A for vime; see #107):

- `data.py` debug-assert widen: log_probs `-0.5→-1`, entropy `0.5→1`
- `test_qwen3_0.6B_parallel_check` sweep `[1,2,4,8]→[1,2,4]` via parallel_sizes + skip when `tp*pp*cp > num_gpus`

Mirror slime. (#1985/#1986 — the larger test-shortening — are sequenced AFTER mega-A/G merge, tracked in #107.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)