### PR TITLE
Remove redundant vLLM sleep guards

### DIFF
--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -139,6 +139,29 @@ def test_build_vllm_subprocess_env_colocate(vllm_args, monkeypatch):
 
 
 @pytest.mark.unit
+def test_build_vllm_cmd_adds_sleep_mode_only_for_offload_rollout(vllm_args):
+    vllm_args.offload_rollout = True
+    server_args = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
+
+    cmd, _ = mod.build_vllm_cmd_and_env(server_args)
+
+    assert "--enable-sleep-mode" in cmd
+    assert vllm_args.vllm_enable_sleep_mode is True
+
+
+@pytest.mark.unit
+def test_build_vllm_cmd_does_not_infer_sleep_mode_from_colocate(vllm_args):
+    vllm_args.colocate = True
+    vllm_args.offload_rollout = False
+    server_args = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
+
+    cmd, _ = mod.build_vllm_cmd_and_env(server_args)
+
+    assert "--enable-sleep-mode" not in cmd
+    assert not getattr(vllm_args, "vllm_enable_sleep_mode", False)
+
+
+@pytest.mark.unit
 def test_get_base_gpu_id_colocate(vllm_args):
     vllm_args.colocate = True
     vllm_args.num_gpus_per_node = 8

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -183,11 +183,16 @@ def test_finish_weight_update_posts_empty_body(vllm_engine, monkeypatch):
 
 @pytest.mark.unit
 def test_update_weights_from_tensor_posts_ipc_payload_and_records_version(vllm_engine, monkeypatch):
-    posted: list[dict] = []
+    calls: list[tuple[str, dict, float]] = []
+
+    def fake_make_request(endpoint: str, payload: dict, timeout: float):
+        calls.append((endpoint, payload, timeout))
+        return {"ok": True}
+
     monkeypatch.setattr(
         vllm_engine,
-        "_post_vllm_update_weights_http",
-        lambda payload: (posted.append(payload), {"ok": True})[1],
+        "_make_request",
+        fake_make_request,
     )
     assert vllm_engine._weight_version is None
 
@@ -199,8 +204,12 @@ def test_update_weights_from_tensor_posts_ipc_payload_and_records_version(vllm_e
         weight_version="42",
     )
 
-    assert len(posted) == 1
-    sent = posted[0]
+    assert len(calls) == 1
+    endpoint, posted, timeout = calls[0]
+    assert endpoint == "collective_rpc"
+    assert timeout == vllm_engine._weight_transfer_http_timeout()
+    assert posted["method"] == "update_weights_chunk"
+    sent = posted["kwargs"]["update_info"]
     # ipc_handles got cloudpickle'd into ipc_handles_pickled
     assert "ipc_handles" not in sent
     assert isinstance(sent["ipc_handles_pickled"], str)
@@ -214,10 +223,10 @@ def test_update_weights_from_tensor_posts_ipc_payload_and_records_version(vllm_e
 def test_update_weights_from_tensor_does_not_advance_version_on_failure(vllm_engine, monkeypatch):
     """POST failure must not advance _weight_version (else a retry would skip the resync)."""
 
-    def fake_post_vllm_fail(payload: dict) -> dict:
+    def fake_make_request_fail(endpoint: str, payload: dict, timeout: float) -> dict:
         raise RuntimeError("simulated POST failure")
 
-    monkeypatch.setattr(vllm_engine, "_post_vllm_update_weights_http", fake_post_vllm_fail)
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_make_request_fail)
 
     vllm_engine._weight_version = "old"
     with pytest.raises(RuntimeError, match="simulated POST failure"):
@@ -441,9 +450,40 @@ def test_resume_memory_occupation_wake_tags_query(vllm_engine, monkeypatch):
 
 
 @pytest.mark.unit
