### PR TITLE
[Example] multi_agent: preserve rollout logprobs (port slime #1995)

### DIFF
--- a/examples/multi_agent/agent_system.py
+++ b/examples/multi_agent/agent_system.py
@@ -42,12 +42,19 @@ async def generate_response(args, prompt, key):
         output = await post(url, payload)
         choice = output["choices"][0]
         finish_reason = choice.get("finish_reason") or "stop"
-        new_response_tokens, _ = _inference_generate_tokens_and_logprobs(choice)
+        new_response_tokens, new_response_log_probs = _inference_generate_tokens_and_logprobs(choice)
         response_text = tokenizer.decode(new_response_tokens, skip_special_tokens=False) if new_response_tokens else ""
 
         # Update sample with tokens directly - avoiding re-tokenization
         sample.tokens = sample.tokens + new_response_tokens
         sample.response_length += len(new_response_tokens)
+        if sample.rollout_log_probs is None:
+            sample.rollout_log_probs = []
+        sample.rollout_log_probs += new_response_log_probs
+        assert len(sample.rollout_log_probs) == sample.response_length, (
+            f"rollout logprob length mismatch: {len(sample.rollout_log_probs)} logprobs "
+            f"vs {sample.response_length} response tokens"
+        )
         sample.response = response_text
 
         match finish_reason:

--- a/examples/multi_agent/run-qwen3-30B-A3B-multi-agent.sh
+++ b/examples/multi_agent/run-qwen3-30B-A3B-multi-agent.sh
@@ -87,6 +87,7 @@ GRPO_ARGS=(
    --entropy-coef 0.00
    --eps-clip 0.2
    --eps-clip-high 0.28
+   --use-rollout-logprobs
 )
 
 OPTIMIZER_ARGS=(


### PR DESCRIPTION
Ports slime [#1995](https://github.com/THUDM/slime/pull/1995) — `fix(multi-agent): preserve rollout logprobs`.

## What & why
The `examples/multi_agent` rollout dropped per-token rollout logprobs, so `--use-rollout-logprobs` training had nothing to consume. This captures them and asserts the length invariant.

## Changes (faithful slime mirror, vLLM-translated)
- `examples/multi_agent/agent_system.py`: vime already returns logprobs from `_inference_generate_tokens_and_logprobs(choice)` but discarded them with `_`; now capture `new_response_log_probs`, append to `sample.rollout_log_probs`, and `assert len(rollout_log_probs) == response_length` — the vLLM-normalized equivalent of slime's `output["meta_info"]["output_token_logprobs"]` path.
- `run-qwen3-30B-A3B-multi-agent.sh`: add `--use-rollout-logprobs` to GRPO_ARGS (matches slime).

## Scope / risk
Example-only; no core/engine change. Post-cutoff upstream item tracked in #107.

## Test
`py_compile` OK. Functional path needs the multi_agent example run (GPU) — not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)