### PR TITLE
Refactor distributed weight sync to mirror slime

### DIFF
--- a/tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_distributed.py
+++ b/tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_distributed.py
@@ -4,15 +4,107 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import sys
+import types
 from dataclasses import dataclass, field
+from unittest.mock import MagicMock
 
 import pytest
 import torch
 
+MODULE_PATH = "vime.backends.megatron_utils.update_weight.update_weight_from_distributed"
+
 
 @pytest.fixture(scope="module")
 def upw():
-    return importlib.import_module("vime.backends.megatron_utils.update_weight.update_weight_from_distributed")
+    previous = sys.modules.pop(MODULE_PATH, None)
+    try:
+        yield importlib.import_module(MODULE_PATH)
+    finally:
+        sys.modules.pop(MODULE_PATH, None)
+        if previous is not None:
+            sys.modules[MODULE_PATH] = previous
+
+
+def _install_stubs():
+    mpu_stub = MagicMock()
+    mpu_stub.get_data_parallel_rank.return_value = 0
+    mpu_stub.get_tensor_model_parallel_rank.return_value = 0
+    mpu_stub.get_tensor_model_parallel_world_size.return_value = 1
+    mpu_stub.get_pipeline_model_parallel_rank.return_value = 0
+    mpu_stub.get_expert_model_parallel_world_size.return_value = 1
+    mpu_stub.get_expert_model_parallel_group.return_value = "ep_group"
+
+    megatron_core = types.ModuleType("megatron.core")
+    megatron_core.__path__ = []
+    megatron_core.mpu = mpu_stub
+    parallel_state_mod = types.ModuleType("megatron.core.parallel_state")
+    parallel_state_mod.get_tensor_model_parallel_rank = mpu_stub.get_tensor_model_parallel_rank
+    parallel_state_mod.get_tensor_model_parallel_world_size = mpu_stub.get_tensor_model_parallel_world_size
+    transformer_mod = types.ModuleType("megatron.core.transformer")
+    transformer_mod.__path__ = []
+    transformer_layer_mod = types.ModuleType("megatron.core.transformer.transformer_layer")
+    transformer_layer_mod.get_transformer_layer_offset = lambda *args, **kwargs: 0
+    transformer_mod.transformer_layer = transformer_layer_mod
+    megatron_core.parallel_state = parallel_state_mod
+    megatron_core.transformer = transformer_mod
+    megatron_mod = types.ModuleType("megatron")
+    megatron_mod.core = megatron_core
+    sys.modules.setdefault("megatron", megatron_mod)
+    sys.modules.setdefault("megatron.core", megatron_core)
+    sys.modules.setdefault("megatron.core.parallel_state", parallel_state_mod)
+    sys.modules.setdefault("megatron.core.transformer", transformer_mod)
+    sys.modules.setdefault("megatron.core.transformer.transformer_layer", transformer_layer_mod)
+
+    ray_mod = types.ModuleType("ray")
+    ray_mod.get = lambda refs: refs
+    ray_mod.ObjectRef = object
+    ray_mod.actor = types.ModuleType("ray.actor")
+    ray_mod.actor.ActorHandle = object
+    ray_mod._private = types.SimpleNamespace(
+        services=types.SimpleNamespace(get_node_ip_address=lambda: "127.0.0.1")
+    )
+    sys.modules.setdefault("ray", ray_mod)
+    sys.modules.setdefault("ray.actor", ray_mod.actor)
+
+    vime_utils = types.ModuleType("vime.utils.distributed_utils")
+    vime_utils.get_gloo_group = MagicMock(return_value="gloo")
+    sys.modules.setdefault("vime.utils.distributed_utils", vime_utils)
+
+    nccl_mod = types.ModuleType("vllm.distributed.weight_transfer.nccl_engine")
+
+    class DummyNCCLTrainerSendWeightsArgs:
+        def __init__(self, *, group, packed):
+            self.group = group
+            self.packed = packed
+
+    class DummyNCCLWeightTransferEngine:
+        @staticmethod
+        def trainer_send_weights(*args, **kwargs):
+            return None
+
+        @staticmethod
+        def trainer_init(*args, **kwargs):
+            return object()
+
+    nccl_mod.NCCLTrainerSendWeightsArgs = DummyNCCLTrainerSendWeightsArgs
+    nccl_mod.NCCLWeightTransferEngine = DummyNCCLWeightTransferEngine
+    vllm_mod = types.ModuleType("vllm")
+    vllm_mod.__path__ = []
+    distributed_mod = types.ModuleType("vllm.distributed")
+    distributed_mod.__path__ = []
+    weight_transfer_mod = types.ModuleType("vllm.distributed.weight_transfer")
+    weight_transfer_mod.__path__ = []
+    vllm_mod.distributed = distributed_mod
+    distributed_mod.weight_transfer = weight_transfer_mod
+    weight_transfer_mod.nccl_engine = nccl_mod
+    sys.modules.setdefault("vllm", vllm_mod)
+    sys.modules.setdefault("vllm.distributed", distributed_mod)
+    sys.modules.setdefault("vllm.distributed.weight_transfer", weight_transfer_mod)
+    sys.modules.setdefault("vllm.distributed.weight_transfer.nccl_engine", nccl_mod)
+
+
+_install_stubs()
 
 
 @dataclass
