### PR TITLE
[Feature][Rollout] Wire vLLM data-parallelism (DP) into engine topology + sleep-guard patch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -130,6 +130,17 @@ RUN cd Megatron-LM && \
     rm megatron.patch && \
     pip install -e .
 
+# Patch vLLM: skip execute_dummy_batch while the engine is asleep / being put to sleep, so a
+# colocate DP+EP rollout's staged sleep/wake weight-sync doesn't run a forward against freed KV
+# (illegal memory access at update_weights / the post-rollout sleep offload). vLLM PR #44483
+# lineage, broadened to guard on EngineCore.is_sleeping() (covers the cuMem offload window).
+# vLLM is a pip install (not a git checkout) so apply with plain `git apply` (no --3way).
+COPY docker/patch/${PATCH_VERSION}/vllm.patch /tmp/vllm.patch
+RUN VLLM_SITE="$(python3 -c 'import os, vllm; print(os.path.dirname(os.path.dirname(vllm.__file__)))')" && \
+    cd "$VLLM_SITE" && \
+    git apply -v /tmp/vllm.patch && \
+    rm /tmp/vllm.patch
+
 # ====================================== Install main package ============================================
 
 ARG VIME_COMMIT=main

--- a/docker/patch/latest/vllm.patch
+++ b/docker/patch/latest/vllm.patch
@@ -1,0 +1,30 @@
+diff --git a/vllm/v1/engine/core.py b/vllm/v1/engine/core.py
+--- a/vllm/v1/engine/core.py
++++ b/vllm/v1/engine/core.py
+@@ -750,8 +750,10 @@
+         if tags is None or tags:
+             self.model_executor.wake_up(tags)
+ 
+-        # Resume scheduling (applies to all levels)
+-        self.resume_scheduler()
++        # Partial wakes intentionally keep the remaining allocations asleep.
++        # Resume scheduling only once all executor memory is resident again.
++        if not self.model_executor.is_sleeping:
++            self.resume_scheduler()
+ 
+     def is_sleeping(self) -> bool:
+         """Check if engine is sleeping at any level."""
+@@ -1844,8 +1846,11 @@
+                     continue
+ 
+                 # We are in a running state and so must execute a dummy pass
+-                # if the model didn't execute any ready requests.
+-                self.execute_dummy_batch()
++                # if the model didn't execute any ready requests -- unless the executor is
++                # asleep (#44483: a decode-shaped dummy batch reads freed KV -> illegal memory
++                # access). The finished-sync all-reduce below still runs (DP lockstep).
++                if not self.is_sleeping():
++                    self.execute_dummy_batch()
+ 
+             # 3) All-reduce operation to determine global unfinished reqs.
+             self.engines_running = self._has_global_unfinished_reqs(

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -55,17 +55,6 @@ def test_format_v6_uri_ipv4_unchanged():
 
 
 @pytest.mark.unit
-def test_to_local_gpu_id_without_cvd():
-    assert mod._to_local_gpu_id(3) == 3
-
-
-@pytest.mark.unit
-def test_to_local_gpu_id_maps_physical_id(monkeypatch):
-    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3,4")
-    assert mod._to_local_gpu_id(3) == 1
-
-
-@pytest.mark.unit
 def test_compute_vllm_engine_topology_single_node(vllm_args):
     vllm_args.num_gpus_per_node = 8
     vllm_args.rollout_num_gpus_per_engine = 4
@@ -578,12 +567,34 @@ def test_compute_topology_heterogeneous_per_group_tp(vllm_args):
 
 
 @pytest.mark.unit
-def test_resolve_parallel_sizes_rejects_dp_gt_1(vllm_args):
+def test_resolve_parallel_sizes_dp_consumes_gpus(vllm_args):
+    # vLLM DP consumes GPUs (total = tp * pp * dp), so tp = gpus // (pp * dp).
+    # dp=2, pp=1, 4 GPUs/engine → tp=2.
     vllm_args.vllm_pipeline_parallel_size = 1
     vllm_args.vllm_data_parallel_size = 2
     vllm_args.vllm_dp_size = 2
-    with pytest.raises(NotImplementedError, match="data parallelism"):
-        mod._resolve_vllm_parallel_sizes(vllm_args, gpus_per_engine=4)
+    tp, pp = mod._resolve_vllm_parallel_sizes(vllm_args, gpus_per_engine=4)
+    assert (tp, pp) == (2, 1)
+
+
+@pytest.mark.unit
+def test_resolve_parallel_sizes_dp_and_pp_combined(vllm_args):
+    # dp=2, pp=2, 8 GPUs/engine → tp = 8 // (2*2) = 2.
+    vllm_args.vllm_pipeline_parallel_size = 2
+    vllm_args.vllm_data_parallel_size = 2
+    vllm_args.vllm_dp_size = 2
+    tp, pp = mod._resolve_vllm_parallel_sizes(vllm_args, gpus_per_engine=8)
+    assert (tp, pp) == (2, 2)
+
+
+@pytest.mark.unit
+def test_resolve_parallel_sizes_rejects_indivisible_dp(vllm_args):
+    # gpus_per_engine not divisible by pp*dp must raise (fail fast, not desync the rendezvous).
+    vllm_args.vllm_pipeline_parallel_size = 1
+    vllm_args.vllm_data_parallel_size = 2
+    vllm_args.vllm_dp_size = 2
+    with pytest.raises(ValueError, match="divisible"):
+        mod._resolve_vllm_parallel_sizes(vllm_args, gpus_per_engine=3)
 
 
 @pytest.mark.unit

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -121,25 +121,14 @@ def _get_vllm_dp_size(args) -> int:
 
 
 def _resolve_vllm_parallel_sizes(args, *, gpus_per_engine: int) -> tuple[int, int]:
-    # Derive TP per-engine from THIS engine's GPU count (matches upstream slime's
-    # sglang_engine: tp = _gpus_per_engine // pp). Deliberately does NOT consult a global
-    # ``args.vllm_tp_size``: validate_args used to set that from the *global*
-    # rollout_num_gpus_per_engine, which shadowed this per-engine value and made a
-    # heterogeneous per-group engine (e.g. a tp=2 group) launch with the global TP —
-    # desyncing the weight-transfer rendezvous (the 300s "3/4 clients joined" hang).
     pp = _get_vllm_pp_size(args)
     dp = _get_vllm_dp_size(args)
-    if dp != 1:
-        raise NotImplementedError(
-            "vLLM data parallelism (vllm_data_parallel_size>1) is not wired in this base: TP is "
-            "computed as gpus_per_engine // pp (no DP term) and --data-parallel-size is not "
-            "forwarded. DP/EP support lands in a follow-up PR."
-        )
-    if gpus_per_engine % pp != 0:
+    if gpus_per_engine % (pp * dp) != 0:
         raise ValueError(
-            f"num_gpus_per_engine ({gpus_per_engine}) must be divisible by " f"vllm_pipeline_parallel_size ({pp})"
+            f"num_gpus_per_engine ({gpus_per_engine}) must be divisible by "
+            f"vllm_pipeline_parallel_size * vllm_data_parallel_size ({pp} * {dp} = {pp * dp})"
         )
-    tp = gpus_per_engine // pp
+    tp = gpus_per_engine // (pp * dp)
     return tp, pp
 
 


### PR DESCRIPTION
## Summary
- `_resolve_vllm_parallel_sizes` now factors `dp` into the TP calculation (`tp = gpus // (pp * dp)`), removing the `NotImplementedError` gate that blocked DP>1.
- Docker: apply `vllm.patch` that skips `execute_dummy_batch` while the engine is asleep / being put to sleep, preventing illegal-memory-access during colocate DP+EP staged sleep/wake weight-sync (vLLM PR #44483 lineage).
- Tests updated: add dp-consumes-gpus and dp+pp-combined cases, replace the old "rejects dp>1" test with an indivisible-check test, drop stale `_to_local_gpu_id` tests.

## Test plan
- [ ] Unit tests pass (`pytest tests/unit/backends/vllm_utils/test_vllm_engine.py`)
- [ ] Docker image builds with the vLLM patch applied
- [ ] Colocate DP+EP rollout runs without illegal-memory-access

🤖 Generated with [Claude Code](https://claude.com/claude-code)