### PR TITLE
[Bugfix] Quiesce colocated vLLM engines before weight release/inject

### DIFF
--- a/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -303,14 +303,6 @@ class UpdateWeightFromTensor:
         # ── 1. Pause generation and flush KV cache (rank 0 only) ────────────
         if rank == 0:
             if self._colocated_engines:
-                # Quiesce BEFORE freeing weights. ``pause_generation`` posts ``/pause`` with
-                # mode="keep" -> scheduler enters PAUSED_ALL (token_budget=0, no new step) and
-                # the call blocks until the engine is idle. This guarantees no in-flight model
-                # step overlaps the ``release_memory_occupation(level=0)`` + IPC weight injection
-                # below. Without it, an in-flight step's device->host sync
-                # (gpu_model_runner.get_output()/_bookkeeping_sync._to_list) hangs forever once
-                # the weight/KV memory is mutated under it (intermittent weight-sync hang).
-                # Mirrors the distributed branch below and slime, which pause every engine.
                 ray.get([engine.pause_generation.remote() for engine in self._colocated_engines])
                 ray.get([engine.release_memory_occupation.remote(level=0) for engine in self._colocated_engines])
             if self._distributed_engines:
@@ -380,8 +372,6 @@ class UpdateWeightFromTensor:
                         for engine in self._colocated_engines
                     ]
                 )
-                # Counterpart to the pause_generation() in step 1: clear the PAUSED state so the
-                # scheduler resumes stepping now that weights are live and KV is re-allocated.
                 ray.get([engine.continue_generation.remote() for engine in self._colocated_engines])
             if self._distributed_engines:
                 ray.get([engine.continue_generation.remote() for engine in self._distributed_engines])

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -303,6 +303,15 @@ class UpdateWeightFromTensor:
         # ── 1. Pause generation and flush KV cache (rank 0 only) ────────────
         if rank == 0:
             if self._colocated_engines:
+                # Quiesce BEFORE freeing weights. ``pause_generation`` posts ``/pause`` with
+                # mode="keep" -> scheduler enters PAUSED_ALL (token_budget=0, no new step) and
+                # the call blocks until the engine is idle. This guarantees no in-flight model
+                # step overlaps the ``release_memory_occupation(level=0)`` + IPC weight injection
+                # below. Without it, an in-flight step's device->host sync
+                # (gpu_model_runner.get_output()/_bookkeeping_sync._to_list) hangs forever once
+                # the weight/KV memory is mutated under it (intermittent weight-sync hang).
+                # Mirrors the distributed branch below and slime, which pause every engine.
+                ray.get([engine.pause_generation.remote() for engine in self._colocated_engines])
                 ray.get([engine.release_memory_occupation.remote(level=0) for engine in self._colocated_engines])
             if self._distributed_engines:
                 ray.get([engine.pause_generation.remote() for engine in self._distributed_engines])
@@ -371,6 +380,9 @@ class UpdateWeightFromTensor:
                         for engine in self._colocated_engines
                     ]
                 )
+                # Counterpart to the pause_generation() in step 1: clear the PAUSED state so the
+                # scheduler resumes stepping now that weights are live and KV is re-allocated.
+                ray.get([engine.continue_generation.remote() for engine in self._colocated_engines])
             if self._distributed_engines:
                 ray.get([engine.continue_generation.remote() for engine in self._distributed_engines])
         dist.barrier(group=get_gloo_group())


### PR DESCRIPTION
## Problem

The **colocate** weight-sync path frees + IPC-injects weights without halting the
vLLM engine step loop first. An in-flight model/sampling step can overlap the
`release_memory_occupation(level=0)` (`flush_cache()` + `POST /sleep?level=0`) and
the weight-chunk injection; its device→host sync
(`gpu_model_runner.get_output` / `_bookkeeping_sync._to_list`) then **hangs
forever** because the weight/KV memory is mutated underneath it.

Intermittent (race on whether a step is in-flight at release time). Reproduced on
the 30B-A3B `dp2 x tp2 x ep4` colocate config (GB200): the `Update weights: N/114`
bar freezes mid-transfer, GPU pegged at 100% spin, no IMA, no exit — captured via
py-spy in both async-on and `--no-vllm-async-scheduling` modes (same root, the
async flag only changes *which* sync path blocks).

## Why only colocate

Every other vLLM-backend RL framework quiesces the engine before mutating weights:
- **verl** — `wait_for_requests_to_drain()` before `engine.sleep()`
- **SkyRL** — `sleep()` only after `await generate()` returns; `has_unfinished_requests()`→abort backstop
- **prime-rl** — `/pause(mode=keep)` blocks until EngineCore drains to idle before `/update_weights`
- **ROLL** — `pause_sampling → abort_all → wait_complete()` before sleep

vime's own **distributed** branch already calls `pause_generation()` /
`continue_generation()`. Only the **colocate** branch skipped it. slime pauses
every engine on the tensor weight-sync path.

## Fix

Make the colocate branch symmetric (2 lines):
- **step 1**: `pause_generation()` — `POST /pause mode="keep"` → scheduler
  `PAUSED_ALL` (token_budget=0, no new step) and the call blocks until the engine
  is idle — **before** `release_memory_occupation(level=0)`.
- **step 6**: `continue_generation()` — `POST /resume` — **after**
  `resume_memory_occupation`.

`pause_generation` / `continue_generation` already existed in `vllm_engine.py`
(used by the distributed branch); this just wires them into the colocate branch.

## Scope / safety
- Colocate path only. PD (separate prefill/decode engines) unaffected.
- Orthogonal to #44483 (the partial-wake `execute_dummy_batch` IMA): that guards a
  *dummy* forward against freed KV; this guards a *real* in-flight step's sync.
  Both are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)