@@ -42,6 +134,12 @@ class RecordingEngine:
     )
     start_weight_update: RecordingRemoteMethod = field(default_factory=lambda: RecordingRemoteMethod("start_ref"))
     finish_weight_update: RecordingRemoteMethod = field(default_factory=lambda: RecordingRemoteMethod("finish_ref"))
+
+
+@dataclass
+class RecordingLock:
+    acquire: RecordingRemoteMethod = field(default_factory=lambda: RecordingRemoteMethod("acquired"))
+    release: RecordingRemoteMethod = field(default_factory=lambda: RecordingRemoteMethod("released"))
 
 
 @dataclass
@@ -93,6 +191,23 @@ def _patch_nccl_on_module(
 def _patch_trainer_send(monkeypatch, upw, seen: list[dict]) -> None:
     _patch_nccl_on_module(monkeypatch, upw, send_seen=seen)
     monkeypatch.setattr(upw.torch.cuda, "synchronize", lambda: None)
+
+
+def _make_instance(upw):
+    obj = object.__new__(upw.UpdateWeightFromDistributed)
+    obj.args = type("Args", (), {"update_weight_buffer_size": 1 << 30, "vllm_weight_sync_packed": True})()
+    obj.model = []
+    obj.weights_getter = lambda: {}
+    obj.model_name = "test"
+    obj.quantization_config = None
+    obj.weight_version = 0
+    obj._model_update_groups = DummyGroup()
+    obj._hf_weight_iterator = None
+    obj._is_pp_src_rank = True
+    obj._group_name = "g"
+    obj.rollout_engines = []
+    obj.rollout_engine_lock = RecordingLock()
+    return obj
 
 
 @pytest.mark.unit
@@ -272,6 +387,100 @@ def test_empty_tensor_list_still_dispatches(upw, monkeypatch):
 
 
 @pytest.mark.unit
+def test_raw_packed_path_sends_dense_chunks_only(upw, monkeypatch):
+    obj = _make_instance(upw)
+    obj._is_pp_src_rank = True
+    obj._group_name = "g"
+    obj._hf_weight_iterator = None
+    obj._use_vllm_packed = lambda: True
+    obj._iter_non_expert_chunks = lambda: iter(
+        [[("dense.0", torch.zeros(1))], [("dense.1", torch.zeros(1))]]
+    )
+    obj._iter_expert_chunks = lambda: (_ for _ in ()).throw(AssertionError("expert pass should be skipped"))
+
+    seen: list[tuple[list[str], bool, str]] = []
+    monkeypatch.setattr(
+        upw.UpdateWeightFromDistributed,
+        "_update_bucket_weights_from_distributed",
+        lambda self, converted_named_tensors, pbar=None, packed=False: seen.append(
+            ([name for name, _ in converted_named_tensors], packed, pbar)
+        ),
+    )
+    monkeypatch.setattr(upw.dist, "barrier", lambda *args, **kwargs: None)
+    monkeypatch.setattr(upw, "get_gloo_group", lambda: "gloo")
+
+    upw.UpdateWeightFromDistributed._send_weights(obj, pbar="pbar")
+
+    assert seen == [(["dense.0"], True, "pbar"), (["dense.1"], True, "pbar")]
+
+
+@pytest.mark.unit
+def test_raw_nonpacked_path_runs_dense_then_expert(upw, monkeypatch):
+    obj = _make_instance(upw)
+    obj._is_pp_src_rank = True
+    obj._group_name = "g"
+    obj._hf_weight_iterator = None
+    obj._use_vllm_packed = lambda: False
+    obj._iter_non_expert_chunks = lambda: iter(
+        [[("dense.0", torch.zeros(1))], [("dense.1", torch.zeros(1))]]
+    )
+    obj._iter_expert_chunks = lambda: iter([ [("expert.0", torch.zeros(1))] ])
+
+    seen: list[tuple[list[str], bool, str]] = []
+    monkeypatch.setattr(
+        upw.UpdateWeightFromDistributed,
+        "_update_bucket_weights_from_distributed",
+        lambda self, converted_named_tensors, pbar=None, packed=False: seen.append(
+            ([name for name, _ in converted_named_tensors], packed, pbar)
+        ),
+    )
+    barriers: list[str] = []
+    monkeypatch.setattr(upw.dist, "barrier", lambda *args, **kwargs: barriers.append(kwargs.get("group")))
+    monkeypatch.setattr(upw, "get_gloo_group", lambda: "gloo")
+
+    upw.UpdateWeightFromDistributed._send_weights(obj, pbar="pbar")
+
+    assert seen == [
+        (["dense.0"], False, "pbar"),
+        (["dense.1"], False, "pbar"),
+        (["expert.0"], False, "pbar"),
+    ]
+    assert barriers == ["gloo", "gloo"]
+
+
+@pytest.mark.unit
+def test_bridge_path_forwards_packed_flag_and_listifies_chunks(upw, monkeypatch):
+    obj = _make_instance(upw)
+    obj._is_pp_src_rank = True
+    obj._group_name = "g"
+    obj.weights_getter = lambda: {"actor": torch.zeros(1)}
+    obj._hf_weight_iterator = MagicMock()
+    obj._hf_weight_iterator.get_hf_weight_chunks.return_value = iter(
+        ((("bridge.0", torch.zeros(1)),), (("bridge.1", torch.zeros(1)),))
+    )
+
+    seen: list[tuple[list[str], bool, str]] = []
+    monkeypatch.setattr(
+        upw.UpdateWeightFromDistributed,
+        "_update_bucket_weights_from_distributed",
+        lambda self, converted_named_tensors, pbar=None, packed=False: seen.append(
+            ([name for name, _ in converted_named_tensors], packed, pbar)
+        ),
+    )
+    monkeypatch.setattr(upw.dist, "barrier", lambda *args, **kwargs: None)
+    monkeypatch.setattr(upw, "get_gloo_group", lambda: "gloo")
+
+    upw.UpdateWeightFromDistributed._sync_bridge_weights_to_rollout_engines(
+        obj, pbar="pbar", use_vllm_packed=True
+    )
+
+    assert seen == [
+        (["bridge.0"], True, "pbar"),
+        (["bridge.1"], True, "pbar"),
+    ]
+
+
+@pytest.mark.unit
 def test_source_no_standalone_use_vllm_param(upw):
     src = inspect.getsource(upw)
     lines = [line.strip() for line in src.splitlines() if "use_vllm=" in line and "use_vllm_packed" not in line]
@@ -345,7 +554,7 @@ def test_source_wraps_sync_with_weight_update_session(upw):
     src = inspect.getsource(upw.UpdateWeightFromDistributed.update_weights)
     assert "_begin_vllm_weight_update_session" in src
     assert "_end_vllm_weight_update_session" in src
-    assert "_sync_weights_to_rollout_engines" in src
+    assert "_send_weights" in src
 
 
 @pytest.mark.unit
@@ -358,6 +567,6 @@ def test_source_uses_nccl_trainer_send_weights_args(upw):
 @pytest.mark.unit
 def test_cuda_sync_once_after_all_buckets_not_per_bucket(upw):
     send_src = inspect.getsource(upw.update_weights_from_distributed)
-    sync_src = inspect.getsource(upw.UpdateWeightFromDistributed._sync_weights_to_rollout_engines)
+    sync_src = inspect.getsource(upw.UpdateWeightFromDistributed.update_weights)
     assert "torch.cuda.synchronize" not in send_src
     assert "torch.cuda.synchronize" in sync_src

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -5,7 +5,7 @@ import os
 import socket
 import time
 from argparse import Namespace
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import Any
 
 import ray
@@ -123,7 +123,7 @@ class UpdateWeightFromDistributed:
     @torch.no_grad()
     def update_weights(self) -> None:
         """
-        Pause → flush → non-expert (TP) → expert (EP) → continue. Progress on PP source.
+        Pause → flush → _send_weights → continue. Progress on PP source.
         """
         self.weight_version += 1
 
@@ -140,9 +140,12 @@ class UpdateWeightFromDistributed:
                 )
         dist.barrier(group=get_gloo_group())
 
