### PR TITLE
refactor(vllm): align control requests with sglang

### DIFF
--- a/tests/unit/backends/vllm_utils/conftest.py
+++ b/tests/unit/backends/vllm_utils/conftest.py
@@ -14,7 +14,6 @@ def vllm_args() -> SimpleNamespace:
         hf_checkpoint="/tmp/model",
         vllm_router_ip=None,
         vllm_router_port=None,
-        vllm_weight_transfer_timeout_sec=900.0,
         num_gpus_per_node=8,
         rollout_num_gpus_per_engine=4,
         colocate=False,

--- a/tests/unit/backends/vllm_utils/test_arguments.py
+++ b/tests/unit/backends/vllm_utils/test_arguments.py
@@ -278,21 +278,9 @@ def test_orchestration_dests_use_vllm_prefix(args_mod):
     assert "vllm_router_ip" in args_mod._VIME_ORCHESTRATION_DESTS
     assert "vllm_router_port" in args_mod._VIME_ORCHESTRATION_DESTS
     assert "router_request_timeout_secs" in args_mod._VIME_ORCHESTRATION_DESTS
-    assert "vllm_weight_transfer_timeout_sec" in args_mod._VIME_ORCHESTRATION_DESTS
     assert "router_ip" not in args_mod._VIME_ORCHESTRATION_DESTS
     assert "router_port" not in args_mod._VIME_ORCHESTRATION_DESTS
     assert "vllm_router_request_timeout_secs" not in args_mod._VIME_ORCHESTRATION_DESTS
-
-
-@pytest.mark.unit
-def test_add_vllm_arguments_parses_weight_transfer_timeout(args_mod, monkeypatch):
-    monkeypatch.setattr(args_mod.AsyncEngineArgs, "add_cli_args", staticmethod(lambda parser: parser))
-    parser = argparse.ArgumentParser(add_help=False)
-    args_mod.add_vllm_arguments(parser)
-    default, _ = parser.parse_known_args([])
-    assert default.vllm_weight_transfer_timeout_sec == 900.0
-    parsed, _ = parser.parse_known_args(["--vllm-weight-transfer-timeout-sec", "123.5"])
-    assert parsed.vllm_weight_transfer_timeout_sec == 123.5
 
 
 def _realistic_add_vllm_arguments(parser):
@@ -301,12 +289,6 @@ def _realistic_add_vllm_arguments(parser):
     parser.add_argument("--vllm-router-ip", dest="vllm_router_ip", type=str, default=None)
     parser.add_argument("--vllm-router-port", dest="vllm_router_port", type=int, default=None)
     parser.add_argument("--vllm-server-concurrency", dest="vllm_server_concurrency", type=int, default=512)
-    parser.add_argument(
-        "--vllm-weight-transfer-timeout-sec",
-        dest="vllm_weight_transfer_timeout_sec",
-        type=float,
-        default=900.0,
-    )
     return parser
 
 
@@ -329,7 +311,6 @@ def test_action_table_excludes_orchestration(args_mod, monkeypatch):
     assert "vllm_router_ip" not in table
     assert "vllm_router_port" not in table
     assert "vllm_server_concurrency" not in table
-    assert "vllm_weight_transfer_timeout_sec" not in table
 
 
 @pytest.mark.unit

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -173,8 +173,8 @@ def test_get_base_gpu_id_colocate(vllm_args):
 def test_start_weight_update_posts_four_phase_endpoint(vllm_engine, monkeypatch):
     calls: list[tuple] = []
 
-    def fake_post(endpoint: str, payload: dict, timeout: float):
-        calls.append((endpoint, payload, timeout))
+    def fake_post(endpoint: str, payload: dict):
+        calls.append((endpoint, payload))
         return {"ok": True}
 
     monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
@@ -185,15 +185,14 @@ def test_start_weight_update_posts_four_phase_endpoint(vllm_engine, monkeypatch)
     assert len(calls) == 1
     assert calls[0][0] == "start_weight_update"
     assert calls[0][1] == {"is_checkpoint_format": True}
-    assert calls[0][2] == vllm_engine._weight_transfer_http_timeout()
 
 
 @pytest.mark.unit
 def test_finish_weight_update_posts_empty_body(vllm_engine, monkeypatch):
     calls: list[tuple] = []
 
-    def fake_post(endpoint: str, payload: dict, timeout: float):
-        calls.append((endpoint, payload, timeout))
+    def fake_post(endpoint: str, payload: dict):
+        calls.append((endpoint, payload))
         return {"done": True}
 
     monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
