### PR TITLE
[Refactor] Align UpdateWeightFromTensor structure with slime (colocate weight sync)

### DIFF
--- a/tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py
+++ b/tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py
@@ -32,6 +32,7 @@ def _install_stubs():
 
     ray_mod = types.ModuleType("ray")
     ray_mod.get = lambda refs: refs
+    ray_mod.ObjectRef = object
     ray_mod.actor = types.ModuleType("ray.actor")
     ray_mod.actor.ActorHandle = object
     sys.modules.setdefault("ray", ray_mod)
@@ -41,7 +42,7 @@ def _install_stubs():
 
     dist_stub = MagicMock()
     dist_stub.get_rank.return_value = 0
-    dist_stub.get_world_size.return_value = 8
+    dist_stub.get_world_size.return_value = 1
     dist_stub.get_process_group_ranks.return_value = [0, 1]
     dist_stub.barrier = MagicMock()
     dist_stub.all_gather_object = MagicMock()
@@ -135,13 +136,12 @@ def _make_instance(upw_vllm, args=None):
     obj.quantization_config = None
     obj.weight_version = 0
     obj._hf_weight_iterator = _HF_ITER_STUB
-    obj._colocated_engines = []
+    obj.rollout_engines = []
+    obj.distributed_rollout_engines = []
+    obj.use_distribute = False
     obj._ipc_engine = None
-    obj._ipc_engine_coordinator = False
-    obj._ipc_engine_slot_start = None
-    obj._ipc_engine_slot_end = None
-    obj._ipc_slot_group = None
-    obj._distributed_engines = []
+    obj._ipc_gather_group = None
+    obj._ipc_gather_src = None
     obj._model_update_groups = None
     obj._is_distributed_src_rank = False
     obj._group_name = "vime"
@@ -149,78 +149,83 @@ def _make_instance(upw_vllm, args=None):
     return obj
 
 
+def _bind_single_slot(obj, engine, *, src=0):
+    """Bind ``obj`` to one colocated engine forming a slot whose leader rank is ``src``."""
+    obj.rollout_engines = [engine]
+    obj._ipc_engine = engine
+    obj._ipc_gather_group = "slot_group"
+    obj._ipc_gather_src = src
+
+
 def _chunks(n=1):
     return [[(f"p.{i}", torch.zeros(2, 2)) for i in range(2)] for _ in range(n)]
 
 
-def _run_update(obj, *, chunks=None, ipc_engine_cls=None, ipc_args_cls=None) -> int:
+def _run_update(obj, *, chunks=None, rank=0, slot_size=1) -> dict:
+    """Drive ``update_weights`` with controlled rank / slot size.
+
+    ``slot_size`` is what ``dist.get_world_size(self._ipc_gather_group)`` returns,
+    so slot_size==1 takes the direct IPC path and slot_size>1 the gather path.
+    Returns counters for barriers and ipc_collect calls.
+    """
     chunks = chunks or _chunks(1)
     obj._hf_weight_iterator = MagicMock()
     obj._hf_weight_iterator.get_hf_weight_chunks.return_value = iter(chunks)
 
-    ipc_engine_cls = ipc_engine_cls or MagicMock()
-    ipc_args_cls = ipc_args_cls or MagicMock(side_effect=lambda **kw: kw)
-
-    ipc_mod = types.SimpleNamespace(
-        IPCWeightTransferEngine=ipc_engine_cls,
-        IPCTrainerSendWeightsArgs=ipc_args_cls,
-    )
-    barrier_calls = {"n": 0}
+    counters = {"barrier": 0, "ipc_collect": 0}
 
     def counting_barrier(*args, **kwargs):
-        barrier_calls["n"] += 1
+        counters["barrier"] += 1
 
-    with patch.dict("sys.modules", {"vllm.distributed.weight_transfer.ipc_engine": ipc_mod}):
-        with patch("torch.distributed.get_rank", return_value=0), patch(
-            "torch.distributed.barrier", side_effect=counting_barrier
-        ):
-            obj.update_weights()
-    return barrier_calls["n"]
+    def counting_ipc_collect(*args, **kwargs):
+        counters["ipc_collect"] += 1
+
+    with patch("torch.distributed.get_rank", return_value=rank), patch(
+        "torch.distributed.get_world_size", return_value=slot_size
+    ), patch("torch.distributed.barrier", side_effect=counting_barrier), patch(
+        "torch.cuda.ipc_collect", side_effect=counting_ipc_collect
+    ):
+        obj.update_weights()
+    return counters
 
 
 @pytest.mark.unit
 def test_colocated_lifecycle_uses_pause_flush_and_weight_transfer_apis(upw_vllm):
     obj = _make_instance(upw_vllm)
     engine = RecordingVLLMEngine()
-    obj._colocated_engines = [engine]
-    obj._ipc_engine = engine
-    obj._ipc_engine_coordinator = True
-    obj._ipc_engine_slot_start = 0
-    obj._ipc_engine_slot_end = 1
+    _bind_single_slot(obj, engine, src=0)
 