+        pbar = tqdm(desc=f"[{self._group_name}] Update weights", total=0) if self._is_pp_src_rank else None
         _begin_vllm_weight_update_session(self.rollout_engines)
         try:
-            self._sync_weights_to_rollout_engines()
+            self._send_weights(pbar)
+            if self._is_pp_src_rank:
+                torch.cuda.synchronize()
         finally:
             _end_vllm_weight_update_session(self.rollout_engines)
 
@@ -158,105 +161,46 @@ class UpdateWeightFromDistributed:
             ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
         dist.barrier(group=get_gloo_group())
 
-    def _sync_weights_to_rollout_engines(self) -> None:
+    def _send_weights(self, pbar: tqdm | None) -> None:
+        """
+        Non-expert (TP) pass → barrier → expert (EP) pass → barrier. Each iterator
+        yields broadcast-ready chunks (bucketing happens internally); vime packed
+        mode sends the non-expert dense chunks through vLLM's packed NCCL path.
+        """
+        use_vllm_packed = self._use_vllm_packed()
         if self._hf_weight_iterator is not None:
-            self._sync_bridge_weights_to_rollout_engines()
+            self._sync_bridge_weights_to_rollout_engines(pbar, use_vllm_packed=use_vllm_packed)
             return
 
-        use_vllm_packed = self._use_vllm_packed()
         if use_vllm_packed and self._is_pp_src_rank:
             logger.info("Using vLLM packed weight sync (bucketed; metadata + trainer_send_weights per bucket)")
 