@@ -201,22 +200,18 @@ def test_finish_weight_update_posts_empty_body(vllm_engine, monkeypatch):
     result = vllm_engine.finish_weight_update()
 
     assert result == {"done": True}
-    assert calls == [("finish_weight_update", {}, vllm_engine._weight_transfer_http_timeout())]
+    assert calls == [("finish_weight_update", {})]
 
 
 @pytest.mark.unit
 def test_update_weights_from_tensor_posts_ipc_payload_and_records_version(vllm_engine, monkeypatch):
-    calls: list[tuple[str, dict, float]] = []
+    posted: list[tuple[str, dict]] = []
 
-    def fake_make_request(endpoint: str, payload: dict, timeout: float):
-        calls.append((endpoint, payload, timeout))
+    def fake_post(endpoint: str, payload: dict):
+        posted.append((endpoint, payload))
         return {"ok": True}
 
-    monkeypatch.setattr(
-        vllm_engine,
-        "_make_request",
-        fake_make_request,
-    )
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
     assert vllm_engine._weight_version is None
 
     vllm_engine.update_weights_from_tensor(
@@ -227,12 +222,9 @@ def test_update_weights_from_tensor_posts_ipc_payload_and_records_version(vllm_e
         weight_version="42",
     )
 
-    assert len(calls) == 1
-    endpoint, posted, timeout = calls[0]
-    assert endpoint == "collective_rpc"
-    assert timeout == vllm_engine._weight_transfer_http_timeout()
-    assert posted["method"] == "update_weights_chunk"
-    sent = posted["kwargs"]["update_info"]
+    assert posted[0][0] == "collective_rpc"
+    assert posted[0][1]["method"] == "update_weights_chunk"
+    sent = posted[0][1]["kwargs"]["update_info"]
     # ipc_handles got cloudpickle'd into ipc_handles_pickled
     assert "ipc_handles" not in sent
     assert isinstance(sent["ipc_handles_pickled"], str)
@@ -246,10 +238,10 @@ def test_update_weights_from_tensor_posts_ipc_payload_and_records_version(vllm_e
 def test_update_weights_from_tensor_does_not_advance_version_on_failure(vllm_engine, monkeypatch):
     """POST failure must not advance _weight_version (else a retry would skip the resync)."""
 
-    def fake_make_request_fail(endpoint: str, payload: dict, timeout: float) -> dict:
+    def fake_post_fail(endpoint: str, payload: dict) -> dict:
         raise RuntimeError("simulated POST failure")
 
-    monkeypatch.setattr(vllm_engine, "_make_request", fake_make_request_fail)
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_post_fail)
 
     vllm_engine._weight_version = "old"
     with pytest.raises(RuntimeError, match="simulated POST failure"):
@@ -318,8 +310,8 @@ def test_update_weights_from_distributed_posts_update_weights_without_checkpoint
 def test_post_vllm_update_weights_http_wraps_update_info(vllm_engine, monkeypatch):
     seen: list[tuple] = []
 
-    def fake_post(endpoint: str, payload: dict, timeout: float):
-        seen.append((endpoint, payload, timeout))
+    def fake_post(endpoint: str, payload: dict):
+        seen.append((endpoint, payload))
         return {"status": "ok"}
 
     monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
@@ -329,55 +321,6 @@ def test_post_vllm_update_weights_http_wraps_update_info(vllm_engine, monkeypatc
     assert result == {"status": "ok"}
     assert seen[0][0] == "update_weights"
     assert seen[0][1] == {"update_info": {"names": ["w"], "packed": False}}
-
-
-@pytest.mark.unit
-def test_weight_transfer_http_timeout_reads_config(vllm_engine):
-    vllm_engine.args.vllm_weight_transfer_timeout_sec = 123.5
-    assert vllm_engine._weight_transfer_http_timeout() == 123.5
-
-
-@pytest.mark.unit
-def test_weight_transfer_http_timeout_uses_argument_default(vllm_engine):
-    assert vllm_engine.args.vllm_weight_transfer_timeout_sec == 900.0
-    assert vllm_engine._weight_transfer_http_timeout() == 900.0
-
-
-@pytest.mark.unit
-def test_start_weight_update_uses_config_timeout(vllm_engine, monkeypatch):
-    vllm_engine.args.vllm_weight_transfer_timeout_sec = 123.5
-    calls: list[tuple] = []
-
-    def fake_post(endpoint: str, payload: dict, timeout: float):
-        calls.append((endpoint, payload, timeout))
-        return {"ok": True}
-
-    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
-
-    vllm_engine.start_weight_update()
-    assert calls[0][2] == 123.5
-
-
-@pytest.mark.unit
-def test_init_weights_update_group_uses_config_timeout(vllm_engine, monkeypatch):
-    vllm_engine.args.vllm_weight_transfer_timeout_sec = 123.5
-    calls: list[tuple] = []
-
-    def fake_post(endpoint: str, payload: dict, timeout: float):
-        calls.append((endpoint, payload, timeout))
-        return {"initialized": True}
-
-    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
-
-    vllm_engine.init_weights_update_group(
-        "127.0.0.1",
-        29500,
-        rank_offset=1,
-        world_size=4,
-        group_name="unused",
-        backend="nccl",
-    )
-    assert calls[0][2] == 123.5
 
 
 @pytest.mark.unit
@@ -513,7 +456,7 @@ def test_resume_memory_occupation_posts_wake_even_when_sleep_disabled(vllm_engin
 def test_init_weights_update_group_retries_then_succeeds(vllm_engine, monkeypatch):
     attempts = {"n": 0}
 
-    def fake_post(endpoint: str, payload: dict, timeout: float):
+    def fake_post(endpoint: str, payload: dict):
         attempts["n"] += 1
         if attempts["n"] < 2:
             raise requests.ConnectionError("transient")
@@ -669,7 +612,7 @@ def test_make_request_short_circuits_on_headless(vllm_engine, monkeypatch):
 
     monkeypatch.setattr(mod.requests, "post", _boom)
     vllm_engine.node_rank = 1
-    assert vllm_engine._make_request("whatever", {}, timeout=1) is None
+    assert vllm_engine._make_request("whatever", {}) is None
 
 
 @pytest.mark.unit

--- a/vime/backends/vllm_utils/arguments.py
+++ b/vime/backends/vllm_utils/arguments.py
@@ -234,12 +234,6 @@ def add_vllm_arguments(parser):
             "true determinism — seed alone does not control kernel selection."
         ),
     )
-    parser.add_argument(
-        "--vllm-weight-transfer-timeout-sec",
-        type=float,
-        default=900.0,
-        help="Timeout (seconds) for vLLM weight-transfer HTTP control-plane calls.",
-    )
     # vime-only orchestration knob: not part of vllm's CLI but read by
     # UpdateWeightFromDistributed._use_vllm_packed() to choose packed
     # broadcast vs per-bucket NCCL for dense models.
@@ -362,7 +356,6 @@ _VIME_ORCHESTRATION_DESTS = frozenset(
         "router_policy",
         "vllm_server_concurrency",
         "vllm_enable_deterministic_inference",
-        "vllm_weight_transfer_timeout_sec",
         "vllm_weight_sync_packed",
         # vime-only flags for fine-grained deployment; consumed in vime/ray/rollout.py
         # (start_rollout_servers / _resolve_vllm_config) and must NOT be forwarded to

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -475,7 +475,7 @@ def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None)
     """Wait until the vLLM server responds on ``GET /health``."""
     while True:
         try:
-            response = requests.get(f"{base_url}/health", timeout=3)
+            response = requests.get(f"{base_url}/health")
             if response.status_code == 200:
                 return
         except requests.RequestException:
@@ -512,9 +512,6 @@ class VLLMEngine(RayActor):
 
     def _http_base(self) -> str:
         return f"http://{self.server_host}:{self.server_port}"
-
-    def _weight_transfer_http_timeout(self) -> float:
-        return float(self.args.vllm_weight_transfer_timeout_sec)
 
     def init(
         self,
@@ -585,7 +582,6 @@ class VLLMEngine(RayActor):
         response = requests.post(
             f"http://{self.router_ip}:{self.router_port}/workers",
             json=payload,
-            timeout=30,
         )
         response.raise_for_status()
 
@@ -594,14 +590,11 @@ class VLLMEngine(RayActor):
             return
         worker_url = self._http_base()
         try:
-            all_workers = requests.get(f"http://{self.router_ip}:{self.router_port}/workers", timeout=30).json()[
-                "workers"
-            ]
+            all_workers = requests.get(f"http://{self.router_ip}:{self.router_port}/workers").json()["workers"]
             for worker in all_workers:
                 if worker["url"] == worker_url:
                     response = requests.delete(
                         f"http://{self.router_ip}:{self.router_port}/workers/{quote(worker_url, safe='')}",
-                        timeout=30,
                     )
                     response.raise_for_status()
                     return
@@ -628,7 +621,7 @@ class VLLMEngine(RayActor):
         treated as a mismatch (e.g. vLLM ``parallel_config`` may not surface ``nnodes``), so the
         check stays strict for reported fields without false-failing on unreported ones.
         """
-        response = requests.get(f"{self._http_base()}/server_info", params={"config_format": "json"}, timeout=30)
+        response = requests.get(f"{self._http_base()}/server_info", params={"config_format": "json"})
         body = _response_json(response)
         parallel_cfg = body.get("vllm_config", {}).get("parallel_config", {})
         if not parallel_cfg:
@@ -668,12 +661,12 @@ class VLLMEngine(RayActor):
         else:
             _wait_worker_process_alive(self.process)
 
-    def _make_request(self, endpoint: str, payload: dict | None = None, *, timeout: float) -> dict | None:
+    def _make_request(self, endpoint: str, payload: dict | None = None) -> dict | None:
         """Control-plane POST returning parsed JSON."""
         if self.node_rank != 0:
             return None
         url = f"{self._http_base()}/{endpoint.lstrip('/')}"
-        return _response_json(requests.post(url, json=payload or {}, timeout=timeout))
+        return _response_json(requests.post(url, json=payload or {}))
 
     def _post_vllm_update_weights_http(self, update_info: dict) -> dict:
         """POST ``/update_weights`` with ``{"update_info": ...}`` (vLLM RLHF control plane).
@@ -684,7 +677,6 @@ class VLLMEngine(RayActor):
         return self._make_request(
             "update_weights",
             {"update_info": update_info},
-            timeout=self._weight_transfer_http_timeout(),
         )
 
     def health_generate(self, timeout: float = 5.0) -> bool:
@@ -721,7 +713,6 @@ class VLLMEngine(RayActor):
         response = self._make_request(
             "collective_rpc",
             {"method": "update_weights_chunk", "kwargs": {"update_info": payload}},
-            timeout=self._weight_transfer_http_timeout(),
         )
         if weight_version is not None:
             self._weight_version = str(weight_version)
@@ -759,23 +750,15 @@ class VLLMEngine(RayActor):
         response = self._make_request(
             "collective_rpc",
             {"method": "update_weights_chunk", "kwargs": {"update_info": payload}},
-            timeout=self._weight_transfer_http_timeout(),
         )
         return response
 
     def flush_cache(self):
-        """Reset the prefix cache via ``POST /reset_prefix_cache``.
-
-        vLLM's endpoint always returns 200 (it does not signal a busy engine),
-        so a single call suffices — no retry loop. ``reset_running_requests``
-        stays False: if any block is still in use the server skips the reset and
-        still returns 200; vime only calls this when the engine is idle
-        (colocate sleep / keep-mode pause).
-        """
+        """Reset the prefix cache via ``POST /reset_prefix_cache``."""
         if self.node_rank != 0:
             return
-        params = {"reset_running_requests": False}
-        requests.post(f"{self._http_base()}/reset_prefix_cache", params=params, timeout=60).raise_for_status()
+        params = {"reset_running_requests": False, "reset_external": False}
+        requests.post(f"{self._http_base()}/reset_prefix_cache", params=params).raise_for_status()
 
     def get_url(self):
         """Worker HTTP base URL, or ``None`` when ``node_rank != 0``."""
@@ -840,7 +823,6 @@ class VLLMEngine(RayActor):
         response = requests.post(
             f"{self._http_base()}/sleep",
             params={"level": level},
-            timeout=30,
         )
         return _response_json(response)
 
@@ -853,7 +835,6 @@ class VLLMEngine(RayActor):
         response = requests.post(
             f"{self._http_base()}/wake_up",
             params=wake_params,
-            timeout=30,
         )
         return _response_json(response)
 
@@ -863,11 +844,10 @@ class VLLMEngine(RayActor):
         For IPC mode the payload is ``{"init_info": {}}``; for NCCL use
         ``init_weights_update_group`` which constructs the payload from typed args.
         """
-        init_timeout_s = self._weight_transfer_http_timeout()
         last_error = None
         for attempt in range(1, 4):
             try:
-                return self._make_request("init_weight_transfer_engine", payload, timeout=init_timeout_s)
+                return self._make_request("init_weight_transfer_engine", payload)
             except Exception as e:
                 last_error = e
                 if attempt < 3:
@@ -877,11 +857,7 @@ class VLLMEngine(RayActor):
 
     def start_weight_update(self, is_checkpoint_format: bool = False) -> dict:
         """``POST /start_weight_update`` — signals vLLM to enter IPC weight-update mode."""
-        return self._make_request(
-            "start_weight_update",
-            {"is_checkpoint_format": is_checkpoint_format},
-            timeout=self._weight_transfer_http_timeout(),
-        )
+        return self._make_request("start_weight_update", {"is_checkpoint_format": is_checkpoint_format})
 
     def finish_weight_update(self) -> dict:
         """``POST /finish_weight_update`` — signals vLLM to exit IPC weight-update mode.
@@ -890,7 +866,7 @@ class VLLMEngine(RayActor):
         ``update_weights_from_tensor`` (the IPC data-carrying RPC), matching vime's
         single-RPC version-with-data semantics.
         """
-        return self._make_request("finish_weight_update", {}, timeout=self._weight_transfer_http_timeout())
+        return self._make_request("finish_weight_update", {})
 
     def check_weights(self, action: str):
         """No vLLM ``weights_checker`` route; return a placeholder dict."""
@@ -912,11 +888,10 @@ class VLLMEngine(RayActor):
                 "world_size": world_size,
             }
         }
-        init_timeout_s = self._weight_transfer_http_timeout()
         last_error = None
         for attempt in range(1, 4):
             try:
-                return self._make_request("init_weight_transfer_engine", payload, timeout=init_timeout_s)
+                return self._make_request("init_weight_transfer_engine", payload)
             except Exception as e:
                 last_error = e
                 if attempt < 3:
@@ -968,7 +943,6 @@ class VLLMEngine(RayActor):
                 "method": "reload_weights",
                 "kwargs": {"weights_path": model_path, "is_checkpoint_format": True},
             },
-            timeout=600,
         )
         return _response_json(response)
 
@@ -980,7 +954,6 @@ class VLLMEngine(RayActor):
             f"{self._http_base()}/pause",
             params={"mode": "keep", "clear_cache": "false"},
             json={},
-            timeout=120,
         )
         response.raise_for_status()
         return response
@@ -989,7 +962,7 @@ class VLLMEngine(RayActor):
         """``POST /resume`` to continue generation after pause."""
         if self.node_rank != 0:
             return None
-        response = requests.post(f"{self._http_base()}/resume", json={}, timeout=120)
+        response = requests.post(f"{self._http_base()}/resume", json={})
         response.raise_for_status()
         return response
 
@@ -1028,7 +1001,7 @@ class VLLMEngine(RayActor):
             )
         ):
             logger.warning("vLLM start_profile: extra kwargs may be ignored by server; see vLLM profiling docs.")
-        response = requests.post(f"{self._http_base()}/start_profile", json={}, timeout=30)
+        response = requests.post(f"{self._http_base()}/start_profile", json={})
         response.raise_for_status()
         return response
 
@@ -1036,7 +1009,7 @@ class VLLMEngine(RayActor):
         """POST ``/stop_profile`` to stop an active server-side profile."""
         if self.node_rank != 0:
             return None
-        response = requests.post(f"{self._http_base()}/stop_profile", json={}, timeout=30)
+        response = requests.post(f"{self._http_base()}/stop_profile", json={})
         response.raise_for_status()
         return response
 

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -757,7 +757,7 @@ class VLLMEngine(RayActor):
         """Reset the prefix cache via ``POST /reset_prefix_cache``."""
         if self.node_rank != 0:
             return
-        params = {"reset_running_requests": False, "reset_external": False}
+        params = {"reset_running_requests": False}
         requests.post(f"{self._http_base()}/reset_prefix_cache", params=params).raise_for_status()
 
     def get_url(self):


### PR DESCRIPTION
## Summary
- remove the vLLM weight-transfer HTTP timeout knob and helper
- align vLLM control-plane requests with the SGLang-style no client-side timeout pattern
- keep health/process wait timeouts and preserve collective_rpc/update_weights_chunk semantics

## Tests
- python -m pytest tests/unit/backends/vllm_utils/test_arguments.py tests/unit/backends/vllm_utils/test_vllm_engine.py