-def test_resume_memory_occupation_skips_when_sleep_disabled(vllm_engine):
+def test_release_memory_occupation_flushes_then_posts_sleep(vllm_engine, monkeypatch):
+    calls: list[str] = []
+
+    def fake_flush_cache():
+        calls.append("flush_cache")
+
+    def fake_post(url, *, params=None, timeout=30, json=None):
+        calls.append(url)
+        assert params == {"level": 2}
+        assert timeout == 30
+        assert json is None
+        return _MockResponse(json_data={"ok": True, "sleep_mode": True})
+
     vllm_engine.args.vllm_enable_sleep_mode = False
-    assert vllm_engine.resume_memory_occupation() == {"ok": True, "sleep_mode": False}
+    monkeypatch.setattr(vllm_engine, "flush_cache", fake_flush_cache)
+    monkeypatch.setattr(mod.requests, "post", fake_post)
+
+    assert vllm_engine.release_memory_occupation(level=2) == {"ok": True, "sleep_mode": True}
+    assert calls == ["flush_cache", "http://127.0.0.1:8765/sleep"]
+
+
+@pytest.mark.unit
+def test_resume_memory_occupation_posts_wake_even_when_sleep_disabled(vllm_engine, monkeypatch):
+    seen: list[tuple] = []
+
+    def fake_post(url, *, params=None, timeout=30, json=None):
+        seen.append((url, params, timeout, json))
+        return _MockResponse(json_data={"ok": True, "sleep_mode": True})
+
+    vllm_engine.args.vllm_enable_sleep_mode = False
+    monkeypatch.setattr(mod.requests, "post", fake_post)
+
+    assert vllm_engine.resume_memory_occupation() == {"ok": True, "sleep_mode": True}
+    assert seen == [("http://127.0.0.1:8765/wake_up", None, 30, None)]
 
 
 @pytest.mark.unit

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -844,11 +844,10 @@ class VLLMEngine(RayActor):
         return self._weight_version
 
     def release_memory_occupation(self, level: int = 1):
+        """Flush prefix cache, then ``POST /sleep?level={level}``."""
         if self.node_rank != 0:
             return None
         self.flush_cache()
-        if not getattr(self.args, "vllm_enable_sleep_mode", False):
-            return {"ok": True, "sleep_mode": False, "note": "vLLM sleep mode disabled; no /sleep call."}
         response = requests.post(
             f"{self._http_base()}/sleep",
             params={"level": level},
@@ -857,11 +856,9 @@ class VLLMEngine(RayActor):
         return _response_json(response)
 
     def resume_memory_occupation(self, tags: list[str] | None = None):
-        """``POST /wake_up`` when sleep mode is on; else a no-op placeholder dict."""
+        """``POST /wake_up`` with vLLM-supported wake tags."""
         if self.node_rank != 0:
             return None
-        if not getattr(self.args, "vllm_enable_sleep_mode", False):
-            return {"ok": True, "sleep_mode": False}
         tags = _normalize_vllm_wake_tags(tags)
         wake_params: list[tuple[str, str]] | None = [("tags", t) for t in tags] if tags else None
         response = requests.post(

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -390,9 +390,7 @@ def build_vllm_cmd_and_env(server_args: dict[str, Any]) -> tuple[list[str], dict
     if getattr(args, "fp16", False):
         cmd += ["--dtype", "float16"]
 
-    if (getattr(args, "offload_rollout", False) or getattr(args, "colocate", False)) and not getattr(
-        args, "vllm_enable_sleep_mode", False
-    ):
+    if getattr(args, "offload_rollout", False) and not getattr(args, "vllm_enable_sleep_mode", False):
         cmd += ["--enable-sleep-mode"]
         args.vllm_enable_sleep_mode = True
 


### PR DESCRIPTION
## Summary
- Remove the redundant `vllm_enable_sleep_mode` early-return guards from vLLM control-plane release/resume methods.
- Keep headless worker no-op behavior and preserve launch-time auto-enable of sleep mode.
- Update unit tests to assert `/sleep` and `/wake_up` are still called even when `vllm_enable_sleep_mode` is false.

## Validation
- PYTHONPATH=. pytest tests/unit/backends/vllm_utils/test_vllm_engine.py -q
- PYTHONPATH=. pytest tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py -q