-        if use_vllm_packed:
-            buffer_size = 0
-            converted_named_tensors: list[tuple[str, torch.Tensor]] = []
-            pbar = (
-                tqdm(desc=f"[{self._group_name}] Update weights (vLLM packed)", total=0)
-                if self._is_pp_src_rank
-                else None
-            )
-            for name, param in named_params_and_buffers(self.args, self.model):
-                if ".experts." in name:
-                    continue
-                buffer_size = self._update_weight_from_distributed(
-                    name,
-                    param,
-                    converted_named_tensors,
-                    buffer_size,
-                    pbar=pbar,
-                    flush_packed=True,
-                )
-            if converted_named_tensors and self._is_pp_src_rank:
-                self._update_weights_vllm_packed(converted_named_tensors)
-                if pbar is not None:
-                    pbar.update(1)
-        else:
-            buffer_size = 0
-            converted_named_tensors = []
-            pbar = tqdm(desc=f"[{self._group_name}] Update weights", total=0) if self._is_pp_src_rank else None
-
-            for name, param in named_params_and_buffers(self.args, self.model):
-                if ".experts." in name:
-                    continue
-                buffer_size = self._update_weight_from_distributed(
-                    name, param, converted_named_tensors, buffer_size, pbar=pbar
-                )
-
-            if converted_named_tensors:
-                self._update_bucket_weights_from_distributed(converted_named_tensors, pbar=pbar)
-
+        for hf_chunk in self._iter_non_expert_chunks():
+            self._send_hf_chunk(hf_chunk, pbar=pbar, packed=use_vllm_packed)
         dist.barrier(group=get_gloo_group())
 