-    barrier_count = _run_update(obj, chunks=_chunks(2))
+    dummy_info = {"names": ["w"], "dtype_names": ["bfloat16"], "shapes": [[2, 2]], "ipc_handles": [{"u": ("f", ())}]}
+    with patch(f"{MODULE_PATH}._build_ipc_update_info_from_named_tensors", return_value=(dummy_info, [])):
+        counters = _run_update(obj, chunks=_chunks(2))
 
-    # Colocate quiesce mirrors slime / the distributed branch: pause_generation +
-    # flush_cache, with no /sleep round-trip. (level=0 freed no GPU memory and the
-    # paired resume only warned "Executor is not sleeping"; continue_generation
-    # already handles resume.)
+    # Colocate quiesce: pause_generation + flush_cache only, no /sleep round-trip;
+    # continue_generation resumes. No release/resume_memory_occupation.
     assert len(engine.pause_generation.calls) == 1
     assert len(engine.flush_cache.calls) == 1
     assert len(engine.release_memory_occupation.calls) == 0
-    assert len(engine.init_weight_transfer_engine.calls) == 1
-    assert engine.init_weight_transfer_engine.calls[0].args[0] == {"init_info": {}}
+    assert len(engine.resume_memory_occupation.calls) == 0
+    # vLLM #39212: init runs in connect_rollout_engines, not update_weights.
+    assert len(engine.init_weight_transfer_engine.calls) == 0
     assert len(engine.start_weight_update.calls) == 1
     assert engine.start_weight_update.calls[0].kwargs.get("is_checkpoint_format") is True
     assert len(engine.finish_weight_update.calls) == 1
     assert len(engine.continue_generation.calls) == 1