-        if not use_vllm_packed:
-            buffer_size = 0
-            named_tensors = []
-            pbar = (
-                tqdm(desc=f"[{self._group_name}] Update weights (experts)", total=0) if self._is_pp_src_rank else None
-            )
-            for name, param in named_params_and_buffers(self.args, self.model):
-                if ".experts." not in name:
-                    continue
-                buffer_size = self._update_expert_weight_from_distributed(
-                    name, param, named_tensors, buffer_size, pbar=pbar
-                )
+        if use_vllm_packed:
+            return
 
-            if named_tensors:
-                self._update_expert_bucket_weights_from_distributed(named_tensors, pbar=pbar)
+        for hf_chunk in self._iter_expert_chunks():
+            self._send_hf_chunk(hf_chunk, pbar=pbar, packed=False)
+        dist.barrier(group=get_gloo_group())
 
-        if self._is_pp_src_rank:
-            torch.cuda.synchronize()
-
-    def _sync_bridge_weights_to_rollout_engines(self) -> None:
+    def _sync_bridge_weights_to_rollout_engines(self, pbar: tqdm | None, *, use_vllm_packed: bool) -> None:
         """
         Export HF weights through Megatron-Bridge, then send each exported chunk
         over the same NCCL non-colocate path used by the raw converter.
         """
-        use_vllm_packed = self._use_vllm_packed()
         if self._is_pp_src_rank:
             logger.info("Using Megatron-Bridge HF weight export for non-colocate vLLM weight sync")
-            pbar = tqdm(
-                desc=f"[{self._group_name}] Update weights (Megatron-Bridge"
-                f"{', vLLM packed' if use_vllm_packed else ''})",
-                total=0,
-            )
-        else:
-            pbar = None
 
         megatron_local_weights = self.weights_getter()
         for hf_named_tensors in self._hf_weight_iterator.get_hf_weight_chunks(megatron_local_weights):
             if self._is_pp_src_rank:
                 hf_named_tensors = list(hf_named_tensors)
-                if use_vllm_packed:
-                    self._update_weights_vllm_packed(hf_named_tensors)
-                    if pbar is not None:
-                        pbar.update(1)
-                else:
-                    self._update_bucket_weights_from_distributed(hf_named_tensors, pbar=pbar)
+                self._send_hf_chunk(hf_named_tensors, pbar=pbar, packed=use_vllm_packed)
 
         dist.barrier(group=get_gloo_group())
-
-        if self._is_pp_src_rank:
-            torch.cuda.synchronize()
 
     def _use_vllm_packed(self) -> bool:
         """Use vLLM packed weight transfer (one-shot metadata + trainer_send_weights)."""
@@ -270,85 +214,87 @@ class UpdateWeightFromDistributed:
 
     def _update_weights_vllm_packed(self, converted_named_tensors: list[tuple[str, torch.Tensor]]) -> None:
         """Single-shot vLLM weight update using packed broadcast."""
-        while not ray.get(self.rollout_engine_lock.acquire.remote()):
-            time.sleep(0.1)
+        self._update_bucket_weights_from_distributed(converted_named_tensors, packed=True)
 