-    assert len(engine.resume_memory_occupation.calls) == 0
-    # lifecycle barriers + one per HF chunk
-    assert barrier_count >= 2 + 2
+    # ipc_collect: one per HF chunk + one after the loop.
+    assert counters["ipc_collect"] == 2 + 1
+    # lifecycle barriers (no per-chunk barrier).
+    assert counters["barrier"] >= 4
 
 
 @pytest.mark.unit
 def test_send_via_ipc_dispatches_update_weights_from_tensor_with_version(upw_vllm):
     """slot_size=1: every HF chunk fires
-    ``engine.update_weights_from_tensor.remote(**fields, weight_version=...)``.
-    Mirrors vime's IPC RPC contract — same name, parameterized fields,
-    version travels with data (no piggyback onto ``finish_weight_update``)."""
+    ``engine.update_weights_from_tensor.remote(**fields, weight_version=...)`` —
+    same name, parameterized fields, version travels with data (no piggyback onto
+    ``finish_weight_update``)."""
     obj = _make_instance(upw_vllm)
     engine = RecordingVLLMEngine()
-    obj._colocated_engines = [engine]
-    obj._ipc_engine = engine
-    obj._ipc_engine_coordinator = True
-    obj._ipc_engine_slot_start = 0
-    obj._ipc_engine_slot_end = 1
+    _bind_single_slot(obj, engine, src=0)
 
     dummy_info = {"names": ["w"], "dtype_names": ["bfloat16"], "shapes": [[2, 2]], "ipc_handles": [{"u": ("f", ())}]}
     with patch(
@@ -246,15 +251,11 @@ def test_send_via_ipc_dispatches_update_weights_from_tensor_with_version(upw_vll
 
 @pytest.mark.unit
 def test_send_via_ipc_dispatches_update_weights_from_tensor_coordinator_multi_gpu(upw_vllm):
-    """slot_size > 1: coordinator gathers payloads from all slot ranks, merges them,
-    and fires a single engine.update_weights_from_tensor.remote() RPC per chunk."""
+    """slot_size > 1: the slot leader (rank == _ipc_gather_src) gathers payloads from
+    all slot ranks, merges them, and fires a single update_weights_from_tensor RPC per chunk."""
     obj = _make_instance(upw_vllm)
     engine = RecordingVLLMEngine()
-    obj._colocated_engines = [engine]
-    obj._ipc_engine = engine
-    obj._ipc_engine_coordinator = True
-    obj._ipc_engine_slot_start = 0
-    obj._ipc_engine_slot_end = 2
+    _bind_single_slot(obj, engine, src=0)
 
     dummy_info_0 = {
         "names": ["w"],
@@ -273,19 +274,15 @@ def test_send_via_ipc_dispatches_update_weights_from_tensor_coordinator_multi_gp
         gathered_payloads[0] = "payload0"
         gathered_payloads[1] = "payload1"
 
-    with patch("torch.distributed.get_rank", return_value=0), patch(
-        "megatron.core.mpu.get_tensor_model_parallel_rank", return_value=0
-    ), patch(
+    with patch(
         f"{MODULE_PATH}._build_ipc_update_info_from_named_tensors",
         return_value=(dummy_info_0, []),
     ), patch(
         f"{MODULE_PATH}._serialize_ipc_update_info", return_value="payload0"
-    ), patch(
-        f"{MODULE_PATH}._deserialize_ipc_update_info", side_effect=[dummy_info_0, dummy_info_1] * 2
-    ), patch(
+    ), patch(f"{MODULE_PATH}._deserialize_ipc_update_info", side_effect=[dummy_info_0, dummy_info_1] * 2), patch(
         "torch.distributed.all_gather_object", side_effect=fake_all_gather_object
     ):
-        _run_update(obj, chunks=_chunks(2))
+        _run_update(obj, chunks=_chunks(2), rank=0, slot_size=2)
 
     assert len(engine.update_weights_from_tensor.calls) == 2
     kwargs = engine.update_weights_from_tensor.calls[0].kwargs
@@ -316,21 +313,22 @@ def test_merge_ipc_update_infos_combines_gpu_uuids(upw_vllm):
 
 
 @pytest.mark.unit
-def test_connect_marks_one_coordinator_per_engine_gpu_slot(upw_vllm):
-    """Only the first trainer rank in each engine GPU range may call start/finish."""
+def test_connect_binds_engine_and_slot_leader_per_gpu_slot(upw_vllm):
+    """Each rank binds to its slot's engine; the slot leader (== _ipc_gather_src,
+    the lowest trainer rank in the engine GPU range) is the start/finish coordinator."""
     engines = [RecordingVLLMEngine() for _ in range(4)]
-    for rank, is_coordinator, engine_idx, tp_rank in [
-        (0, True, 0, 0),
-        (1, False, 0, 1),
-        (2, True, 1, 0),
-        (3, False, 1, 1),
+    for rank, engine_idx, expected_src in [
+        (0, 0, 0),
+        (1, 0, 0),
+        (2, 1, 2),
+        (3, 1, 2),
     ]:
         obj = _make_instance(
             upw_vllm,
             args=_default_args(actor_num_gpus_per_node=8, rollout_num_gpus_per_engine=2),
         )
         with patch("torch.distributed.get_rank", return_value=rank), patch(
-            "megatron.core.mpu.get_tensor_model_parallel_rank", return_value=tp_rank
+            "megatron.core.mpu.get_tensor_model_parallel_rank", return_value=rank % 2
         ), patch("torch.distributed.new_group", return_value="slot_group"):
             obj.connect_rollout_engines(
                 engines,
@@ -339,51 +337,72 @@ def test_connect_marks_one_coordinator_per_engine_gpu_slot(upw_vllm):
                 engine_gpu_offsets=[0, 2, 4, 6],
             )
         assert obj._ipc_engine is engines[engine_idx]
-        assert obj._ipc_engine_coordinator is is_coordinator
+        assert obj._ipc_gather_src == expected_src
+        is_coordinator = rank == obj._ipc_gather_src
+        assert is_coordinator is (rank in (0, 2))
+        assert obj.use_distribute is False
+        assert obj.distributed_rollout_engines == []
+        # vLLM #39212: init_weight_transfer_engine fires once during connect (rank 0 only).
+        if rank == 0:
+            assert len(engines[0].init_weight_transfer_engine.calls) == 1
+            assert engines[0].init_weight_transfer_engine.calls[0].args[0] == {"init_info": {}}
 
 
 @pytest.mark.unit
-def test_non_coordinator_skips_start_finish(upw_vllm):
+def test_non_leader_skips_start_finish_and_merged_rpc(upw_vllm):
     obj = _make_instance(upw_vllm)
     engine = RecordingVLLMEngine()
-    obj._colocated_engines = [engine]
-    obj._ipc_engine = engine
-    obj._ipc_engine_coordinator = False
-    obj._ipc_engine_slot_start = 0
-    obj._ipc_engine_slot_end = 2
+    # slot leader is rank 0; we drive update_weights as rank 1 (non-leader).
+    _bind_single_slot(obj, engine, src=0)
 
     dummy_info = {"names": [], "dtype_names": [], "shapes": [], "ipc_handles": []}
-
-    with patch("torch.distributed.get_rank", return_value=1), patch(
-        "megatron.core.mpu.get_tensor_model_parallel_rank", return_value=1
-    ), patch(
+    with patch(
         f"{MODULE_PATH}._build_ipc_update_info_from_named_tensors",
         return_value=(dummy_info, []),
     ), patch(
         f"{MODULE_PATH}._serialize_ipc_update_info", return_value="payload"
-    ), patch(
-        "torch.distributed.all_gather_object"
-    ) as all_gather_obj:
-        _run_update(obj, chunks=_chunks(1))
+    ), patch("torch.distributed.all_gather_object") as all_gather_obj:
+        _run_update(obj, chunks=_chunks(1), rank=1, slot_size=2)
 
     all_gather_obj.assert_called_once()
-
+    # non-leader: no start/finish, and no merged update_weights_from_tensor RPC
     assert len(engine.start_weight_update.calls) == 0
     assert len(engine.finish_weight_update.calls) == 0
+    assert len(engine.update_weights_from_tensor.calls) == 0
 
 
 @pytest.mark.unit
-def test_ipc_init_runs_once(upw_vllm):
-    obj = _make_instance(upw_vllm)
-    engine = RecordingVLLMEngine()
-    obj._colocated_engines = [engine]
-    obj._ipc_engine = engine
-    obj._ipc_engine_coordinator = True
-    obj._ipc_engine_slot_start = 0
-    obj._ipc_engine_slot_end = 1
-
-    _run_update(obj)
-    _run_update(obj)
-
-    assert len(engine.init_weight_transfer_engine.calls) == 1
+def test_ipc_init_runs_once_in_connect(upw_vllm):
+    """init_weight_transfer_engine fires once in connect_rollout_engines (rank 0),
+    not in update_weights. A second connect call does not re-init."""
+    engines = [RecordingVLLMEngine() for _ in range(2)]
+    obj = _make_instance(
+        upw_vllm,
+        args=_default_args(actor_num_gpus_per_node=4, rollout_num_gpus_per_engine=2),
+    )
+    with patch("torch.distributed.get_rank", return_value=0), patch(
+        "megatron.core.mpu.get_tensor_model_parallel_rank", return_value=0
+    ), patch("torch.distributed.new_group", return_value="slot_group"):
+        obj.connect_rollout_engines(
+            engines,
+            rollout_engine_lock=MagicMock(),
+            engine_gpu_counts=[2, 2],
+            engine_gpu_offsets=[0, 2],
+        )
     assert obj._ipc_initialized is True
+    assert len(engines[0].init_weight_transfer_engine.calls) == 1
+    assert len(engines[1].init_weight_transfer_engine.calls) == 1
+
+    # Second connect with _ipc_initialized=True does not re-init.
+    engines2 = [RecordingVLLMEngine() for _ in range(2)]
+    with patch("torch.distributed.get_rank", return_value=0), patch(
+        "megatron.core.mpu.get_tensor_model_parallel_rank", return_value=0
+    ), patch("torch.distributed.new_group", return_value="slot_group"):
+        obj.connect_rollout_engines(
+            engines2,
+            rollout_engine_lock=MagicMock(),
+            engine_gpu_counts=[2, 2],
+            engine_gpu_offsets=[0, 2],
+        )
+    assert len(engines2[0].init_weight_transfer_engine.calls) == 0
+    assert len(engines2[1].init_weight_transfer_engine.calls) == 0

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -15,11 +15,13 @@ from __future__ import annotations
 import os
 from argparse import Namespace
 from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import Any
 
 import ray
 import torch
 import torch.distributed as dist
 from megatron.core import mpu
+from ray import ObjectRef
 from ray.actor import ActorHandle
 
 from vime.utils.distributed_utils import get_gloo_group
@@ -123,24 +125,11 @@ def _merge_ipc_update_infos(infos: Sequence[dict[str, list]]) -> dict[str, list]
 
 
 class UpdateWeightFromTensor:
-    """Update colocated vLLM engines via CUDA IPC, with NCCL fallback for
-    non-colocated overflow engines. See the module docstring for the
-    high-level design (why we dispatch via ``update_weights_from_tensor``
-    directly instead of vLLM's ``trainer_send_weights``).
-
-    Engine lifecycle per ``update_weights`` call::
-
-        colocated:   pause_generation / flush_cache      (rank 0)
-        distributed: pause_generation / flush_cache      (rank 0)
-        init_weight_transfer_engine                      (rank 0, colocated, first call only)
-        start_weight_update                              (coordinator rank per engine only)
-        [for each HF chunk]
-          update_weights_from_tensor                     (per-rank or coordinator-merged)
-          update_weights_from_distributed                (src rank, distributed)
-          barrier                                        (all ranks)
-        finish_weight_update                             (coordinator rank per engine only)
-        colocated:   continue_generation                 (rank 0)
-        distributed: continue_generation                 (rank 0)
+    """
+    Update rollout engines from tensor dict:
+    gather TP(GPU NCCL) → convert HF(GPU) → send.
+    Colocated: build CUDA IPC handles → all_gather_object(Gloo CPU, over the engine
+    slot ranks) → Ray IPC to engine.  Distributed: GPU NCCL broadcast to remote engines.
     """
 
     def __init__(
@@ -152,37 +141,28 @@ class UpdateWeightFromTensor:
         model_name: str,
         quantization_config: dict[str, int | str | list[str]] | None,
     ) -> None:
+        """
+        Compute param buckets.  IPC Gloo groups are created later in
+        ``connect_rollout_engines`` once ``engine_gpu_counts`` is known.
+        """
         self.args = args
         self.model = model
         self.weights_getter = weights_getter
         self.model_name = model_name
         self.quantization_config = quantization_config
         self.weight_version = 0
+        self.update_weight_metrics: dict[str, float] = {}
 
         self._hf_weight_iterator = HfWeightIteratorBase.create(
-            args=args,
-            model=model,
-            model_name=model_name,
-            quantization_config=quantization_config,
+            args=args, model=model, model_name=model_name, quantization_config=quantization_config
         )
 
-        # Populated by connect_rollout_engines
-        self._colocated_engines: list[ActorHandle] = []
-        # vLLM 0.21 IPC (mode=ray): one Ray actor per GPU slot; this rank's engine.
-        self._ipc_engine: ActorHandle | None = None
-        # First trainer rank in each engine GPU range issues start/finish (TP ranks share one engine).
-        self._ipc_engine_coordinator: bool = False
-        self._ipc_engine_slot_start: int | None = None
-        self._ipc_engine_slot_end: int | None = None
-        self._distributed_engines: list[ActorHandle] = []
+        self._ipc_gather_group = None
+        self._ipc_gather_src = None
+        self._ipc_engine = None
         self._model_update_groups = None
-        self._is_distributed_src_rank: bool = False
-        self._group_name = "vime"
-        # IPC weight transfer engine is initialized once per set of colocated
-        # engines (not per update call).
-        self._ipc_initialized: bool = False
-        # Per-engine-slot process group for IPC payload gather (created in connect_rollout_engines).
-        self._ipc_slot_group = None
+        # vLLM #39212 IPC transfer-engine init runs once per set of colocated engines.
+        self._ipc_initialized = False
         # vLLM IPC handle payloads may use cloudpickle on the Ray/HTTP bridge.
         os.environ.setdefault("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
 
@@ -198,23 +178,22 @@ class UpdateWeightFromTensor:
         engine_gpu_offsets: Sequence[int] | None = None,
     ) -> None:
         """
-        Split engines into colocated (IPC) vs distributed (NCCL) buckets.
-
-        Colocated engines are those whose GPU range fits entirely within the
-        trainer actor GPU range.  The remainder are treated as distributed and
-        receive weights via NCCL broadcast.
+        Split colocated/distributed engines. Global source rank (DP=TP=PP=0) creates NCCL
+        for distributed. Map ranks to colocated IPC engines.
         """
-        self.rollout_engine_lock = rollout_engine_lock
+        self.rollout_engines = rollout_engines
 
         if engine_gpu_counts is None:
             engine_gpu_counts = [self.args.rollout_num_gpus_per_engine] * len(rollout_engines)
         if engine_gpu_offsets is None:
+            # Fallback: assume engines are densely packed (no placeholder gaps).
             engine_gpu_offsets = []
             offset = 0
             for c in engine_gpu_counts:
                 engine_gpu_offsets.append(offset)
                 offset += c
 
+        # Compute colocated engine count: engines whose GPUs fall within actor GPU range.
         total_actor_gpus = self.args.actor_num_nodes * self.args.actor_num_gpus_per_node
         colocate_engine_nums = 0
         for gpu_offset, gpu_count in zip(engine_gpu_offsets, engine_gpu_counts, strict=True):
@@ -222,67 +201,62 @@ class UpdateWeightFromTensor:
                 break
             colocate_engine_nums += 1
 
-        self._colocated_engines = list(rollout_engines[:colocate_engine_nums])
-        self._distributed_engines = list(rollout_engines[colocate_engine_nums:])
+        self.use_distribute = len(rollout_engines) > colocate_engine_nums
 
-        # Map this trainer rank to the colocated vLLM engine on the same GPU slot.
-        # vLLM 0.21 ``trainer_send_weights(mode="ray")`` expects a single ``llm_handle``,
-        # not a list (list fan-out is only in newer vLLM with ``send_mode="ray"``).
-        self._ipc_engine = None
-        self._ipc_engine_coordinator = False
-        self._ipc_engine_slot_start = None
-        self._ipc_engine_slot_end = None
-        # Build per-slot process groups so IPC payload gather covers all ranks in the
-        # engine's GPU slot — Megatron TP group does NOT cover the slot when Megatron
-        # TP != rollout-num-gpus-per-engine (e.g. Megatron TP=1 + rollout TP=2 in
-        # parallel-check). Every trainer rank must enter dist.new_group collectively.
-        self._ipc_slot_group = None
-        rank_for_slot = dist.get_rank()
-        colocate_gpu_offsets = engine_gpu_offsets[:colocate_engine_nums]
-        colocate_gpu_counts = engine_gpu_counts[:colocate_engine_nums]
-        # First pass: create per-slot process groups collectively (every rank must call new_group).
-        for i in range(colocate_engine_nums):
-            slot_start = colocate_gpu_offsets[i]
-            slot_end = slot_start + colocate_gpu_counts[i]
-            slot_ranks = list(range(slot_start, slot_end))
-            grp = dist.new_group(ranks=slot_ranks, backend="gloo")
-            if slot_start <= rank_for_slot < slot_end:
-                self._ipc_slot_group = grp
-        # Second pass: bind this rank to its engine + decide coordinator.
-        for i, engine in enumerate(self._colocated_engines):
-            start = colocate_gpu_offsets[i]
-            end = start + colocate_gpu_counts[i]
-            rank = dist.get_rank()
-            if start <= rank < end:
-                self._ipc_engine = engine
-                self._ipc_engine_slot_start = start
-                self._ipc_engine_slot_end = end
-                # Slot leader (lowest trainer rank in the engine GPU range) issues start/finish.
-                if rank == start:
-                    self._ipc_engine_coordinator = True
-
-        # Set up NCCL bridge for any overflow (non-colocated) engines.
-        if self._distributed_engines:
+        if self.use_distribute:
+            self.rollout_engines = rollout_engines[:colocate_engine_nums]
+            self.distributed_rollout_engines = rollout_engines[colocate_engine_nums:]
             distributed_gpu_counts = engine_gpu_counts[colocate_engine_nums:]
             self._is_distributed_src_rank = (
                 mpu.get_data_parallel_rank(with_context_parallel=True) == 0
                 and mpu.get_tensor_model_parallel_rank() == 0
                 and mpu.get_pipeline_model_parallel_rank() == 0
             )
+            self._group_name = "vime"
             if self._is_distributed_src_rank:
                 if self._model_update_groups is not None:
                     disconnect_rollout_engines_from_distributed(
-                        self.args,
-                        self._group_name,
-                        self._model_update_groups,
-                        self._distributed_engines,
+                        self.args, self._group_name, self._model_update_groups, self.distributed_rollout_engines
                     )
                 self._model_update_groups = connect_rollout_engines_from_distributed(
                     self.args,
                     self._group_name,
-                    self._distributed_engines,
+                    self.distributed_rollout_engines,
                     engine_gpu_counts=distributed_gpu_counts,
                 )
+
+        colocate_gpu_offsets = engine_gpu_offsets[:colocate_engine_nums]
+        colocate_gpu_counts = engine_gpu_counts[:colocate_engine_nums]
+
+        # Create IPC Gloo gather groups (only on first call; partitioning is
+        # fixed across reconnects).
+        if self._ipc_gather_group is None:
+            for i in range(colocate_engine_nums):
+                group_ranks = list(range(colocate_gpu_offsets[i], colocate_gpu_offsets[i] + colocate_gpu_counts[i]))
+                new_group = dist.new_group(ranks=group_ranks, backend="gloo")
+                if dist.get_rank() in group_ranks:
+                    self._ipc_gather_group = new_group
+                    self._ipc_gather_src = colocate_gpu_offsets[i]
+
+        # Map training ranks to colocated engine actors.
+        for i, engine in enumerate(self.rollout_engines):
+            start = colocate_gpu_offsets[i]
+            end = start + colocate_gpu_counts[i]
+            if start <= dist.get_rank() < end:
+                self._ipc_engine = engine
+
+        # vLLM #39212: one-time IPC transfer-engine init on each colocated engine.
+        if dist.get_rank() == 0 and self.rollout_engines and not self._ipc_initialized:
+            ray.get([engine.init_weight_transfer_engine.remote({"init_info": {}}) for engine in self.rollout_engines])
+            self._ipc_initialized = True
+
+    def pop_metrics(self) -> dict[str, float]:
+        """
+        Return and clear ``update_weight_metrics``. Empty under colocate today;
+        kept symmetric with UpdateWeightFromDistributed so the actor can drain unconditionally.
+        """
+        out, self.update_weight_metrics = self.update_weight_metrics, {}
+        return out
 
     # ------------------------------------------------------------------
     # weight update
@@ -291,140 +265,122 @@ class UpdateWeightFromTensor:
     @torch.no_grad()
     def update_weights(self) -> None:
         """
-        Transfer updated Megatron weights to all rollout engines.
-
-        Colocated engines receive weights via CUDA IPC (per-rank engine RPC).
-        Distributed overflow engines receive weights via NCCL broadcast (source rank only).
+        version++, flush caches, process buckets. Progress on rank 0.
         """
         self.weight_version += 1
-        rank = dist.get_rank()
-        all_engines = self._colocated_engines + self._distributed_engines
 
-        # ── 1. Pause generation and flush KV cache (rank 0 only) ────────────
+        rank = dist.get_rank()
         if rank == 0:
-            if self._colocated_engines:
-                ray.get([engine.pause_generation.remote() for engine in self._colocated_engines])
-                ray.get([engine.flush_cache.remote() for engine in self._colocated_engines])
-            if self._distributed_engines:
-                ray.get([engine.pause_generation.remote() for engine in self._distributed_engines])
-                ray.get([engine.flush_cache.remote() for engine in self._distributed_engines])
-            if self.quantization_config and self.quantization_config.get("quant_method") in ["compressed-tensors"]:
+            ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
+            ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
+            if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
                 post_process_weights(
                     restore_weights_before_load=True,
                     post_process_quantization=False,
-                    rollout_engines=all_engines,
+                    rollout_engines=self.rollout_engines,
                 )
         dist.barrier(group=get_gloo_group())
 
-        # ── 2. One-time IPC weight transfer engine init (rank 0 only) ───────
-        if rank == 0 and self._colocated_engines and not self._ipc_initialized:
-            ray.get(
-                [engine.init_weight_transfer_engine.remote({"init_info": {}}) for engine in self._colocated_engines]
-            )
-            self._ipc_initialized = True
-        dist.barrier(group=get_gloo_group())
-
-        # ── 3. Enter weight-update mode (vLLM #39212: /start_weight_update) ───
-        if self._ipc_engine_coordinator:
+        # vLLM #39212: enter weight-update mode on each slot leader.
+        if self._ipc_engine is not None and rank == self._ipc_gather_src:
             ray.get(self._ipc_engine.start_weight_update.remote(is_checkpoint_format=True))
         dist.barrier(group=get_gloo_group())
 
-        # ── 4. Iterate HF weight chunks and send ─────────────────────────────
         megatron_local_weights = self.weights_getter()
+
         for hf_named_tensors in self._hf_weight_iterator.get_hf_weight_chunks(megatron_local_weights):
-            if self._ipc_engine is not None:
-                self._send_hf_chunk_via_ipc(hf_named_tensors)
+            refs, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+            ray.get(refs)
+            # Free GPU tensors so the caching allocator can reuse the blocks,
+            # then release CUDA IPC cache entries whose consumers (vLLM engines)
+            # have already closed their IPC handles.
+            del long_lived_tensors, hf_named_tensors
+            torch.cuda.ipc_collect()
 
-            if self._distributed_engines and self._is_distributed_src_rank:
-                refs = update_weights_from_distributed(
-                    self._group_name,
-                    self._model_update_groups,
-                    self.weight_version,
-                    self._distributed_engines,
-                    hf_named_tensors,
-                    packed=False,
-                )
-                if refs:
-                    ray.get(refs)
+        dist.barrier(group=get_gloo_group())
+        # After the barrier all engines have returned, so every rank's last-chunk
+        # IPC handles are now released by the consumers.  Clean them up.
+        torch.cuda.ipc_collect()
 
-            dist.barrier(group=get_gloo_group())
-
-        # ── 5. Signal colocated engines to exit weight-update mode ───────────
-        # State-machine bookend only; ``_weight_version`` is recorded inside
-        # ``update_weights_from_tensor`` (step 4) when the data RPC succeeds —
-        # matches vime's single-RPC version-with-data semantics.
-        if self._ipc_engine_coordinator:
+        # vLLM #39212: exit weight-update mode.
+        if self._ipc_engine is not None and rank == self._ipc_gather_src:
             ray.get(self._ipc_engine.finish_weight_update.remote())
         dist.barrier(group=get_gloo_group())
 
-        # ── 6. Post-process quantization (if needed) and resume ───────────────
+        # int4/fp4 post_process
         if rank == 0:
-            if self.quantization_config and self.quantization_config.get("quant_method") in ["compressed-tensors"]:
+            if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
                 post_process_weights(
                     restore_weights_before_load=False,
                     post_process_quantization=True,
-                    rollout_engines=all_engines,
+                    rollout_engines=self.rollout_engines,
                 )
-            if self._colocated_engines:
-                ray.get([engine.continue_generation.remote() for engine in self._colocated_engines])
-            if self._distributed_engines:
-                ray.get([engine.continue_generation.remote() for engine in self._distributed_engines])
+            ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
         dist.barrier(group=get_gloo_group())
 
-    def _send_hf_chunk_via_ipc(self, hf_named_tensors: Sequence[tuple[str, torch.Tensor]]) -> None:
-        """Send one HF chunk to the colocated vLLM engine via CUDA IPC (Ray → HTTP).
+    def _send_hf_params(self, hf_named_tensors) -> tuple[list[ObjectRef], Any]:
+        all_refs = []
 
-        ``slot_size == 1``: this rank ships its IPC payload directly.
-        ``slot_size > 1`` (vLLM TP): every rank in the slot builds its handle;
-        the coordinator gathers them, merges UUIDs, and issues one RPC for the
-        slot. Both paths dispatch the same RPC — ``update_weights_from_tensor`` —
-        with ``weight_version`` alongside the data (see module docstring).
-        """
-        assert self._ipc_engine is not None
-        assert self._ipc_engine_slot_start is not None
-        assert self._ipc_engine_slot_end is not None
+        refs_colocated, long_lived_tensors = _send_to_colocated_engine(
+            hf_named_tensors,
+            ipc_engine=self._ipc_engine,
+            ipc_gather_src=self._ipc_gather_src,
+            ipc_gather_group=self._ipc_gather_group,
+            weight_version=self.weight_version,
+        )
+        all_refs.extend(refs_colocated)
 
-        slot_size = self._ipc_engine_slot_end - self._ipc_engine_slot_start
-        if slot_size <= 1:
-            local_info, weight_refs = _build_ipc_update_info_from_named_tensors(hf_named_tensors)
-            ray.get(
-                self._ipc_engine.update_weights_from_tensor.remote(
-                    **local_info,
-                    weight_version=str(self.weight_version),
-                )
+        if self.use_distribute and self._is_distributed_src_rank:
+            refs_distributed = update_weights_from_distributed(
+                self._group_name,
+                self._model_update_groups,
+                self.weight_version,
+                self.distributed_rollout_engines,
+                hf_named_tensors,
+                packed=False,
             )
-            # Keep CUDA IPC producer tensors alive until ray.get() returns
-            # (the HTTP weight update completes inside the engine actor); then release.
-            del weight_refs
-            return
+            if refs_distributed:
+                all_refs.extend(refs_distributed)
 
+        return all_refs, long_lived_tensors
+
+
+def _send_to_colocated_engine(
+    hf_named_tensors: list[tuple[str, torch.Tensor]],
+    *,
+    ipc_engine,
+    ipc_gather_src,
+    ipc_gather_group,
+    weight_version,
+) -> tuple[list[ObjectRef], Any]:
+    # Placeholder ranks (GPU slots reserved but no engine) have no gather group.
+    # all_gather_object is only collective among group members, so we skip entirely.
+    if ipc_gather_group is None:
+        return [], None
+
+    slot_size = dist.get_world_size(ipc_gather_group)
+    if slot_size <= 1:
         local_info, weight_refs = _build_ipc_update_info_from_named_tensors(hf_named_tensors)
-        payload = _serialize_ipc_update_info(local_info)
+        ref = ipc_engine.update_weights_from_tensor.remote(**local_info, weight_version=str(weight_version))
+        return [ref], weight_refs
 
-        slot_group = self._ipc_slot_group
-        slot_ranks = list(range(self._ipc_engine_slot_start, self._ipc_engine_slot_end))
+    local_info, weight_refs = _build_ipc_update_info_from_named_tensors(hf_named_tensors)
+    payload = _serialize_ipc_update_info(local_info)
 
-        # Gather IPC payloads over the engine slot ranks (NOT Megatron TP group — see
-        # connect_rollout_engines for why). all_gather_object is monkey-patched for
-        # ReloadableProcessGroup; gather_object is not (fails after Megatron reload).
-        gathered_payloads: list[str | None] = [None] * slot_size
-        dist.all_gather_object(gathered_payloads, payload, group=slot_group)
-        if self._ipc_engine_coordinator:
-            if any(p is None for p in gathered_payloads):
-                raise RuntimeError(f"Missing IPC payloads on slot ranks {slot_ranks}; " f"got {gathered_payloads!r}")
-            slot_infos = [_deserialize_ipc_update_info(p) for p in gathered_payloads]
-            merged = _merge_ipc_update_infos(slot_infos)
-            ray.get(
-                self._ipc_engine.update_weights_from_tensor.remote(
-                    **merged,
-                    weight_version=str(self.weight_version),
-                )
-            )
+    # all_gather_object is monkey-patched for ReloadableProcessGroup; gather_object
+    # is not (it fails after a Megatron reload).
+    gathered_payloads = [None] * slot_size
+    dist.all_gather_object(gathered_payloads, payload, group=ipc_gather_group)
 
-        dist.barrier(group=slot_group)
-        # Keep CUDA IPC producer tensors alive until every TP worker has opened
-        # the handles and the coordinator's HTTP update has completed.
-        del weight_refs
+    refs = []
+    if dist.get_rank() == ipc_gather_src:
+        if any(p is None for p in gathered_payloads):
+            raise RuntimeError(f"Missing IPC payloads in slot {ipc_gather_src}; got {gathered_payloads!r}")
+        slot_infos = [_deserialize_ipc_update_info(p) for p in gathered_payloads]
+        merged = _merge_ipc_update_infos(slot_infos)
+        refs.append(ipc_engine.update_weights_from_tensor.remote(**merged, weight_version=str(weight_version)))
+
+    return refs, weight_refs
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Structural refactor of the colocate IPC weight-sync trainer (`UpdateWeightFromTensor`) to follow slime's layout line-for-line, with the vLLM-specific pieces isolated. Builds on #169. **−60 net lines.**

## Changes

**`connect_rollout_engines`**
- rename `_colocated_engines` → `rollout_engines`, `_distributed_engines` → `distributed_rollout_engines`; add the `use_distribute` flag
- collapse the `_ipc_engine_coordinator` / `_ipc_engine_slot_start` / `_ipc_engine_slot_end` / `_ipc_slot_group` quartet into `_ipc_gather_group` + `_ipc_gather_src` (slot leader == `rank == _ipc_gather_src`, `slot_size == get_world_size(group)`); guarded single-pass group creation
- drop the unused `rollout_engine_lock` store

**`update_weights`**
- pause / flush / continue act on `self.rollout_engines` only (the distributed pause/flush/continue is dropped — that path is dead under `args.colocate`, which is the only mode that selects this class; the distributed *send* stays, folded into `_send_hf_params`)
- add `torch.cuda.ipc_collect()` per chunk + after the loop (was missing — a likely producer-side IPC leak over many sync rounds)
- remove the per-chunk global barrier; restore the single after-loop barrier

**send path**
- `_send_hf_params` now returns `(refs, long_lived_tensors)`; `update_weights` does `ray.get(refs)` then `del long_lived_tensors`
- `_send_to_colocated_engine` returns `(refs, weight_refs)` with **no internal `ray.get` / per-slot barrier**. Synchronization is the `all_gather_object` collective deferral + the after-loop barrier, plus the receiver-side `torch.accelerator.synchronize()` already in the worker extension.

## Irreducible vLLM divergences (kept, encapsulated in `_send_to_colocated_engine`)
1. `reduce_tensor` UUID-keyed handles + `all_gather_object` + merge (vs slime's `FlattenedTensorBucket` + `gather_object`) — forced by the vLLM IPC format and the Megatron-reload monkey-patch (`gather_object` unsupported there).
2. vLLM #39212 `init` / `start` / `finish_weight_update` state machine (no sglang analog).

`pop_metrics` intentionally not added (unused anywhere in vime).

<img width="534" height="402" alt="image" src="https://github.com/user-attachments/assets/ee2132a0-7508-49e5-b021-c78066a1b971" />

<img width="554" height="400" alt="image" src="https://github.com/user-attachments/assets/a62503d0-9727-4cec-820f-59975f41322d" />
<img width="542" height="410" alt="image" src="https://github.com/user-attachments/assets/b3b68c1a-bb07-4763-a2a0-6b4aa566d26d" />