-        try:
-            refs = update_weights_from_distributed(
-                self._group_name,
-                self._model_update_groups,
-                self.weight_version,
-                self.rollout_engines,
-                converted_named_tensors,
-                packed=True,
-            )
-            ray.get(refs)
-        finally:
-            ray.get(self.rollout_engine_lock.release.remote())
-
-    def _update_weight_from_distributed(
+    def _send_hf_chunk(
         self,
-        name: str,
-        param: torch.nn.Parameter,
         converted_named_tensors: list[tuple[str, torch.Tensor]],
-        buffer_size: int,
-        pbar: tqdm | None = None,
         *,
-        flush_packed: bool = False,
-    ) -> int | None:
-        """
-        Non-expert: gather TP → rm pad → HF → buffer (flush if full). All gather, PP source buffers.
-        Returns updated bytes on source, None on non-source.
-        """
-        param = all_gather_param(name, param)
-        if not self._is_pp_src_rank:
-            return
-
-        param_size = param.numel() * param.element_size()
-        if buffer_size + param_size > self.args.update_weight_buffer_size:
-            if converted_named_tensors:
-                if flush_packed:
-                    self._update_weights_vllm_packed(converted_named_tensors)
-                    converted_named_tensors.clear()
-                    if pbar is not None:
-                        pbar.update(1)
-                else:
-                    self._update_bucket_weights_from_distributed(converted_named_tensors, pbar=pbar)
-            buffer_size = 0
-        converted_named_tensors += convert_to_hf(self.args, self.model_name, name, param, self.quantization_config)
-        buffer_size += param_size
-        return buffer_size
-
-    def _update_expert_weight_from_distributed(
-        self,
-        name: str,
-        param: torch.nn.Parameter,
-        named_tensors: list[tuple[str, torch.Tensor]],
-        buffer_size: int,
-        pbar: tqdm | None = None,
-    ) -> int:
-        """
-        Expert: gather TP → rm pad → buffer. EP gather + HF deferred. Threshold × EP size.
-        """
-        param = all_gather_param(name, param)
-
-        param_size = param.numel() * param.element_size()
-        if (
-            buffer_size + param_size
-        ) * mpu.get_expert_model_parallel_world_size() > self.args.update_weight_buffer_size:
-            self._update_expert_bucket_weights_from_distributed(named_tensors, pbar=pbar)
-            buffer_size = 0
-
-        named_tensors.append((name, param))
-        buffer_size += param_size
-        return buffer_size
-
-    def _update_expert_bucket_weights_from_distributed(
-        self, named_tensors: list[tuple[str, torch.Tensor]], pbar: tqdm | None = None
+        pbar: tqdm | None,
+        packed: bool,
     ) -> None:
+        if not converted_named_tensors:
+            return
+        self._update_bucket_weights_from_distributed(converted_named_tensors, pbar=pbar, packed=packed)
+
+    def _iter_non_expert_chunks(self) -> Iterator[list[tuple[str, torch.Tensor]]]:
         """
-        Gather EP → HF → broadcast. Clears buffer.
+        Yield broadcast-sized HF chunks of non-expert params: TP all-gather +
+        HF convert per param, then bucket up to ``--update-weight-buffer-size``.
+        Empty on non-PP-src ranks (they still join all_gather_param).
         """
+        buffer_size = 0
+        buffer: list[tuple[str, torch.Tensor]] = []
+        for name, param in named_params_and_buffers(self.args, self.model):
+            if ".experts." in name:
+                continue
+            param = all_gather_param(name, param)
+            if not self._is_pp_src_rank:
+                continue
+
+            param_size = param.numel() * param.element_size()
+            if buffer and buffer_size + param_size > self.args.update_weight_buffer_size:
+                yield buffer
+                buffer = []
+                buffer_size = 0
+
+            buffer.extend(convert_to_hf(self.args, self.model_name, name, param, self.quantization_config))
+            buffer_size += param_size
+
+        if buffer:
+            yield buffer
+
+    def _iter_expert_chunks(
+        self,
+        params: Iterator[tuple[str, torch.Tensor]] | None = None,
+    ) -> Iterator[list[tuple[str, torch.Tensor]]]:
+        """
+        Yield one HF chunk per EP-weighted batch of expert params: TP gather +
+        buffer until threshold, then EP gather + HF convert.
+        """
+        if params is None:
+            params = ((n, p) for n, p in named_params_and_buffers(self.args, self.model) if ".experts." in n)
+
+        buffer_size = 0
+        batch: list[tuple[str, torch.Tensor]] = []
+        for name, param in params:
+            param = all_gather_param(name, param)
+            param_size = param.numel() * param.element_size()
+            if (
+                buffer_size + param_size
+            ) * mpu.get_expert_model_parallel_world_size() > self.args.update_weight_buffer_size:
+                hf_chunk = self._ep_gather_and_convert(batch)
+                if hf_chunk:
+                    yield hf_chunk
+                batch = []
+                buffer_size = 0
+
+            batch.append((name, param))
+            buffer_size += param_size
+
+        if batch:
+            hf_chunk = self._ep_gather_and_convert(batch)
+            if hf_chunk:
+                yield hf_chunk
+
+    def _ep_gather_and_convert(self, named_tensors: list[tuple[str, torch.Tensor]]) -> list[tuple[str, torch.Tensor]]:
+        """
+        EP all-gather a buffered batch + HF convert on PP source. Returns HF tensors on
+        PP source, [] elsewhere. Clears ``named_tensors``.
+        """
+        if not named_tensors:
+            return []
+
         names = [name for name, _ in named_tensors]
         all_names = [None] * mpu.get_expert_model_parallel_world_size()
         dist.all_gather_object(all_names, names, group=mpu.get_expert_model_parallel_group())
@@ -372,17 +318,21 @@ class UpdateWeightFromDistributed:
 
         named_tensors.clear()
         if not self._is_pp_src_rank:
-            return
+            return []
 
         all_gathered_params = sum(all_gathered_params, [])
         converted_hf_tensors = []
         for name, param in all_gathered_params:
             converted_hf_tensors += convert_to_hf(self.args, self.model_name, name, param, self.quantization_config)
 
-        self._update_bucket_weights_from_distributed(converted_hf_tensors, pbar)
+        return converted_hf_tensors
 
     def _update_bucket_weights_from_distributed(
-        self, converted_named_tensors: list[tuple[str, torch.Tensor]], pbar: tqdm | None = None
+        self,
+        converted_named_tensors: list[tuple[str, torch.Tensor]],
+        pbar: tqdm | None = None,
+        *,
+        packed: bool = False,
     ) -> None:
         """
         Lock → broadcast → clear → unlock → pbar++. Lock prevents NCCL deadlock.
@@ -397,7 +347,7 @@ class UpdateWeightFromDistributed:
             self.weight_version,
             self.rollout_engines,
             converted_named_tensors,
-            packed=False,
+            packed=packed,
         )
 
         ray.get(refs)


### PR DESCRIPTION
## Summary
- Refactor `UpdateWeightFromDistributed` toward the slime-style `_send_weights` and chunk-iterator structure.
- Keep vime-specific vLLM NCCL packed transfer, bridge HF iterator support, and start/finish weight-update session handling.
- Add focused unit coverage for raw packed, raw non-packed, and bridge chunk forwarding paths.
<img width="838" height="840" alt="image" src="https://github.com/user-attachments/assets/45ccce24-5f4b-4161-9c6a-db51ef500a03" />
<img width="1014" height="852" alt="image" src="https://github.com/user-attachments/assets/aa5d3da2-a2bb-4dfb-a39c-3bf06967a4da" />
<img width="942" height="816" alt="image" src="https://github.com/user-attachments/assets/2ba1ce63-398c-4043-b37b-55e8c9b13abc" />
