### PR TITLE
add npu support.

### DIFF
--- a/docker/npu_patch/README.md
+++ b/docker/npu_patch/README.md
@@ -1,0 +1,112 @@
+# Vime NPU Patch Installation Guide
+
+This guide provides instructions for installing Vime with NPU support, including all required dependencies and patches.
+
+## Component Version Mapping
+
+| Component       | Version/Commit                           | Source                                                                                                              |
+| --------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| vime            | main                                     | [GitHub](https://github.com/vllm-project/vime/tree/main)                                                            |
+| Megatron-Bridge | 3fd3768045422d0aa5c97e90a4e6c659aea9acb9 | [GitHub](https://github.com/radixark/Megatron-Bridge)                                                               |
+| Megatron-LM     | 3714d81d418c9f1bca4594fc35f9e8289f652862 | [GitHub](https://github.com/NVIDIA/Megatron-LM)                                                                     |
+| MindSpeed       | fc63de5c48426dd019c3b3f39e65f5bdf56e4086 | [GitCode](https://gitcode.com/Ascend/MindSpeed)                                                                     |
+| HDK             | 25.3.RC1                                 | [Ascend](https://www.hiascend.com/hardware/firmware-drivers/commercial?product=7\&model=33)                         |
+| CANN            | 9.0.0                                    | [Ascend](https://www.hiascend.com/developer/download/community/result?module=cann\&cann=9.0.0\&product=7\&model=33) |
+
+## Preparing the Running Environment
+
+### Python Version
+
+Only `python==3.11` is supported currently.
+
+```shell
+conda create -n vime_release python=3.11
+conda activate vime_release
+```
+
+### Working Directory Setup
+
+```shell
+mkdir <WORKSPACE> && cd <WORKSPACE>
+```
+
+### CANN Environment
+
+Prior to start work with vime on Ascend you need to install CANN Toolkit, Kernels operator package and NNAL version 9.0.0 , check the [installation guide](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/83RC1/softwareinst/instg/instg_0008.html?Mode=PmIns\&InstallType=local\&OS=openEuler\&Software=cannToolKit)
+
+```shell
+source <CANN_PATH>/ascend-toolkit/set_env.sh
+source <CANN_PATH>/nnal/atb/set_env.sh
+```
+
+### PyTorch and PyTorch NPU
+
+```shell
+pip install torch-npu==2.10.0
+```
+
+## Installing Dependencies
+
+
+### Megatron-Bridge
+
+```shell
+pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
+
+cd <WORKSPACE>
+git clone https://github.com/radixark/Megatron-Bridge.git -b bridge
+git checkout 3fd3768045422d0aa5c97e90a4e6c659aea9acb9
+pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation
+```
+
+### Megatron-LM
+
+```shell
+cd <WORKSPACE>
+git clone https://github.com/NVIDIA/Megatron-LM.git --recursive && \
+  cd Megatron-LM/ && git checkout 3714d81d418c9f1bca4594fc35f9e8289f652862 && \
+  pip install -e .
+```
+
+### MindSpeed
+
+```shell
+cd <WORKSPACE>
+git clone https://gitcode.com/Ascend/MindSpeed.git && \
+  cd MindSpeed/ && git checkout fc63de5c48426dd019c3b3f39e65f5bdf56e4086 && \
+  pip install -e .
+```
+
+### Vime
+
+```shell
+cd <WORKSPACE>
+git clone https://github.com/vllm-project/vime.git -b wxx-ascend && cd vime
+cp -r docker/npu_patch ../npu_patch
+pip install -e .
+```
+
+## Applying Patches
+
+```shell
+cd <WORKSPACE>/Megatron-LM
+git apply ../npu_patch/megatron_common.patch
+git apply ../npu_patch/megatron.patch
+
+cd <WORKSPACE>/Megatron-Bridge
+git apply ../npu_patch/megatron-bridge.patch
+
+cd <WORKSPACE>/MindSpeed
+git apply ../npu_patch/mindspeed.patch
+```
+
+## Additional Dependencies
+
+```shell
+cd <WORKSPACE>/vime
+pip install triton-ascend
+pip install torch-npu==2.10.0
+pip install torchvision==0.25.0
+pip install numpy==1.26.4
+```
+

--- a/docker/npu_patch/meagtron_comm.patch
+++ b/docker/npu_patch/meagtron_comm.patch
@@ -1,0 +1,772 @@
+diff --git a/megatron/core/dist_checkpointing/strategies/common.py b/megatron/core/dist_checkpointing/strategies/common.py
+index 41c21d93d..ef80f72d6 100644
+--- a/megatron/core/dist_checkpointing/strategies/common.py
++++ b/megatron/core/dist_checkpointing/strategies/common.py
+@@ -86,7 +86,7 @@ class TorchCommonLoadStrategy(LoadCommonStrategy):
+                 msc = MultiStorageClientFeature.import_package()
+                 return msc.torch.load(load_path, map_location='cpu')
+             else:
+-                return torch.load(load_path, map_location='cpu')
++                return torch.load(load_path, map_location='cpu', weights_only=False)
+         except FileNotFoundError as e:
+             err_msg = f'Common file {load_path} does not exist'
+             if MultiStorageClientFeature.is_enabled():
+diff --git a/megatron/core/dist_checkpointing/strategies/torch.py b/megatron/core/dist_checkpointing/strategies/torch.py
+index 5a1ea308d..aa701237f 100644
+--- a/megatron/core/dist_checkpointing/strategies/torch.py
++++ b/megatron/core/dist_checkpointing/strategies/torch.py
+@@ -597,10 +597,12 @@ class MCoreLoadPlanner(DefaultLoadPlanner):
+     def _validate_global_shapes(self, metadata, sharded_tensors):
+         for sh_ten in sharded_tensors:
+             if sh_ten.key not in metadata.state_dict_metadata:
+-                raise KeyError(
+-                    f"{sh_ten.key} from model not in state dict:"
+-                    f" {sorted(metadata.state_dict_metadata.keys())}"
+-                )
++                # raise KeyError(
++                #     f"{sh_ten.key} from model not in state dict:"
++                #     f" {sorted(metadata.state_dict_metadata.keys())}"
++                # )
++                print(f"{sh_ten.key} from model not in state dict, will skip")
++                continue
+             loaded_shape = metadata.state_dict_metadata[sh_ten.key].size
+             expected_shape = self._expected_shape(sh_ten)
+             if loaded_shape != expected_shape:
+@@ -630,7 +632,7 @@ class MCoreLoadPlanner(DefaultLoadPlanner):
+         tensor_metadata = self.metadata.state_dict_metadata
+         metadata_with_sizes = [
+             (tensor_metadata[key], tensor_metadata[key].size, sharded_tensor)
+-            for key, sharded_tensor in self.allow_shape_mismatch_sharded_tensors.items()
++            for key, sharded_tensor in self.allow_shape_mismatch_sharded_tensors.items() if key in tensor_metadata
+         ]
+         try:
+             # Temporarily set sizes to expected shapes
+@@ -959,6 +961,7 @@ class TorchDistLoadShardedStrategy(LoadShardedStrategy):
+             planner=MCoreLoadPlanner(
+                 shapes_validation_sharded_tensors=flexible_shape_sharded_tensors,
+                 allow_shape_mismatch_sharded_tensors=allow_shape_mismatch_sharded_tensors,
++                allow_partial_load=True,
+             ),
+         )
+ 
+diff --git a/megatron/core/extensions/transformer_engine.py b/megatron/core/extensions/transformer_engine.py
+index acb93ef78..d239db4ab 100644
+--- a/megatron/core/extensions/transformer_engine.py
++++ b/megatron/core/extensions/transformer_engine.py
+@@ -408,6 +408,7 @@ class TELinear(te.pytorch.Linear):
+         )
+ 
+         for param in self.parameters():
++            setattr(param, "parallel_mode", parallel_mode)
+             if is_expert:
+                 # Reduce the gradient on the expert_data_parallel group for expert linear layers
+                 setattr(param, "allreduce", not self.expert_parallel)
+@@ -1161,6 +1162,61 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
+ 
+ 
+ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
++    def ceil_div(x: int, y: int) -> int:
++        return (x + y - 1) // y
++
++    class _FakeInt4QuantizationSTE(torch.autograd.Function):
++        @staticmethod
++        def forward(ctx, x, group_size):
++            m, n = x.shape
++            block_size_m, block_size_n = 1, group_size
++
++
++            m_padded = ceil_div(m, block_size_m) * block_size_m
++            n_padded = ceil_div(n, block_size_n) * block_size_n
++
++            x_padded = torch.zeros(
++                (m_padded, n_padded),
++                dtype=x.dtype, device=x.device
++            )
++            x_padded[:m, :n] = x
++
++            x_view = x_padded.view(
++                m_padded // block_size_m,
++                block_size_m,
++                n_padded // block_size_n,
++                block_size_n
++            )
++
++            x_max = x_view.abs().float().amax(dim=(1, 3), keepdim=True)
++            q_max = 7
++            x_scale = x_max / q_max
++
++            x_scale = x_scale.clamp(min=1e-5)
++
++            x_div = x_view / x_scale
++            x_round = torch.round(x_div)
++
++            x_q_clamped = x_round.clamp(-q_max, q_max)
++
++            x_dequant_view = x_q_clamped * x_scale
++
++            x_dequant_full = x_dequant_view.view_as(x_padded)
++            x_out = x_dequant_full[:m, :n].contiguous().to(x.dtype)
++
++            return x_out
++
++        @staticmethod
++        def backward(ctx, grad_output):
++            return grad_output, None
++
++    def fake_int4_quantization_ste(x, group_size):
++        x_out = _FakeInt4QuantizationSTE.apply(x, group_size)
++        
++        if hasattr(x, 'main_grad'):
++            x_out.main_grad = x.main_grad
++            
++        return x_out
+ 
+     class TEGroupedLinear(te.pytorch.GroupedLinear):
+         """
+@@ -1351,6 +1407,7 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
+             _is_first_microbatch = (
+                 None if self.disable_parameter_transpose_cache else self.is_first_microbatch
+             )
++
+             out = super().forward(x, m_splits, is_first_microbatch=_is_first_microbatch)
+             self.is_first_microbatch = False
+ 
+@@ -1361,6 +1418,20 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
+                 return out
+             return out, None
+ 
++        def _get_weight_tensors(self):
++            """Get the weight tensors of the module."""
++            weight_tensors = super()._get_weight_tensors()
++
++            if os.getenv("OPEN_TRAINING_INT4_FAKE_QAT_FLAG", "0") == "1":
++                group_size = int(os.getenv("OPEN_TRAINING_INT4_GROUP_SIZE", "128"))
++
++                weight_tensors = [
++                    fake_int4_quantization_ste(w, group_size) 
++                    for w in weight_tensors
++                ]
++                
++            return weight_tensors
++
+         def _encode_extra_state(self, state):
+             # TE 2.0 changed the format of extra_state to be a byte tensor
+             if is_te_min_version("2.0.0"):
+diff --git a/megatron/core/fusions/fused_mla_yarn_rope_apply.py b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+index 1fd5dcfae..c9aeef1f0 100644
+--- a/megatron/core/fusions/fused_mla_yarn_rope_apply.py
++++ b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+@@ -385,6 +385,7 @@ def rotary_fwd_kv_kernel(
+     SIN,
+     emb_dim: tl.constexpr,
+     k_dim: tl.constexpr,
++    k_dim_ceil: tl.constexpr,
+     v_dim: tl.constexpr,
+     head_num: tl.constexpr,
+     batch_size,
+@@ -434,21 +435,27 @@ def rotary_fwd_kv_kernel(
+     cos_right = tl.load(COS + token_idx * emb_dim + emb_dim // 2 + tl.arange(0, emb_dim // 2))
+     sin_right = tl.load(SIN + token_idx * emb_dim + emb_dim // 2 + tl.arange(0, emb_dim // 2))
+ 
+-    KV_ptr = KV + pid_m * stride_kv_seq + pid_head * BLOCK_H * stride_kv_nheads
+-    kv_off = tl.arange(0, BLOCK_H)[:, None] * stride_kv_nheads
+-    mask = kv_off < head_num * stride_kv_nheads
+-    k_in_off = kv_off + tl.arange(0, k_dim)[None, :]
+-    v_in_off = kv_off + k_dim + tl.arange(0, v_dim)[None, :]
+-    k = tl.load(KV_ptr + k_in_off, mask=mask)
+-    v = tl.load(KV_ptr + v_in_off, mask=mask)
++    KV_ptr = KV + pid_m * stride_kv_seq # + pid_head * BLOCK_H * stride_kv_nheads
++    ki_range = tl.arange(0, BLOCK_H)[:, None] + pid_head * BLOCK_H
++    kj_range = tl.arange(0, k_dim_ceil)[None, :]
++    mask_k = (ki_range < head_num) & (kj_range < k_dim)
++    mask_v = ki_range < head_num
++    k_off = ki_range * stride_kv_nheads + kj_range
++    if v_dim > 0:
++        v_off = ki_range * stride_kv_nheads + k_dim + tl.arange(0, v_dim)[None, :]
++        v = tl.load(KV_ptr + v_off, mask=mask_v)
++    else:
++        v = tl.zeros((BLOCK_H, 1), dtype=KV.dtype.element_ty)
++    k = tl.load(KV_ptr + k_off, mask=mask_k)
+ 
+-    K_ptr = O_KEY + pid_m * stride_k_seq + pid_head * BLOCK_H * stride_k_nheads
+-    V_ptr = O_VALUE + pid_m * stride_v_seq + pid_head * BLOCK_H * stride_v_nheads
++    K_ptr = O_KEY + pid_m * stride_k_seq # + pid_head * BLOCK_H * stride_k_nheads
++    V_ptr = O_VALUE + pid_m * stride_v_seq # + pid_head * BLOCK_H * stride_v_nheads
+ 
+-    k_out_off = tl.arange(0, BLOCK_H)[:, None] * stride_k_nheads + tl.arange(0, k_dim)[None, :]
+-    v_out_off = tl.arange(0, BLOCK_H)[:, None] * stride_v_nheads + tl.arange(0, v_dim)[None, :]
+-    tl.store(K_ptr + k_out_off, k, mask=mask)
+-    tl.store(V_ptr + v_out_off, v, mask=mask)
++    k_out_off = ki_range * stride_k_nheads + kj_range
++    tl.store(K_ptr + k_out_off, k, mask=mask_k)
++    if v_dim > 0:
++        v_out_off = ki_range * stride_v_nheads + tl.arange(0, v_dim)[None, :]
++        tl.store(V_ptr + v_out_off, v, mask=mask_v)
+ 
+     EMB = K_POS_EMB + pid_m * stride_emb_seq
+     # x1 = t[..., 0::2], x2 = t[..., 1::2]
+@@ -460,14 +467,16 @@ def rotary_fwd_kv_kernel(
+     x_left = x_left.expand_dims(0).broadcast_to(BLOCK_H, emb_dim // 2)
+     x_right = x_right.expand_dims(0).broadcast_to(BLOCK_H, emb_dim // 2)
+ 
++    x_range = tl.arange(0, BLOCK_H)[:, None] + pid_head * BLOCK_H
++    mask_x = x_range < head_num
+     x_left_off = (
+-        tl.arange(0, BLOCK_H)[:, None] * stride_k_nheads
++        x_range * stride_k_nheads
+         + k_dim
+         + tl.arange(0, emb_dim // 2)[None, :]
+     )
+     x_right_off = x_left_off + emb_dim // 2
+-    tl.store(K_ptr + x_left_off, x_left, mask=mask)
+-    tl.store(K_ptr + x_right_off, x_right, mask=mask)
++    tl.store(K_ptr + x_left_off, x_left, mask=mask_x)
++    tl.store(K_ptr + x_right_off, x_right, mask=mask_x)
+ 
+ 
+ @triton.autotune(
+@@ -493,6 +502,7 @@ def rotary_bwd_kv_kernel(
+     SIN,
+     emb_dim: tl.constexpr,
+     k_dim: tl.constexpr,
++    k_dim_ceil: tl.constexpr,
+     v_dim: tl.constexpr,
+     head_num: tl.constexpr,
+     batch_size,
+@@ -533,27 +543,32 @@ def rotary_bwd_kv_kernel(
+     else:
+         token_idx = _get_thd_token_idx(cu_seqlens_kv, pid_m, seq_num, cp_rank, cp_size)
+ 
+-    dKV_ptr = dKV + pid_m * stride_dkv_seq + pid_head * BLOCK_H * stride_dkv_nheads
+-    dkv_off = tl.arange(0, BLOCK_H)[:, None] * stride_dkv_nheads
+-    mask = dkv_off < head_num * stride_dkv_nheads
+-    dk_out_off = dkv_off + tl.arange(0, k_dim)[None, :]
+-    dv_out_off = dkv_off + k_dim + tl.arange(0, v_dim)[None, :]
+-
+-    dK_ptr = dK + pid_m * stride_dk_seq + pid_head * BLOCK_H * stride_dk_nheads
+-    dV_ptr = dV + pid_m * stride_dv_seq + pid_head * BLOCK_H * stride_dv_nheads
+-    dk_in_off = tl.arange(0, BLOCK_H)[:, None] * stride_dk_nheads + tl.arange(0, k_dim)[None, :]
+-    dv_in_off = tl.arange(0, BLOCK_H)[:, None] * stride_dv_nheads + tl.arange(0, v_dim)[None, :]
+-    dk = tl.load(dK_ptr + dk_in_off, mask=mask)
+-    dv = tl.load(dV_ptr + dv_in_off, mask=mask)
+-    tl.store(dKV_ptr + dk_out_off, dk, mask=mask)
+-    tl.store(dKV_ptr + dv_out_off, dv, mask=mask)
++    dKV_ptr = dKV + pid_m * stride_dkv_seq # + pid_head * BLOCK_H * stride_dkv_nheads
++    ki_range = tl.arange(0, BLOCK_H)[:, None] + pid_head * BLOCK_H 
++    kj_range = tl.arange(0, k_dim_ceil)[None, :]
++    mask_k = (ki_range < head_num) & (kj_range < k_dim)
++    mask_v = ki_range < head_num
++    dk_out_off = ki_range * stride_dkv_nheads + kj_range
++
++    dK_ptr = dK + pid_m * stride_dk_seq # + pid_head * BLOCK_H * stride_dk_nheads
++    dV_ptr = dV + pid_m * stride_dv_seq # + pid_head * BLOCK_H * stride_dv_nheads
++    dk_in_off = ki_range * stride_dk_nheads + kj_range
++
++    dk = tl.load(dK_ptr + dk_in_off, mask=mask_k)
++    tl.store(dKV_ptr + dk_out_off, dk, mask=mask_k)
++    
++    if v_dim > 0:
++        dv_out_off = ki_range * stride_dkv_nheads + k_dim + tl.arange(0, v_dim)[None, :]
++        dv_in_off = ki_range * stride_dv_nheads + tl.arange(0, v_dim)[None, :]
++        dv = tl.load(dV_ptr + dv_in_off, mask=mask_v)
++        tl.store(dKV_ptr + dv_out_off, dv, mask=mask_v)
+ 
+     if pid_head == 0:
+         x_left_accum = tl.zeros((BLOCK_H, emb_dim // 2), dtype=tl.float32)
+         x_right_accum = tl.zeros((BLOCK_H, emb_dim // 2), dtype=tl.float32)
+         for i in tl.static_range(triton.cdiv(head_num, BLOCK_H)):
+-            dK_ptr = dK + pid_m * stride_dk_seq + i * BLOCK_H * stride_dk_nheads
+-            x_off = tl.arange(0, BLOCK_H)[:, None] * stride_dk_nheads + k_dim
++            dK_ptr = dK + pid_m * stride_dk_seq # + i * BLOCK_H * stride_dk_nheads
++            x_off = tl.arange(0, BLOCK_H)[:, None] * stride_dk_nheads + k_dim + i * BLOCK_H * stride_dk_nheads
+             mask = x_off < head_num * stride_dk_nheads
+             x_left_off = x_off + tl.arange(0, emb_dim // 2)[None, :]
+             x_right_off = x_left_off + emb_dim // 2
+@@ -632,6 +647,7 @@ class ApplyMLARotaryEmbKV(torch.autograd.Function):
+ 
+         o_key = kv.new_empty(total_seqlen, nheads, emb_dim + k_dim)
+         o_value = kv.new_empty(total_seqlen, nheads, v_dim)
++        k_dim_ceil = triton.next_power_of_2(k_dim)
+ 
+         grid = lambda META: (total_seqlen, triton.cdiv(nheads, META["BLOCK_H"]))
+         rotary_fwd_kv_kernel[grid](
+@@ -643,6 +659,7 @@ class ApplyMLARotaryEmbKV(torch.autograd.Function):
+             sin,
+             emb_dim,
+             k_dim,
++            k_dim_ceil,
+             v_dim,
+             nheads,
+             batch_size,
+@@ -700,6 +717,7 @@ class ApplyMLARotaryEmbKV(torch.autograd.Function):
+ 
+         d_kv = dk.new_empty(total_seqlen, nheads, ctx.k_dim + ctx.v_dim)
+         d_emb = dk.new_empty(total_seqlen, 1, ctx.emb_dim)
++        k_dim_ceil = triton.next_power_of_2(ctx.k_dim)
+ 
+         grid = lambda META: (total_seqlen, triton.cdiv(nheads, META["BLOCK_H"]))
+         rotary_bwd_kv_kernel[grid](
+@@ -711,6 +729,7 @@ class ApplyMLARotaryEmbKV(torch.autograd.Function):
+             sin,
+             ctx.emb_dim,
+             ctx.k_dim,
++            k_dim_ceil,
+             ctx.v_dim,
+             nheads,
+             batch_size,
+diff --git a/megatron/core/models/common/language_module/language_module.py b/megatron/core/models/common/language_module/language_module.py
+index 13d74aa52..060898a7a 100644
+--- a/megatron/core/models/common/language_module/language_module.py
++++ b/megatron/core/models/common/language_module/language_module.py
+@@ -184,7 +184,15 @@ class LanguageModule(MegatronModule):
+             assert (
+                 column_parallel_linear is not None
+             ), "column_parallel_linear cannot be None when not using fused linear cross entropy."
+-            logits, _ = column_parallel_linear(hidden, **col_linear_kwargs)
++            # output
++            output_layer_params = {k: v.detach() for k, v in column_parallel_linear.named_parameters()}
++            output_layer_buffers = dict(column_parallel_linear.named_buffers())
++            logits, _ = torch.func.functional_call(
++                column_parallel_linear,
++                {**output_layer_params, **output_layer_buffers},
++                (hidden,),
++                col_linear_kwargs,
++            )
+ 
+             return self.compute_language_model_loss(labels, logits)
+ 
+diff --git a/megatron/core/models/gpt/gpt_layer_specs.py b/megatron/core/models/gpt/gpt_layer_specs.py
+index e21127b87..712793853 100755
+--- a/megatron/core/models/gpt/gpt_layer_specs.py
++++ b/megatron/core/models/gpt/gpt_layer_specs.py
+@@ -188,6 +188,8 @@ def get_gpt_layer_with_transformer_engine_spec(
+     use_kitchen: bool = False,
+     use_te_activation_func: bool = False,
+     fallback_to_eager_attn: bool = False,
++    post_self_attn_layernorm: bool = False,
++    post_mlp_layernorm: bool = False,
+ ) -> ModuleSpec:
+     """Use this spec to use lower-level Transformer Engine modules (required for fp8 training).
+ 
+@@ -260,6 +262,8 @@ def get_gpt_layer_with_transformer_engine_spec(
+         mlp=mlp,
+         sharded_state_dict_keys_map=sharded_state_dict_keys_map,
+         normalization=normalization,
++        post_self_attn_layernorm=post_self_attn_layernorm,
++        post_mlp_layernorm=post_mlp_layernorm,
+     )
+ 
+ 
+@@ -349,6 +353,8 @@ def get_transformer_layer_spec_for_backend(
+     mlp: ModuleSpec,
+     sharded_state_dict_keys_map: Optional[dict] = None,
+     normalization: Optional[str] = None,
++    post_self_attn_layernorm: bool = False,
++    post_mlp_layernorm: bool = False,
+ ) -> ModuleSpec:
+     """Helper function to get module spec for TransformerLayer"""
+ 
+@@ -371,9 +377,11 @@ def get_transformer_layer_spec_for_backend(
+             input_layernorm=input_layernorm,
+             self_attention=attention,
+             self_attn_bda=get_bias_dropout_add,
++            post_self_attn_layernorm=TENorm if post_self_attn_layernorm else IdentityOp,
+             pre_mlp_layernorm=pre_mlp_layernorm,
+             mlp=mlp,
+             mlp_bda=get_bias_dropout_add,
++            post_mlp_layernorm=TENorm if post_mlp_layernorm else IdentityOp,
+             sharded_state_dict_keys_map=sharded_state_dict_keys_map,
+         ),
+     )
+diff --git a/megatron/core/models/gpt/gpt_model.py b/megatron/core/models/gpt/gpt_model.py
+index a1230568c..1fd52f65a 100644
+--- a/megatron/core/models/gpt/gpt_model.py
++++ b/megatron/core/models/gpt/gpt_model.py
+@@ -446,6 +446,7 @@ class GPTModel(LanguageModule):
+         *,
+         inference_params: Optional[BaseInferenceContext] = None,
+         loss_mask: Optional[Tensor] = None,
++        mtp_kwargs: Optional[dict] = {},
+     ) -> Tensor:
+         """Forward function of the GPT Model This function passes the input tensors
+         through the embedding layer, and then the decoder and finally into the post
+@@ -508,6 +509,7 @@ class GPTModel(LanguageModule):
+             runtime_gather_output=runtime_gather_output,
+             extra_block_kwargs=extra_block_kwargs,
+             inference_context=inference_context,
++            mtp_kwargs=mtp_kwargs,
+         )
+ 
+     def _postprocess(
+@@ -529,6 +531,7 @@ class GPTModel(LanguageModule):
+         runtime_gather_output=None,
+         extra_block_kwargs=None,
+         inference_context=None,
++        mtp_kwargs={},
+     ):
+         """Postprocesses decoder hidden states to generate logits or compute loss.
+ 
+@@ -543,7 +546,8 @@ class GPTModel(LanguageModule):
+         output_weight = None
+         if self.share_embeddings_and_output_weights:
+             output_weight = self.shared_embedding_or_output_weight()
+-        if mtp_in_postprocess:
++
++        if mtp_in_postprocess and mtp_kwargs.get('mtp_labels', None) is not None:
+             hidden_states = self.mtp(
+                 input_ids=input_ids,
+                 position_ids=position_ids,
+@@ -563,13 +567,18 @@ class GPTModel(LanguageModule):
+             return hidden_states
+ 
+         # Skip when mtp_num_layers is None or 0
+-        if self.config.mtp_num_layers:
+-            mtp_labels = labels.clone()
++        if self.config.mtp_num_layers and mtp_kwargs.get('mtp_labels', None) is not None:
++            mtp_labels = mtp_kwargs['mtp_labels'].clone()
++            mtp_labels, _ = roll_tensor(mtp_labels, shifts=-1, dims=-1, cp_group=self.cp_group, packed_seq_params=packed_seq_params)
++
+             hidden_states_list = torch.chunk(hidden_states, 1 + self.config.mtp_num_layers, dim=0)
+             hidden_states = hidden_states_list[0]
+             if loss_mask is None:
+                 # if loss_mask is not provided, use all ones as loss_mask
+                 loss_mask = torch.ones_like(mtp_labels)
++            else:
++                # Otherwise, roll the loss_mask to keep up with the mtp_labels
++                loss_mask, _ = roll_tensor(loss_mask, shifts=-1, dims=-1, cp_group=self.cp_group, packed_seq_params=packed_seq_params)
+             for mtp_layer_number in range(self.config.mtp_num_layers):
+                 # Calc loss for the current Multi-Token Prediction (MTP) layers.
+                 mtp_labels, _ = roll_tensor(
+@@ -595,7 +604,7 @@ class GPTModel(LanguageModule):
+                     sequence_parallel_enabled=self.output_layer.sequence_parallel,
+                     column_parallel_linear=self.output_layer,
+                     col_linear_kwargs={
+-                        'weight': output_weight,
++                        'weight': output_weight.detach() if output_weight else None,
+                         'runtime_gather_output': runtime_gather_output,
+                     },
+                 )
+diff --git a/megatron/core/optimizer/distrib_optimizer.py b/megatron/core/optimizer/distrib_optimizer.py
+index 6e093f96f..eac21a3ea 100644
+--- a/megatron/core/optimizer/distrib_optimizer.py
++++ b/megatron/core/optimizer/distrib_optimizer.py
+@@ -677,6 +677,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
+                 # TE FusedAdam will not accumulate step for empty param groups, so we need to
+                 # align the step across param groups.
+                 param_group["step"] = int(step)
++            if "step" in param_group and param_group["step"] is None:
++                del param_group["step"]
+ 
+         # Grad scaler state.
+         if self.grad_scaler:
+@@ -1646,6 +1648,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
+                             if key == 'padding':
+                                 tensors[key] = LocalNonpersistentObject(tensors[key])
+                                 continue
++                            if key == 'step':
++                                continue
+                             assert tensors[key].shape == (gbuf_local_end - gbuf_local_start,), (
+                                 tensors[key].shape,
+                                 gbuf_local_start,
+diff --git a/megatron/core/parallel_state.py b/megatron/core/parallel_state.py
+index a273002b9..4f821cfd5 100644
+--- a/megatron/core/parallel_state.py
++++ b/megatron/core/parallel_state.py
+@@ -11,6 +11,7 @@ from typing import Callable, List, Optional
+ 
+ import numpy as np
+ import torch
++import torch.distributed as dist
+ 
+ from .utils import GlobalMemoryBuffer, is_torch_min_version
+ 
+diff --git a/megatron/core/pipeline_parallel/p2p_communication.py b/megatron/core/pipeline_parallel/p2p_communication.py
+index ac839c21f..f18309217 100644
+--- a/megatron/core/pipeline_parallel/p2p_communication.py
++++ b/megatron/core/pipeline_parallel/p2p_communication.py
+@@ -26,22 +26,22 @@ def _batched_p2p_ops(
+     ops = []
+     if tensor_send_prev is not None:
+         send_prev_op = torch.distributed.P2POp(
+-            torch.distributed.isend, tensor_send_prev, prev_pipeline_rank, group
++            torch.distributed.isend, tensor_send_prev, prev_pipeline_rank,
+         )
+         ops.append(send_prev_op)
+     if tensor_recv_prev is not None:
+         recv_prev_op = torch.distributed.P2POp(
+-            torch.distributed.irecv, tensor_recv_prev, prev_pipeline_rank, group
++            torch.distributed.irecv, tensor_recv_prev, prev_pipeline_rank,
+         )
+         ops.append(recv_prev_op)
+     if tensor_send_next is not None:
+         send_next_op = torch.distributed.P2POp(
+-            torch.distributed.isend, tensor_send_next, next_pipeline_rank, group
++            torch.distributed.isend, tensor_send_next, next_pipeline_rank,
+         )
+         ops.append(send_next_op)
+     if tensor_recv_next is not None:
+         recv_next_op = torch.distributed.P2POp(
+-            torch.distributed.irecv, tensor_recv_next, next_pipeline_rank, group
++            torch.distributed.irecv, tensor_recv_next, next_pipeline_rank,
+         )
+         ops.append(recv_next_op)
+     if len(ops) > 0:
+diff --git a/megatron/core/transformer/moe/moe_utils.py b/megatron/core/transformer/moe/moe_utils.py
+index 28cff06f5..58dc4bb70 100644
+--- a/megatron/core/transformer/moe/moe_utils.py
++++ b/megatron/core/transformer/moe/moe_utils.py
+@@ -587,6 +587,9 @@ def topk_routing_with_score_function(
+         else:
+             return torch.topk(scores, k=topk, dim=1)
+ 
++    from vime.utils.routing_replay import get_routing_replay_compute_topk
++    compute_topk = get_routing_replay_compute_topk(compute_topk)
++
+     if score_function == "softmax":
+         if use_pre_softmax:
+             scores = torch.softmax(logits, dim=-1, dtype=torch.float32).type_as(logits)
+diff --git a/megatron/core/transformer/moe/router.py b/megatron/core/transformer/moe/router.py
+index 16fc9d9af..517944f25 100644
+--- a/megatron/core/transformer/moe/router.py
++++ b/megatron/core/transformer/moe/router.py
+@@ -201,6 +201,9 @@ class TopKRouter(Router):
+             self.global_tokens_per_expert = None
+             self.ga_steps = None
+ 
++        from vime.utils.routing_replay import register_routing_replay
++        register_routing_replay(self)
++
+     def _maintain_float32_expert_bias(self):
+         """
+         Maintain the expert bias in float32.
+diff --git a/megatron/core/transformer/multi_token_prediction.py b/megatron/core/transformer/multi_token_prediction.py
+index a8f4abfcd..f33f6f05e 100755
+--- a/megatron/core/transformer/multi_token_prediction.py
++++ b/megatron/core/transformer/multi_token_prediction.py
+@@ -6,6 +6,7 @@ from typing import Callable, List, Optional, Union
+ 
+ import torch
+ from torch import Tensor
++import warnings
+ 
+ from megatron.core import InferenceParams, parallel_state, tensor_parallel
+ from megatron.core.dist_checkpointing.mapping import ShardedStateDict
+@@ -714,17 +715,19 @@ class MultiTokenPredictionLayer(MegatronModule):
+             cp_group=self.cp_group,
+             packed_seq_params=packed_seq_params,
+         )
+-        position_ids, _ = roll_tensor(
+-            position_ids,
+-            shifts=-1,
+-            dims=-1,
+-            cp_group=self.cp_group,
+-            packed_seq_params=packed_seq_params,
+-        )
++        if position_ids is not None:
++            position_ids, _ = roll_tensor(
++                position_ids,
++                shifts=-1,
++                dims=-1,
++                cp_group=self.cp_group,
++                packed_seq_params=packed_seq_params,
++            )
+         # embedding
+         decoder_input = embedding(input_ids=input_ids, position_ids=position_ids)
++        decoder_input = decoder_input.detach()
+ 
+-        hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=True)
++        hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=False)
+ 
+         return input_ids, position_ids, decoder_input, hidden_states
+ 
+@@ -826,6 +829,51 @@ class MultiTokenPredictionLayer(MegatronModule):
+         return hidden_states
+ 
+     def _checkpointed_forward(self, forward_func, *args, **kwargs):
++        """Wrap `forward_func` with activation checkpointing while only passing tensors.
++
++        Non-tensor arguments (e.g., configuration objects, None) are captured via closure so
++        that checkpoint implementations never receive them directly, avoiding save_for_backward
++        issues with non-tensor inputs.
++        """
++
++        # TODO(jiajun): Is there any better implementation here?
++        positional_specs = []
++        kw_specs = []
++        tensor_args: List[torch.Tensor] = []
++
++        for arg in args:
++            if torch.is_tensor(arg):
++                positional_specs.append(('tensor', len(tensor_args)))
++                tensor_args.append(arg)
++            else:
++                positional_specs.append(('const', arg))
++
++        for key, value in kwargs.items():
++            if torch.is_tensor(value):
++                kw_specs.append((key, ('tensor', len(tensor_args))))
++                tensor_args.append(value)
++            else:
++                kw_specs.append((key, ('const', value)))
++
++        def run(*flat_tensor_args):
++            rebuilt_args = []
++            for spec_type, payload in positional_specs:
++                if spec_type == 'tensor':
++                    rebuilt_args.append(flat_tensor_args[payload])
++                else:
++                    rebuilt_args.append(payload)
++
++            rebuilt_kwargs = {}
++            for key, (spec_type, payload) in kw_specs:
++                if spec_type == 'tensor':
++                    rebuilt_kwargs[key] = flat_tensor_args[payload]
++                else:
++                    rebuilt_kwargs[key] = payload
++
++            return forward_func(*rebuilt_args, **rebuilt_kwargs)
++
++        tensor_args_tuple = tuple(tensor_args)
++
+         def checkpoint_handler():
+             """Determines whether to use the `te_checkpoint` or `tensor_parallel.checkpoint`"""
+             if self.config.fp8:
+@@ -836,12 +884,11 @@ class MultiTokenPredictionLayer(MegatronModule):
+                     self.config.distribute_saved_activations,
+                     tensor_parallel.random.get_cuda_rng_tracker,
+                     parallel_state.get_tensor_model_parallel_group(),
+-                    *args,
+-                    **kwargs,
++                    *tensor_args_tuple,
+                 )
+             else:
+                 return tensor_parallel.checkpoint(
+-                    forward_func, self.config.distribute_saved_activations, *args, *kwargs.values()
++                    run, self.config.distribute_saved_activations, *tensor_args_tuple
+                 )
+ 
+         if self.config.recompute_method == 'uniform':
+diff --git a/megatron/core/transformer/transformer_config.py b/megatron/core/transformer/transformer_config.py
+index e2705bd9f..a0aa109b5 100644
+--- a/megatron/core/transformer/transformer_config.py
++++ b/megatron/core/transformer/transformer_config.py
+@@ -210,6 +210,9 @@ class TransformerConfig(ModelParallelConfig):
+     attention_output_gate: bool = False
+     """Whether to apply output gate to the attention layers."""
+ 
++    post_self_attn_layernorm: bool = False
++    post_mlp_layernorm: bool = False
++
+     test_mode: bool = False
+     """Whether to run real-time tests."""
+ 
+diff --git a/megatron/core/transformer/transformer_layer.py b/megatron/core/transformer/transformer_layer.py
+index 3ea405770..5a42001b9 100644
+--- a/megatron/core/transformer/transformer_layer.py
++++ b/megatron/core/transformer/transformer_layer.py
+@@ -223,6 +223,7 @@ class TransformerLayerSubmodules:
+     input_layernorm: Union[ModuleSpec, type] = IdentityOp
+     self_attention: Union[ModuleSpec, type] = IdentityOp
+     self_attn_bda: Union[ModuleSpec, type] = IdentityFuncOp
++    post_self_attn_layernorm: Union[ModuleSpec, type] = IdentityOp
+ 
+     pre_cross_attn_layernorm: Union[ModuleSpec, type] = IdentityOp
+     cross_attention: Union[ModuleSpec, type] = IdentityOp
+@@ -231,6 +232,7 @@ class TransformerLayerSubmodules:
+     pre_mlp_layernorm: Union[ModuleSpec, type] = IdentityOp
+     mlp: Union[ModuleSpec, type] = IdentityOp
+     mlp_bda: Union[ModuleSpec, type] = IdentityFuncOp
++    post_mlp_layernorm: Union[ModuleSpec, type] = IdentityOp
+ 
+     # Mapping for sharded tensor keys to be applied in `sharded_state_dict` method
+     sharded_state_dict_keys_map: Dict[str, str] = field(default_factory=dict)
+@@ -310,6 +312,13 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
+         # [Module 3: BiasDropoutFusion]
+         self.self_attn_bda = build_module(submodules.self_attn_bda)
+ 
++        self.post_self_attn_layernorm = build_module(
++            submodules.post_self_attn_layernorm,
++            config=self.config,
++            hidden_size=self.config.hidden_size,
++            eps=self.config.layernorm_epsilon,
++        )
++
+         # [Module 4: Post SelfAttention] Optional Layernorm after self-attn
+         self.pre_cross_attn_layernorm = build_module(
+             submodules.pre_cross_attn_layernorm,
+@@ -375,6 +384,13 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
+ 
+         self.is_moe_layer = isinstance(self.mlp, MoELayer)
+ 
++        self.post_mlp_layernorm = build_module(
++            submodules.post_mlp_layernorm,
++            config=self.config,
++            hidden_size=self.config.hidden_size,
++            eps=self.config.layernorm_epsilon
++        )
++
+         self.recompute_input_layernorm = False
+         self.recompute_pre_mlp_layernorm = False
+         self.recompute_mlp = False
+@@ -551,6 +567,10 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
+                 attention_output_with_bias[0]
+             )
+ 
++        attention_output, attention_output_bias = attention_output_with_bias
++        attention_output = self.post_self_attn_layernorm(attention_output)
++        attention_output_with_bias = (attention_output, attention_output_bias)
++
+         # TODO: could we move `bias_dropout_add_exec_handler` itself
+         # inside the module provided in the `bias_dropout_add_spec` module?
+         nvtx_range_push(suffix="self_attn_bda")
+@@ -677,6 +697,10 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
+         else:
+             mlp_output_with_bias = self.mlp(pre_mlp_layernorm_output)
+ 
++        mlp_output, mlp_output_bias = mlp_output_with_bias
++        mlp_output = self.post_mlp_layernorm(mlp_output)
++        mlp_output_with_bias = (mlp_output, mlp_output_bias)
++
+         if self.recompute_pre_mlp_layernorm:
+             # discard the output of the pre-mlp layernorm and register the recompute
+             # as a gradient hook of mlp_output_with_bias[0]
+diff --git a/megatron/training/arguments.py b/megatron/training/arguments.py
+index b267c8a81..83736acdc 100644
+--- a/megatron/training/arguments.py
++++ b/megatron/training/arguments.py
+@@ -1398,6 +1398,9 @@ def core_transformer_config_from_args(args, config_class=None):
+ 
+     kw_args['inference_sampling_seed'] = args.seed
+ 
++    kw_args['post_self_attn_layernorm'] = args.post_self_attn_layernorm
++    kw_args['post_mlp_layernorm'] = args.post_mlp_layernorm
++
+     # handle quantization config
+     # NOTE: Kitchen arguments are only added to the namespace when
+     # Kitchen library is available.
+@@ -1764,6 +1767,12 @@ def _add_network_size_args(parser):
+                        action='store_true',
+                        help='If set, use original BERT residula connection '
+                        'ordering.')
++    group.add_argument('--post-self-attn-layernorm', action='store_true',
++                       help='If set, use post self attention layernorm.')
++    group.add_argument('--post-mlp-layernorm', action='store_true',
++                       help='If set, use post MLP layernorm.')
++    group.add_argument('--use-gated-attention', action='store_true',
++                       help='If set, use gated attention as in Qwen3Next')
+     group.add_argument('--openai-gelu', action='store_true',
+                        help='Use OpenAIs GeLU implementation. This option'
+                        'should not be used unless for backward compatibility'
+diff --git a/megatron/training/tokenizer/tokenizer.py b/megatron/training/tokenizer/tokenizer.py
+index 13b7526ca..6c590f653 100644
+--- a/megatron/training/tokenizer/tokenizer.py
++++ b/megatron/training/tokenizer/tokenizer.py
+@@ -136,7 +136,7 @@ class _HuggingFaceTokenizer(MegatronLegacyTokenizer):
+         # TODO(bnorick): download tokenizer once to lustre and use force offline to make sure all tasks read it from there
+         self._tokenizer = transformers.AutoTokenizer.from_pretrained(
+             pretrained_model_name_or_path=pretrained_model_name_or_path,
+-            trust_remote_code=trust_remote_code,
++            trust_remote_code=True,
+             **kwargs,
+         )
+         self._vocab = self._tokenizer.get_vocab()

--- a/docker/npu_patch/megatron-bridge.patch
+++ b/docker/npu_patch/megatron-bridge.patch
@@ -1,0 +1,300 @@
+diff --git a/src/megatron/bridge/models/conversion/param_mapping.py b/src/megatron/bridge/models/conversion/param_mapping.py
+index a0421273..7f9203ab 100644
+--- a/src/megatron/bridge/models/conversion/param_mapping.py
++++ b/src/megatron/bridge/models/conversion/param_mapping.py
+@@ -1097,15 +1097,19 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
+             "LinearCrossEntropyModule",
+             "TEColumnParallelLinear",
+             "TELayerNormColumnParallelLinear",
++            "MindSpeedTELayerNormColumnParallelLinear",
+             "TEColumnParallelGroupedLinear",
++            "MindSpeedTEColumnParallelGroupedLinear",
+             "VocabParallelEmbedding",
+             "DotProductAttention",  # for attention sink only
+             "TEDotProductAttention",  # for attention sink only
++            "MindSpeedTEDotProductAttention",
+         },
+         "row": {
+             "RowParallelLinear",
+             "TERowParallelLinear",
+             "TERowParallelGroupedLinear",
++            "MindSpeedTERowParallelGroupedLinear",
+         },
+         "replicated": {
+             # Normalization layers
+@@ -1176,7 +1180,7 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
+         # Handle fused modules like TELayerNormColumnParallelLinear
+         # These modules have both column-parallel weights (weight, bias)
+         # and replicated layer norm weights (layer_norm_weight, layer_norm_bias)
+-        if module_type == "TELayerNormColumnParallelLinear":
++        if module_type == "TELayerNormColumnParallelLinear" or module_type == "MindSpeedTELayerNormColumnParallelLinear":
+             # Check the actual parameter name to determine the correct parallelism type
+             if self.megatron_param and (
+                 self.megatron_param.endswith("layer_norm_weight") or self.megatron_param.endswith("layer_norm_bias")
+@@ -1207,7 +1211,7 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
+             return "replicated"
+ 
+         # Check parallel_mode for TELinear
+-        if module_type == "TELinear":
++        if module_type == "TELinear" or module_type == "MindSpeedTELinear":
+             if module.parallel_mode == "column":
+                 return "column"
+             elif module.parallel_mode == "row":
+diff --git a/src/megatron/bridge/models/qwen/__init__.py b/src/megatron/bridge/models/qwen/__init__.py
+index b3656b6d..382845cc 100644
+--- a/src/megatron/bridge/models/qwen/__init__.py
++++ b/src/megatron/bridge/models/qwen/__init__.py
+@@ -15,7 +15,7 @@
+ from megatron.bridge.models.qwen.qwen2_bridge import Qwen2Bridge  # noqa: F401
+ from megatron.bridge.models.qwen.qwen3_bridge import Qwen3Bridge  # noqa: F401
+ from megatron.bridge.models.qwen.qwen3_moe_bridge import Qwen3MoEBridge  # noqa: F401
+-from megatron.bridge.models.qwen.qwen3_next_bridge import Qwen3NextBridge
++# from megatron.bridge.models.qwen.qwen3_next_bridge import Qwen3NextBridge
+ from megatron.bridge.models.qwen.qwen_provider import (
+     Qwen2ModelProvider,
+     Qwen2ModelProvider1P5B,
+@@ -32,8 +32,8 @@ from megatron.bridge.models.qwen.qwen_provider import (
+     Qwen3MoEModelProvider,
+     Qwen3MoEModelProvider30B_A3B,
+     Qwen3MoEModelProvider235B_A22B,
+-    Qwen3NextModelProvider,
+-    Qwen3NextModelProvider80B_A3B,
++    # Qwen3NextModelProvider,
++    # Qwen3NextModelProvider80B_A3B,
+     Qwen25ModelProvider1P5B,
+     Qwen25ModelProvider3B,
+     Qwen25ModelProvider7B,
+@@ -67,6 +67,6 @@ __all__ = [
+     "Qwen3MoEModelProvider",
+     "Qwen3MoEModelProvider30B_A3B",
+     "Qwen3MoEModelProvider235B_A22B",
+-    "Qwen3NextModelProvider",
+-    "Qwen3NextModelProvider80B_A3B",
++    # "Qwen3NextModelProvider",
++    # "Qwen3NextModelProvider80B_A3B",
+ ]
+diff --git a/src/megatron/bridge/models/qwen/qwen_provider.py b/src/megatron/bridge/models/qwen/qwen_provider.py
+index 775b9765..6200103c 100644
+--- a/src/megatron/bridge/models/qwen/qwen_provider.py
++++ b/src/megatron/bridge/models/qwen/qwen_provider.py
+@@ -18,9 +18,9 @@ from typing import TYPE_CHECKING, Callable, Optional
+ 
+ import torch
+ import torch.nn.functional as F
+-from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
+-    get_transformer_block_with_experimental_attention_variant_spec,
+-)
++# from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
++#     get_transformer_block_with_experimental_attention_variant_spec,
++# )
+ from megatron.core.transformer.spec_utils import ModuleSpec
+ 
+ from megatron.bridge.models.gpt_provider import GPTModelProvider
+@@ -430,53 +430,53 @@ class Qwen3MoEModelProvider235B_A22B(Qwen3MoEModelProvider):
+ # =============================================================================
+ 
+ 
+-@dataclass
+-class Qwen3NextModelProvider(Qwen3MoEModelProvider):
+-    """Base provider for Qwen 3 Next Models."""
+-
+-    transformer_layer_spec: ModuleSpec | Callable[["GPTModelProvider"], ModuleSpec] = (
+-        get_transformer_block_with_experimental_attention_variant_spec
+-    )
+-
+-    layernorm_zero_centered_gamma: bool = True  # Zero-centered RMSNorm
+-    kv_channels: int | None = 256
+-    num_query_groups: int = 2
+-    seq_length: int = 262144  # 256k tokens
+-    rotary_base: float = 10000000.0
+-    rotary_percent: float = 0.25  # 25% of the hidden size is used for RoPE
+-    attention_output_gate: bool = True  # Gated Attention
+-
+-    # MoE specific parameters
+-    num_moe_experts: int = 512
+-    moe_router_topk: int = 10  # 10 routed experts per token
+-    moe_shared_expert_gate: bool = True  # Qwen3-Next uses a gate for the shared expert
+-    moe_router_dtype: str = "fp32"
+-    moe_router_load_balancing_type: str = "global_aux_loss"  # Qwen3-Next uses global aux loss for load balancing
+-
+-    # Linear Attention specific parameters
+-    experimental_attention_variant: str = "gated_delta_net"  # Gated Delta Net used in 75% of the model layers
+-    linear_attention_freq: int | list[int] = 4  # 1 gated standard attention layer per 4 layers
+-    linear_conv_kernel_dim: int = 4
+-    linear_key_head_dim: int = 128
+-    linear_value_head_dim: int = 128
+-    linear_num_key_heads: int = 16
+-    linear_num_value_heads: int = 32
+-
+-    # Checkpointing
+-    hetereogenous_dist_checkpoint: bool = True
+-
+-
+-@dataclass
+-class Qwen3NextModelProvider80B_A3B(Qwen3NextModelProvider):
+-    """
+-    Provider for Qwen 3 Next 80B-A3B: https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct and https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Thinking
+-    """
+-
+-    num_layers: int = 48
+-    hidden_size: int = 2048
+-    num_attention_heads: int = 16
+-    num_query_groups: int = 2
+-    ffn_hidden_size: int = 5120
+-    moe_ffn_hidden_size: int = 512
+-    moe_shared_expert_intermediate_size: int = 512
+-    mtp_num_layers: Optional[int] = None
++# @dataclass
++# class Qwen3NextModelProvider(Qwen3MoEModelProvider):
++#     """Base provider for Qwen 3 Next Models."""
++
++#     transformer_layer_spec: ModuleSpec | Callable[["GPTModelProvider"], ModuleSpec] = (
++#         get_transformer_block_with_experimental_attention_variant_spec
++#     )
++
++#     layernorm_zero_centered_gamma: bool = True  # Zero-centered RMSNorm
++#     kv_channels: int | None = 256
++#     num_query_groups: int = 2
++#     seq_length: int = 262144  # 256k tokens
++#     rotary_base: float = 10000000.0
++#     rotary_percent: float = 0.25  # 25% of the hidden size is used for RoPE
++#     attention_output_gate: bool = True  # Gated Attention
++
++#     # MoE specific parameters
++#     num_moe_experts: int = 512
++#     moe_router_topk: int = 10  # 10 routed experts per token
++#     moe_shared_expert_gate: bool = True  # Qwen3-Next uses a gate for the shared expert
++#     moe_router_dtype: str = "fp32"
++#     moe_router_load_balancing_type: str = "global_aux_loss"  # Qwen3-Next uses global aux loss for load balancing
++
++#     # Linear Attention specific parameters
++#     experimental_attention_variant: str = "gated_delta_net"  # Gated Delta Net used in 75% of the model layers
++#     linear_attention_freq: int | list[int] = 4  # 1 gated standard attention layer per 4 layers
++#     linear_conv_kernel_dim: int = 4
++#     linear_key_head_dim: int = 128
++#     linear_value_head_dim: int = 128
++#     linear_num_key_heads: int = 16
++#     linear_num_value_heads: int = 32
++
++#     # Checkpointing
++#     hetereogenous_dist_checkpoint: bool = True
++
++
++# @dataclass
++# class Qwen3NextModelProvider80B_A3B(Qwen3NextModelProvider):
++#     """
++#     Provider for Qwen 3 Next 80B-A3B: https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct and https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Thinking
++#     """
++
++#     num_layers: int = 48
++#     hidden_size: int = 2048
++#     num_attention_heads: int = 16
++#     num_query_groups: int = 2
++#     ffn_hidden_size: int = 5120
++#     moe_ffn_hidden_size: int = 512
++#     moe_shared_expert_intermediate_size: int = 512
++#     mtp_num_layers: Optional[int] = None
+diff --git a/src/megatron/bridge/models/qwen_vl/qwen35_vl_provider.py b/src/megatron/bridge/models/qwen_vl/qwen35_vl_provider.py
+index 6c74827c..75973903 100644
+--- a/src/megatron/bridge/models/qwen_vl/qwen35_vl_provider.py
++++ b/src/megatron/bridge/models/qwen_vl/qwen35_vl_provider.py
+@@ -36,9 +36,9 @@ from typing import Any, Callable, List, Optional
+ 
+ import transformers
+ from megatron.core.models.gpt import GPTModel as MCoreGPTModel
+-from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
+-    get_transformer_block_with_experimental_attention_variant_spec,
+-)
++# from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
++#     get_transformer_block_with_experimental_attention_variant_spec,
++# )
+ from megatron.core.transformer.spec_utils import ModuleSpec
+ from megatron.core.transformer.transformer_block import TransformerBlockSubmodules
+ from packaging.version import Version as PkgVersion
+@@ -105,9 +105,10 @@ class Qwen35VLModelProvider(GPTModelProvider):
+     # =========================================================================
+     # Hybrid Architecture (Qwen3-Next style)
+     # =========================================================================
+-    transformer_layer_spec: ModuleSpec | Callable[["GPTModelProvider"], ModuleSpec] = (
+-        get_transformer_block_with_experimental_attention_variant_spec
+-    )
++    # transformer_layer_spec: ModuleSpec | Callable[["GPTModelProvider"], ModuleSpec] = (
++    #     get_transformer_block_with_experimental_attention_variant_spec
++    # )
++    transformer_layer_spec: ModuleSpec = None
+     layernorm_zero_centered_gamma: bool = True
+     attention_output_gate: bool = True
+     experimental_attention_variant: str = "gated_delta_net"
+@@ -261,9 +262,10 @@ class Qwen35VLMoEModelProvider(GPTModelProvider):
+     # =========================================================================
+     # Hybrid Architecture (Qwen3-Next style)
+     # =========================================================================
+-    transformer_layer_spec: ModuleSpec | Callable[["GPTModelProvider"], ModuleSpec] = (
+-        get_transformer_block_with_experimental_attention_variant_spec
+-    )
++    # transformer_layer_spec: ModuleSpec | Callable[["GPTModelProvider"], ModuleSpec] = (
++    #     get_transformer_block_with_experimental_attention_variant_spec
++    # )
++    transformer_layer_spec: ModuleSpec = None
+     layernorm_zero_centered_gamma: bool = True
+     attention_output_gate: bool = True
+     experimental_attention_variant: str = "gated_delta_net"
+diff --git a/src/megatron/bridge/models/transformer_config.py b/src/megatron/bridge/models/transformer_config.py
+index 618700ed..3133f4ea 100644
+--- a/src/megatron/bridge/models/transformer_config.py
++++ b/src/megatron/bridge/models/transformer_config.py
+@@ -47,6 +47,10 @@ def _safe_asdict(obj, skip_keys: set[str]) -> dict:
+         return obj.__class__((_safe_asdict(k, skip_keys), _safe_asdict(v, skip_keys)) for k, v in obj.items())
+     return obj
+ 
++from dataclasses import dataclass, field
++
++class MyConfig:
++    pass
+ 
+ @dataclass
+ class TransformerConfig(MCoreTransformerConfig):
+@@ -70,6 +74,13 @@ class TransformerConfig(MCoreTransformerConfig):
+     """
+ 
+     _NO_COPY_KEYS = {"_pg_collection"}
++    # vllm_eplb_config: MyConfig = field(default_factory=MyConfig)
++    # vllm_ir_op_priority: MyConfig = field(default_factory=MyConfig)
++    # vllm_kernel_config: MyConfig = field(default_factory=MyConfig)
++    # vllm_profiler_config: MyConfig = field(default_factory=MyConfig)
++    # vllm_structured_outputs_config: MyConfig = field(default_factory=MyConfig)
++    # vllm_compilation_config: MyConfig = field(default_factory=MyConfig)
++    # vllm_attention_config: MyConfig = field(default_factory=MyConfig)
+ 
+     def __post_init__(self) -> None:
+         """Skip MCore post_init during initial construction.
+diff --git a/src/megatron/bridge/peft/utils.py b/src/megatron/bridge/peft/utils.py
+index 1ca5b18b..3d8ec12a 100644
+--- a/src/megatron/bridge/peft/utils.py
++++ b/src/megatron/bridge/peft/utils.py
+@@ -62,7 +62,7 @@ HAVE_TE = all(
+     )
+ )
+ 
+-MixedFusedLayerNorm, HAVE_APEX = safe_import_from("apex.normalization.fused_layer_norm", "MixedFusedLayerNorm")
++# MixedFusedLayerNorm, HAVE_APEX = safe_import_from("apex.normalization.fused_layer_norm", "MixedFusedLayerNorm")
+ 
+ TECL = (TEColumnParallelLinear, TELayerNormColumnParallelLinear, TEColumnParallelGroupedLinear)
+ TERL = (TERowParallelLinear, TERowParallelGroupedLinear)
+diff --git a/src/megatron/bridge/training/mlm_compat/model.py b/src/megatron/bridge/training/mlm_compat/model.py
+index 60cc091c..1dd5c808 100644
+--- a/src/megatron/bridge/training/mlm_compat/model.py
++++ b/src/megatron/bridge/training/mlm_compat/model.py
+@@ -21,9 +21,9 @@ from megatron.core import tensor_parallel
+ from megatron.core.enums import ModelType
+ from megatron.core.fp8_utils import correct_amax_history_if_needed
+ from megatron.core.models.gpt import GPTModel
+-from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
+-    get_transformer_block_with_experimental_attention_variant_spec,
+-)
++# from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
++#     get_transformer_block_with_experimental_attention_variant_spec,
++# )
+ from megatron.core.models.gpt.gpt_layer_specs import (
+     get_gpt_decoder_block_spec,
+     get_gpt_layer_local_spec,

--- a/docker/npu_patch/megatron.patch
+++ b/docker/npu_patch/megatron.patch
@@ -1,0 +1,537 @@
+diff --git a/megatron/core/activations.py b/megatron/core/activations.py
+index 8b422d73a..58fba4667 100644
+--- a/megatron/core/activations.py
++++ b/megatron/core/activations.py
+@@ -5,19 +5,19 @@ import torch.nn.functional as F
+ from megatron.core.jit import jit_fuser
+ 
+ 
+-@jit_fuser
++
+ def squared_relu(x: torch.Tensor) -> torch.Tensor:
+     """Squared ReLU activation"""
+     return torch.pow(F.relu(x), 2)
+ 
+ 
+-@jit_fuser
++
+ def quick_gelu(x: torch.Tensor) -> torch.Tensor:
+     """Quick GELU activation"""
+     return x * torch.sigmoid(1.702 * x)
+ 
+ 
+-@jit_fuser
++
+ def fast_gelu(x: torch.Tensor) -> torch.Tensor:
+     """Fast GELU activation"""
+     return 0.5 * x * (1.0 + torch.tanh(x * 0.7978845608 * (1.0 + 0.044715 * x * x)))
+diff --git a/megatron/core/fusions/fused_bias_dropout.py b/megatron/core/fusions/fused_bias_dropout.py
+index 336452562..614ee1a48 100644
+--- a/megatron/core/fusions/fused_bias_dropout.py
++++ b/megatron/core/fusions/fused_bias_dropout.py
+@@ -64,14 +64,14 @@ def bias_dropout_add_unfused(training):
+     return _bias_dropout_add
+ 
+ 
+-@jit_fuser
++
+ def bias_dropout_add_fused_train(
+     x_with_bias: Tuple[torch.Tensor, Optional[torch.Tensor]], residual: torch.Tensor, prob: float
+ ) -> torch.Tensor:
+     return _bias_dropout_add_func(x_with_bias, residual, prob, True)
+ 
+ 
+-@jit_fuser
++
+ def bias_dropout_add_fused_inference(
+     x_with_bias: Tuple[torch.Tensor, Optional[torch.Tensor]], residual: torch.Tensor, prob: float
+ ) -> torch.Tensor:
+diff --git a/megatron/core/fusions/fused_bias_geglu.py b/megatron/core/fusions/fused_bias_geglu.py
+index 7a7fbe7f9..f9a438953 100644
+--- a/megatron/core/fusions/fused_bias_geglu.py
++++ b/megatron/core/fusions/fused_bias_geglu.py
+@@ -13,7 +13,7 @@ from megatron.core.jit import jit_fuser
+ # x * 0.5 * (1.0 + torch.erf(x * 0.70710678))
+ 
+ 
+-@jit_fuser
++
+ def geglu(y):
+     """Performs GEGLU (GELU-Gated Linear Unit) activation.
+ 
+@@ -27,7 +27,7 @@ def geglu(y):
+     return (y_1 * 0.5 * (1.0 + torch.tanh(0.79788456 * y_1 * (1 + 0.044715 * y_1 * y_1)))) * y_2
+ 
+ 
+-@jit_fuser
++
+ def bias_geglu(bias, y):
+     """Performs GEGLU activation with bias addition.
+ 
+@@ -45,7 +45,7 @@ def bias_geglu(bias, y):
+ # gradient of tanh approximation of gelu
+ # gradient of actual gelu is:
+ # 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
+-@jit_fuser
++
+ def geglu_back(g, y):
+     """Computes the gradient for the GEGLU activation.
+ 
+@@ -65,7 +65,7 @@ def geglu_back(g, y):
+     return torch.cat(((g * y_2) * ff, g * (y_1 * 0.5 * (1.0 + tanh_out))), -1)
+ 
+ 
+-@jit_fuser
++
+ def bias_geglu_back(g, y, bias):
+     """Computes the gradient for the biased GEGLU activation.
+ 
+@@ -181,13 +181,13 @@ def bias_geglu_impl(input, bias):
+ # ------------------------- QUICK GEGLU FUSION --------------------------
+ 
+ 
+-@jit_fuser
++
+ def quick_gelu(y: torch.Tensor) -> torch.Tensor:
+     """Sigmoid approximation of gelu"""
+     return y * torch.sigmoid(1.702 * y)
+ 
+ 
+-@jit_fuser
++
+ def quick_geglu(y: torch.Tensor, linear_offset: float = 0.0) -> torch.Tensor:
+     """Performs Quick-GELU-based GEGLU activation : quick_gelu(y1) * (y2 + offset).
+ 
+@@ -202,7 +202,7 @@ def quick_geglu(y: torch.Tensor, linear_offset: float = 0.0) -> torch.Tensor:
+     return quick_gelu(y_1) * (y_2 + linear_offset)
+ 
+ 
+-@jit_fuser
++
+ def weighted_quick_geglu(
+     y: torch.Tensor, weights: torch.Tensor, linear_offset: float = 0.0
+ ) -> torch.Tensor:
+@@ -217,7 +217,7 @@ def weighted_quick_geglu(
+ 
+ 
+ # gradient of sigmoid approximation of gelu
+-@jit_fuser
++
+ def quick_geglu_back(g, y, linear_offset: float = 0.0) -> torch.Tensor:
+     """Backward helper for Quick-GEGLU.
+ 
+@@ -236,7 +236,7 @@ def quick_geglu_back(g, y, linear_offset: float = 0.0) -> torch.Tensor:
+     return torch.cat((dy_1, dy_2), -1)
+ 
+ 
+-@jit_fuser
++
+ def weighted_quick_geglu_back(g, y, weights, linear_offset: float = 0.0):
+     """Backward helper for weighted Quick-GEGLU.
+     Returns gradient w.r.t input `y` and `weights`.
+@@ -255,7 +255,7 @@ def weighted_quick_geglu_back(g, y, weights, linear_offset: float = 0.0):
+ # ---------------- Weighted Bias Quick-GEGLU helpers -----------------
+ 
+ 
+-@jit_fuser
++
+ def weighted_bias_quick_geglu(
+     y: torch.Tensor, bias: torch.Tensor, weights: torch.Tensor, linear_offset: float = 0.0
+ ) -> torch.Tensor:
+@@ -275,7 +275,7 @@ def weighted_bias_quick_geglu(
+     return res.to(dtype)
+ 
+ 
+-@jit_fuser
++
+ def weighted_bias_quick_geglu_back(g, y, bias, weights, linear_offset: float = 0.0):
+     """Backward helper for weighted Quick-GEGLU with bias.
+ 
+diff --git a/megatron/core/fusions/fused_bias_gelu.py b/megatron/core/fusions/fused_bias_gelu.py
+index 8cc90f617..fda8f2f5f 100644
+--- a/megatron/core/fusions/fused_bias_gelu.py
++++ b/megatron/core/fusions/fused_bias_gelu.py
+@@ -13,7 +13,7 @@ from megatron.core.jit import jit_fuser
+ # x * 0.5 * (1.0 + torch.erf(x * 0.70710678))
+ 
+ 
+-@jit_fuser
++
+ def bias_gelu(bias, y):
+     x = bias + y
+     return x * 0.5 * (1.0 + torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x)))
+@@ -22,7 +22,7 @@ def bias_gelu(bias, y):
+ # gradient of tanh approximation of gelu
+ # gradient of actual gelu is:
+ # 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
+-@jit_fuser
++
+ def bias_gelu_back(g, bias, y):
+     x = bias + y
+     tanh_out = torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x))
+diff --git a/megatron/core/fusions/fused_bias_swiglu.py b/megatron/core/fusions/fused_bias_swiglu.py
+index 632470876..105936786 100644
+--- a/megatron/core/fusions/fused_bias_swiglu.py
++++ b/megatron/core/fusions/fused_bias_swiglu.py
+@@ -12,7 +12,7 @@ from megatron.core.utils import nvtx_decorator
+ ###### BIAS SWIGLU FUSION/ NO AUTOGRAD ################
+ 
+ 
+-@jit_fuser
++
+ def swiglu(y):
+     """Performs SwiGLU (Swish-Gated Linear Unit) activation function.
+ 
+@@ -26,7 +26,7 @@ def swiglu(y):
+     return F.silu(y_1) * y_2
+ 
+ 
+-@jit_fuser
++
+ def bias_swiglu(y, bias):
+     """Performs SwiGLU activation with bias addition.
+ 
+@@ -41,7 +41,7 @@ def bias_swiglu(y, bias):
+     return swiglu(y)
+ 
+ 
+-@jit_fuser
++
+ def weighted_swiglu(y, weights):
+     dtype = y.dtype
+     res = swiglu(y) * weights
+@@ -51,7 +51,7 @@ def weighted_swiglu(y, weights):
+ # gradient of tanh approximation of gelu
+ # gradient of actual gelu is:
+ # 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
+-@jit_fuser
++
+ def swiglu_back(g, y):
+     """Computes the gradient for the SwiGLU activation function.
+ 
+@@ -69,7 +69,7 @@ def swiglu_back(g, y):
+     )
+ 
+ 
+-@jit_fuser
++
+ def bias_swiglu_back(g, y, bias):
+     """Computes the gradient for the biased SwiGLU activation function.
+ 
+@@ -86,7 +86,7 @@ def bias_swiglu_back(g, y, bias):
+     return swiglu_back(g, y)
+ 
+ 
+-@jit_fuser
++
+ def weighted_swiglu_back(g, y, weights):
+     input_dtype = y.dtype
+     w_dtype = weights.dtype
+diff --git a/megatron/core/fusions/fused_cross_entropy.py b/megatron/core/fusions/fused_cross_entropy.py
+index 23e4b6031..4d447e0e0 100644
+--- a/megatron/core/fusions/fused_cross_entropy.py
++++ b/megatron/core/fusions/fused_cross_entropy.py
+@@ -9,7 +9,7 @@ from megatron.core.tensor_parallel.cross_entropy import VocabParallelCrossEntrop
+ from megatron.core.tensor_parallel.utils import VocabUtility
+ 
+ 
+-@jit_fuser
++
+ def calculate_logits_max(vocab_parallel_logits: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+     """
+     Calculates the maximum logits of the predicted tokens.
+@@ -22,7 +22,7 @@ def calculate_logits_max(vocab_parallel_logits: torch.Tensor) -> Tuple[torch.Ten
+     return vocab_parallel_logits, logits_max
+ 
+ 
+-@jit_fuser
++
+ def calculate_predicted_logits(
+     vocab_parallel_logits: torch.Tensor,
+     target: torch.Tensor,
+@@ -44,7 +44,7 @@ def calculate_predicted_logits(
+     return target_mask, masked_target_1d, predicted_logits_sum_exp_logits, exp_logits
+ 
+ 
+-@jit_fuser
++
+ def calculate_cross_entropy_loss(
+     exp_logits: torch.Tensor, predicted_logits_sum_exp_logits: torch.Tensor
+ ) -> Tuple[torch.Tensor, torch.Tensor]:
+@@ -61,7 +61,7 @@ def calculate_cross_entropy_loss(
+     return exp_logits, loss
+ 
+ 
+-@jit_fuser
++
+ def calculate_gradients(
+     softmax: torch.Tensor,
+     grad_output: torch.Tensor,
+diff --git a/megatron/core/fusions/fused_pad_routing_map.py b/megatron/core/fusions/fused_pad_routing_map.py
+index c382178b6..563279edd 100644
+--- a/megatron/core/fusions/fused_pad_routing_map.py
++++ b/megatron/core/fusions/fused_pad_routing_map.py
+@@ -70,7 +70,7 @@ def _pad_routing_map_kernel(
+     tl.store(output_row_ptr + token_indices, output_row, mask=token_mask)
+ 
+ 
+-@jit_fuser
++
+ def fused_pad_routing_map(routing_map: torch.Tensor, pad_multiple: int) -> torch.Tensor:
+     """Fused version of pad_routing_map.
+     Args:
+diff --git a/megatron/core/fusions/fused_weighted_squared_relu.py b/megatron/core/fusions/fused_weighted_squared_relu.py
+index 02dabc14c..137022386 100644
+--- a/megatron/core/fusions/fused_weighted_squared_relu.py
++++ b/megatron/core/fusions/fused_weighted_squared_relu.py
+@@ -10,7 +10,7 @@ from megatron.core.utils import nvtx_decorator
+ ######################  WEIGHTED SQUARED ReLU FUSION  ######################
+ 
+ 
+-@jit_fuser
++
+ def weighted_squared_relu(x: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
+     """Element-wise weight applied after Squared-ReLU.
+ 
+@@ -28,7 +28,7 @@ def weighted_squared_relu(x: torch.Tensor, weights: torch.Tensor) -> torch.Tenso
+     return res.to(out_dtype)
+ 
+ 
+-@jit_fuser
++
+ def _squared_relu_back(g: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+     """Gradient of Squared-ReLU.
+ 
+@@ -37,7 +37,7 @@ def _squared_relu_back(g: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+     return g * 2 * F.relu(x)
+ 
+ 
+-@jit_fuser
++
+ def weighted_squared_relu_back(g: torch.Tensor, x: torch.Tensor, weights: torch.Tensor):
+     """Backward for weighted Squared-ReLU.
+ 
+diff --git a/megatron/core/models/gpt/gpt_layer_specs.py b/megatron/core/models/gpt/gpt_layer_specs.py
+index 712793853..76ea4333b 100755
+--- a/megatron/core/models/gpt/gpt_layer_specs.py
++++ b/megatron/core/models/gpt/gpt_layer_specs.py
+@@ -219,7 +219,7 @@ def get_gpt_layer_with_transformer_engine_spec(
+             'The fp8 argument in "get_gpt_layer_with_transformer_engine_spec" has been deprecated'
+             " and will be removed soon. Please update your code accordingly."
+         )
+-
++    from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
+     if use_kitchen:
+         assert HAVE_KITCHEN
+         backend: BackendSpecProvider = KitchenSpecProvider(
+diff --git a/megatron/core/ssm/gated_delta_net.py b/megatron/core/ssm/gated_delta_net.py
+index dfa6e4c35..8b3621819 100644
+--- a/megatron/core/ssm/gated_delta_net.py
++++ b/megatron/core/ssm/gated_delta_net.py
+@@ -413,7 +413,7 @@ class GatedDeltaNet(MegatronModule):
+ 
+         return out, out_bias
+ 
+-    @jit_fuser
++    
+     def _apply_gated_norm(self, x, gate):
+         # Output Norm
+         x_dtype = x.dtype
+diff --git a/megatron/core/transformer/attention.py b/megatron/core/transformer/attention.py
+index 80e9ec6fc..b6bcef6a9 100644
+--- a/megatron/core/transformer/attention.py
++++ b/megatron/core/transformer/attention.py
+@@ -1026,7 +1026,7 @@ class Attention(MegatronModule, ABC):
+ 
+         return output, bias
+ 
+-    @jit_fuser
++    
+     def _apply_output_gate(self, x, gate):
+         x_dtype = x.dtype
+         gate = gate.contiguous()
+diff --git a/megatron/core/transformer/module.py b/megatron/core/transformer/module.py
+index 2330df91b..0446c9097 100644
+--- a/megatron/core/transformer/module.py
++++ b/megatron/core/transformer/module.py
+@@ -16,9 +16,9 @@ from megatron.core.transformer.utils import (
+     sharded_state_dict_default,
+ )
+ 
+-_FLOAT_TYPES = (torch.FloatTensor, torch.cuda.FloatTensor)
+-_HALF_TYPES = (torch.HalfTensor, torch.cuda.HalfTensor)
+-_BF16_TYPES = (torch.BFloat16Tensor, torch.cuda.BFloat16Tensor)
++_FLOAT_TYPES = (torch.FloatTensor, torch.cuda.FloatTensor, torch.npu.FloatTensor)
++_HALF_TYPES = (torch.HalfTensor, torch.cuda.HalfTensor, torch.npu.HalfTensor)
++_BF16_TYPES = (torch.BFloat16Tensor, torch.cuda.BFloat16Tensor, torch.npu.BFloat16Tensor)
+ 
+ 
+ def param_is_not_shared(param):  # pylint: disable=missing-function-docstring
+diff --git a/megatron/core/transformer/moe/experts.py b/megatron/core/transformer/moe/experts.py
+index 5eeafdd8d..a4dce6970 100644
+--- a/megatron/core/transformer/moe/experts.py
++++ b/megatron/core/transformer/moe/experts.py
+@@ -91,7 +91,7 @@ class GroupedMLP(MegatronModule):
+             if self.config.activation_func not in (F.silu, F.gelu):
+                 raise ValueError("Activation function must be silu or gelu when using GroupedMLP.")
+ 
+-            @jit_fuser
++            
+             def glu(x):
+                 x = torch.chunk(x, 2, dim=-1)
+                 return self.config.activation_func(x[0]) * x[1]
+@@ -108,7 +108,7 @@ class GroupedMLP(MegatronModule):
+                 "moe_act recompute for fp8 or fp4 cannot work with the legacy GroupedMLP."
+             )
+ 
+-        @jit_fuser
++        
+         def activation_func_with_probs(x, probs):
+             dtype = x.dtype
+             res = self.activation_func(x) * probs
+diff --git a/megatron/core/transformer/moe/router.py b/megatron/core/transformer/moe/router.py
+index 517944f25..2c5bc0728 100644
+--- a/megatron/core/transformer/moe/router.py
++++ b/megatron/core/transformer/moe/router.py
+@@ -472,7 +472,7 @@ class TopKRouter(Router):
+         else:
+             return input
+ 
+-    @jit_fuser
++    
+     def _apply_expert_bias(self, routing_map: torch.Tensor):
+         """
+         Update expert bias and tokens_per_expert
+diff --git a/megatron/core/transformer/moe/token_dispatcher.py b/megatron/core/transformer/moe/token_dispatcher.py
+index d0da38d63..6d092c88f 100644
+--- a/megatron/core/transformer/moe/token_dispatcher.py
++++ b/megatron/core/transformer/moe/token_dispatcher.py
+@@ -1403,7 +1403,7 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
+         ).contiguous()
+         return routing_map, probs
+ 
+-    @jit_fuser
++    
+     def dispatch_preprocess(
+         self, hidden_states: torch.Tensor, routing_map: torch.Tensor, probs: torch.Tensor
+     ):
+diff --git a/megatron/core/transformer/torch_norm.py b/megatron/core/transformer/torch_norm.py
+index d0ceca7af..f16796680 100644
+--- a/megatron/core/transformer/torch_norm.py
++++ b/megatron/core/transformer/torch_norm.py
+@@ -69,7 +69,7 @@ class L2Norm(torch.nn.Module):
+         self.hidden_size = hidden_size
+         self.eps = eps
+ 
+-    @jit_fuser
++    
+     def _norm(self, x):
+         """
+         Performs the actual L2 normalization.
+diff --git a/megatron/core/transformer/utils.py b/megatron/core/transformer/utils.py
+index 880c53099..dbc95736e 100644
+--- a/megatron/core/transformer/utils.py
++++ b/megatron/core/transformer/utils.py
+@@ -51,7 +51,7 @@ def attention_mask_func(attention_scores, attention_mask):
+     return attention_scores
+ 
+ 
+-@jit_fuser
++
+ def gelu_impl(x):
+     """OpenAI's gelu implementation."""
+     return 0.5 * x * (1.0 + torch.tanh(0.7978845608028654 * x * (1.0 + 0.044715 * x * x)))
+@@ -65,7 +65,7 @@ def openai_gelu(x):
+ # This is actually Python equivalent of torch.nn.functional.gelu(), also with
+ # type hints for ONNX exporter
+ # pylint: disable=missing-function-docstring
+-@jit_fuser
++
+ def erf_gelu(x):
+     return (
+         x * 0.5 * (torch.erf(x / 1.41421).to(dtype=x.dtype) + torch.ones_like(x).to(dtype=x.dtype))
+diff --git a/megatron/legacy/model/fused_bias_gelu.py b/megatron/legacy/model/fused_bias_gelu.py
+index e00e63148..ffe4b7ec6 100644
+--- a/megatron/legacy/model/fused_bias_gelu.py
++++ b/megatron/legacy/model/fused_bias_gelu.py
+@@ -12,7 +12,7 @@ from megatron.core.jit import jit_fuser
+ # actual gelu is:
+ # x * 0.5 * (1.0 + torch.erf(x * 0.70710678))
+ 
+-@jit_fuser
++
+ def bias_gelu(bias, y):
+     x = bias + y
+     return  x * 0.5 * (1.0 + torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x)))
+@@ -20,7 +20,7 @@ def bias_gelu(bias, y):
+ # gradient of tanh approximation of gelu
+ # gradient of actual gelu is:
+ # 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
+-@jit_fuser
++
+ def bias_gelu_back(g, bias, y):
+     x = bias + y
+     tanh_out = torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x))
+diff --git a/megatron/legacy/model/transformer.py b/megatron/legacy/model/transformer.py
+index 2a662a55b..2fc3e1bfb 100644
+--- a/megatron/legacy/model/transformer.py
++++ b/megatron/legacy/model/transformer.py
+@@ -856,7 +856,7 @@ def get_bias_dropout_add(training):
+     return _bias_dropout_add
+ 
+ 
+-@jit_fuser
++
+ def bias_dropout_add_fused_train(x: torch.Tensor,
+                                  bias: Optional[torch.Tensor],
+                                  residual: torch.Tensor,
+@@ -864,7 +864,7 @@ def bias_dropout_add_fused_train(x: torch.Tensor,
+     return bias_dropout_add(x, bias, residual, prob, True)
+ 
+ 
+-@jit_fuser
++
+ def bias_dropout_add_fused_inference(x: torch.Tensor,
+                                      bias: Optional[torch.Tensor],
+                                      residual: torch.Tensor,
+diff --git a/megatron/legacy/model/utils.py b/megatron/legacy/model/utils.py
+index 5762000d5..534858df7 100644
+--- a/megatron/legacy/model/utils.py
++++ b/megatron/legacy/model/utils.py
+@@ -43,7 +43,7 @@ def get_linear_layer(rows, columns, init_method):
+     return layer
+ 
+ 
+-@jit_fuser
++
+ def gelu_impl(x):
+     """OpenAI's gelu implementation."""
+     return 0.5 * x * (1.0 + torch.tanh(0.7978845608028654 * x *
+@@ -54,7 +54,7 @@ def openai_gelu(x):
+ 
+ 
+ #This is actually Python equivalent of torch.nn.functional.gelu(), also with type hints for ONNX exporter
+-@jit_fuser
++
+ def erf_gelu(x):
+     return x * 0.5 * (torch.erf(x / 1.41421).to(dtype=x.dtype)+torch.ones_like(x).to(dtype=x.dtype))
+
+
+diff --git a/megatron/core/inference/contexts/dynamic_context.py b/megatron/core/inference/contexts/dynamic_context.py
+index 9b855effb..90c37c8db 100644
+--- a/megatron/core/inference/contexts/dynamic_context.py
++++ b/megatron/core/inference/contexts/dynamic_context.py
+@@ -49,12 +49,8 @@ try:
+ except:
+     HAVE_PACKAGING = False
+ 
+-try:
+-    import flashinfer  # pylint: disable=unused-import
+ 
+-    HAVE_FLASHINFER = True
+-except ImportError:
+-    HAVE_FLASHINFER = False
++HAVE_FLASHINFER = False
+ 
+ try:
+     import wandb  # pylint: disable=unused-import

--- a/docker/npu_patch/mindspeed.patch
+++ b/docker/npu_patch/mindspeed.patch
@@ -1,0 +1,123 @@
+diff --git a/mindspeed/core/megatron_basic/arguments_basic.py b/mindspeed/core/megatron_basic/arguments_basic.py
+index 8ea25b9f..04ad9663 100644
+--- a/mindspeed/core/megatron_basic/arguments_basic.py
++++ b/mindspeed/core/megatron_basic/arguments_basic.py
+@@ -113,3 +113,26 @@ def transformer_config_init_wrapper(fn):
+         fn(self, *args, **known_config)
+ 
+     return wrapper
++
++def transformer_config_init_subclass(cls, **kwargs):
++    mutable_types = (list, dict, set, bytearray)
++    unknown_config = {}
++    full_args = vars(get_full_args()).copy()
++    full_args.update(kwargs)
++
++    config_key = inspect.signature(cls).parameters
++    for key, value in full_args.items():
++        if key not in config_key:
++            unknown_config[key] = value
++
++    for key, value in unknown_config.items():
++        if not hasattr(cls, key):
++            cls.__annotations__[key] = type(value)
++            value = field(default_factory=value) if callable(value) and not isinstance(value, type) else value
++            if callable(value) and not isinstance(value, type):
++                value = field(default_factory=value)
++            elif type(value) in mutable_types:
++                value = field(default_factory=lambda: value)
++            else:
++                value = value
++            setattr(cls, key, value)
+\ No newline at end of file
+diff --git a/mindspeed/features_manager/megatron_basic/megatron_basic.py b/mindspeed/features_manager/megatron_basic/megatron_basic.py
+index 355913e1..18714baf 100644
+--- a/mindspeed/features_manager/megatron_basic/megatron_basic.py
++++ b/mindspeed/features_manager/megatron_basic/megatron_basic.py
+@@ -43,8 +43,11 @@ class MegatronBasicFeature(MindSpeedFeature):
+ 
+     def register_mcore_basic_patches(self, pm, args):
+         # configuration patches
+-        from mindspeed.core.megatron_basic.arguments_basic import transformer_config_init_wrapper, transformer_config_post_init_wrapper
++        from mindspeed.core.megatron_basic.arguments_basic import (transformer_config_init_wrapper,
++                                                                    transformer_config_post_init_wrapper,
++                                                                    transformer_config_init_subclass)
+         pm.register_patch("megatron.core.transformer.transformer_config.TransformerConfig.__init__", transformer_config_init_wrapper)
++        pm.register_patch("megatron.core.transformer.transformer_config.TransformerConfig.__init_subclass__", classmethod(transformer_config_init_subclass))
+         pm.register_patch("megatron.core.transformer.transformer_config.MLATransformerConfig.__init__", transformer_config_init_wrapper)
+         pm.register_patch("megatron.core.transformer.transformer_config.TransformerConfig.__post_init__", transformer_config_post_init_wrapper)
+ 
+
+diff --git a/mindspeed/patch_utils.py b/mindspeed/patch_utils.py
+index a489d58c..d9328555 100644
+--- a/mindspeed/patch_utils.py
++++ b/mindspeed/patch_utils.py
+@@ -2,7 +2,7 @@ import importlib
+ import sys
+ import types
+ from typing import List, Dict, Union
+-
++import inspect
+ _MEGATRON_TRAINING_AVAILABLE = None
+ 
+ 
+@@ -93,8 +93,10 @@ class Patch:
+ 
+     def remove_patch(self):
+         for key, value in sys.modules.copy().items():
+-            if 'mindspeed' in key:
++            if 'mindspeed' in key or 'torch.classes' == key:
+                 continue
++            if inspect.isclass(self.orig_module) and hasattr(value, self.orig_module_name.split('.')[-1]):
++ 	            value = getattr(value, self.orig_module_name.split('.')[-1])
+             if self.orig_func_name is not None and hasattr(value, self.orig_func_name) \
+                     and id(getattr(value, self.orig_func_name)) == id(self.final_patch_func):
+                 setattr(value, self.orig_func_name, self.orig_func)
+diff --git a/mindspeed/core/fusions/fused_rope.py b/mindspeed/core/fusions/fused_rope.py
+index a6f02e07..70f7cb08 100644
+--- a/mindspeed/core/fusions/fused_rope.py
++++ b/mindspeed/core/fusions/fused_rope.py
+@@ -126,5 +126,6 @@ def apply_rotary_pos_emb(
+         freqs,
+         rotary_interleaved=config.rotary_interleaved,
+         multi_latent_attention=config.multi_latent_attention,
+-        mscale=mscale
++        mscale=mscale,
++        cp_group=cp_group
+     )
+diff --git a/mindspeed/megatron_adaptor.py b/mindspeed/megatron_adaptor.py
+index f14b231d..4615590e 100644
+--- a/mindspeed/megatron_adaptor.py
++++ b/mindspeed/megatron_adaptor.py
+@@ -57,6 +57,7 @@ def delete_lock_file():
+ def repatch(args):
+     MindSpeedFeaturesManager.remove_patches()
+     full_args = get_full_args()
++    args = vars(args)
+     for k, v in args.items():
+         setattr(full_args, k, v)
+     MindSpeedFeaturesManager.apply_features_pre_patches(full_args)
+diff --git a/mindspeed/te/pytorch/attention/dot_product_attention/dot_product_attention.py b/mindspeed/te/pytorch/attention/dot_product_attention/dot_product_attention.py
+index ac4eabe5..78c5866d 100644
+--- a/mindspeed/te/pytorch/attention/dot_product_attention/dot_product_attention.py
++++ b/mindspeed/te/pytorch/attention/dot_product_attention/dot_product_attention.py
+@@ -330,6 +330,8 @@ class DotProductAttention(torch.nn.Module):
+         inference_params: Any = None,
+         pad_between_seqs: Optional[bool] = None,
+         fp8_output: Optional[bool] = False,
++        local_cp_size=None,
++        cp_group=None,
+     ) -> torch.Tensor:
+         """
+         Dot Product Attention Layer.
+@@ -659,7 +661,9 @@ class MindSpeedTEDotProductAttention(DotProductAttention):
+         ) and not getattr(self.config, 'is_llava', False):
+             self.config.sparse_mode = 2
+             attention_mask = get_attention_mask(self.config)
+-
++        attention_mask = torch.triu(
++            torch.ones((2048, 2048),
++                       device=query.device, dtype=torch.bool), diagonal=1) 
+         packed_seq_kwargs = (
+             {key: getattr(packed_seq_params, key) for key in self.kept_packed_seq_params}
+             if packed_seq_params is not None

--- a/tools/convert_hf_to_torch_dist.py
+++ b/tools/convert_hf_to_torch_dist.py
@@ -16,6 +16,7 @@ from vime.backends.megatron_utils.initialize import init
 from vime.backends.megatron_utils.model_provider import get_model_provider_func
 from vime.utils.logging_utils import configure_logger
 from vime.utils.memory_utils import print_memory
+from vime.utils.common import is_npu
 
 
 def add_convertion_args(parser):
@@ -91,8 +92,11 @@ def main():
     os.environ.setdefault("LOCAL_RANK", str(local_rank))
     os.environ.setdefault("MASTER_ADDR", "localhost")
     os.environ.setdefault("MASTER_PORT", "12355")
+    backend = "nccl"
+    if is_npu():
+        backend = "hccl"
     dist.init_process_group(
-        backend="nccl",
+        backend=backend,
         world_size=world_size,
         rank=global_rank,
         device_id=torch.device(f"cuda:{local_rank}"),

--- a/train.py
+++ b/train.py
@@ -4,6 +4,9 @@ from vime.ray.placement_group import create_placement_groups, create_rollout_man
 from vime.utils.arguments import parse_args
 from vime.utils.logging_utils import configure_logger, finish_tracking, init_tracking, update_tracking_open_metrics
 from vime.utils.misc import should_run_periodic_action
+from vime.utils.common import is_npu
+if is_npu():
+    import mindspeed.megatron_adaptor
 
 
 def train(args):

--- a/vime/backends/megatron_utils/actor.py
+++ b/vime/backends/megatron_utils/actor.py
@@ -8,6 +8,10 @@ import numpy as np
 import ray
 import torch
 import torch.distributed as dist
+from vime.utils.common import is_npu
+if is_npu():
+    import mindspeed.megatron_adaptor
+    from mindspeed.megatron_adaptor import repatch
 from megatron.core import mpu
 from torch_memory_saver import torch_memory_saver
 from transformers import AutoConfig, AutoTokenizer
@@ -59,6 +63,8 @@ class MegatronTrainRayActor(TrainRayActor):
 
         init(args)
 
+        if is_npu():
+            repatch(args)
         if is_megatron_main_rank():
             init_tracking(args, primary=False, role=role)
 
@@ -209,11 +215,12 @@ class MegatronTrainRayActor(TrainRayActor):
         )
         # TODO: this is ugly, move to somewhere else?
         # move tokens to GPU in advance
+        device = torch.npu.current_device() if is_npu() else torch.cuda.current_device()
         rollout_data["tokens"] = [
-            torch.tensor(t, dtype=torch.long, device=torch.cuda.current_device()) for t in rollout_data["tokens"]
+            torch.tensor(t, dtype=torch.long, device=device) for t in rollout_data["tokens"]
         ]
         rollout_data["loss_masks"] = [
-            torch.tensor(t, dtype=torch.int, device=torch.cuda.current_device()) for t in rollout_data["loss_masks"]
+            torch.tensor(t, dtype=torch.int, device=device) for t in rollout_data["loss_masks"]
         ]
         if "rollout_mask_sums" in rollout_data:
             # Promote precomputed per-rollout mask totals to GPU tensors here
@@ -227,9 +234,9 @@ class MegatronTrainRayActor(TrainRayActor):
                 (
                     {
                         key: (
-                            torch.from_numpy(v.copy()).to(device=torch.cuda.current_device())
+                            torch.from_numpy(v.copy()).to(device=device)
                             if isinstance(v, np.ndarray)
-                            else v.to(device=torch.cuda.current_device())
+                            else v.to(device=device)
                         )
                         for key, v in mm_dict.items()
                     }

--- a/vime/backends/megatron_utils/model_provider.py
+++ b/vime/backends/megatron_utils/model_provider.py
@@ -103,6 +103,15 @@ def _get_model_provider_func(
             provider.num_layers_in_first_pipeline_stage = args.decoder_first_pipeline_num_layers
         if getattr(args, "decoder_last_pipeline_num_layers", None) is not None:
             provider.num_layers_in_last_pipeline_stage = args.decoder_last_pipeline_num_layers
+        # provider.gradient_accumulation_fusion = args.gradient_accumulation_fusion
+        provider.gradient_accumulation_fusion = False
+        provider.recompute_granularity = args.recompute_granularity
+        provider.recompute_method = args.recompute_method
+        provider.recompute_num_layers = args.recompute_num_layers
+        for key, value in vars(args).items():
+            if hasattr(provider, key):
+                continue
+            setattr(provider, key, value)
         provider.finalize()
 
         if role == "critic":

--- a/vime/backends/megatron_utils/update_weight/common.py
+++ b/vime/backends/megatron_utils/update_weight/common.py
@@ -10,6 +10,7 @@ from megatron.core.transformer.transformer_layer import get_transformer_layer_of
 
 from vime.backends.megatron_utils.misc_utils import strip_param_name_prefix
 from vime.utils.types import ParamInfo
+from vime.utils.common import is_npu
 
 
 def all_gather_param(name: str, param: torch.nn.Parameter) -> torch.Tensor:
@@ -42,6 +43,8 @@ def all_gather_param(name: str, param: torch.nn.Parameter) -> torch.Tensor:
     if "linear_fc1.weight" in name or "linear_fc1.bias" in name:
         param_partitions = [p.chunk(2, dim=0) for p in param_partitions]
         param_partitions = [p[0] for p in param_partitions] + [p[1] for p in param_partitions]
+        if is_npu():
+            partition_dim = 0
     # this is bug in megatron's grouped moe.
     if "linear_fc2.weight" in name:
         if partition_dim == 0:
@@ -104,6 +107,8 @@ def all_gather_params_async(
             if "linear_fc1.weight" in info.name or "linear_fc1.bias" in info.name:
                 param_partitions = [p.chunk(2, dim=0) for p in param_partitions]
                 param_partitions = [p[0] for p in param_partitions] + [p[1] for p in param_partitions]
+                if is_npu():
+                    partition_dim = 0
             # this is bug in megatron's grouped moe.
             if "linear_fc2.weight" in info.name:
                 if partition_dim == 0:

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -16,12 +16,15 @@ from ray import ObjectRef
 from ray.actor import ActorHandle
 from tqdm import tqdm
 from vllm.distributed.weight_transfer.nccl_engine import NCCLTrainerSendWeightsArgs, NCCLWeightTransferEngine
+from vllm_ascend.distributed.weight_transfer.hccl_engine import HCCLTrainerSendWeightsArgs, HCCLWeightTransferEngine
 
 from vime.utils.distributed_utils import get_gloo_group
 
 from ..megatron_to_hf import convert_to_hf
 from .common import all_gather_param, named_params_and_buffers
 from .hf_weight_iterator_base import HfWeightIteratorBase
+
+from vime.utils.common import is_npu
 
 logger = logging.getLogger(__name__)
 
@@ -386,6 +389,7 @@ def connect_rollout_engines_from_distributed(
     for c in engine_gpu_counts:
         cumulative.append(cumulative[-1] + c)
 
+    backend = "hccl" if is_npu() else "nccl"
     refs = [
         engine.init_weights_update_group.remote(
             master_address=master_address,
@@ -393,30 +397,51 @@ def connect_rollout_engines_from_distributed(
             rank_offset=cumulative[i] + 1,
             world_size=world_size,
             group_name=group_name,
-            backend="nccl",
+            backend=backend,
         )
         for i, engine in enumerate(rollout_engines)
     ]
 
-    torch.cuda.synchronize()
-    torch.cuda.empty_cache()
-
-    device = torch.cuda.current_device()
-    logger.info(
-        "vLLM in-process weight transfer: addr=%s port=%d world_size=%d device=%d CVD=%s",
-        master_address,
-        master_port,
-        world_size,
-        device,
-        os.environ.get("CUDA_VISIBLE_DEVICES", ""),
-    )
-    model_update_groups = NCCLWeightTransferEngine.trainer_init(
-        {
-            "master_address": master_address,
-            "master_port": master_port,
-            "world_size": world_size,
-        }
-    )
+    if is_npu():
+        torch.npu.synchronize()
+        torch.npu.empty_cache()
+        device = torch.npu.current_device()
+        logger.info(
+            "vLLM in-process weight transfer: addr=%s port=%d world_size=%d device=%d CVD=%s",
+            master_address,
+            master_port,
+            world_size,
+            device,
+            os.environ.get("ASCEND_RT_VISIBLE_DEVICES", ""),
+        )
+        # 使用HCCLWeightTransferEngine
+        from vllm_ascend.distributed.weight_transfer.hccl_engine import HCCLWeightTransferEngine
+        model_update_groups = HCCLWeightTransferEngine.trainer_init(
+            {
+                "master_address": master_address,
+                "master_port": master_port,
+                "world_size": world_size,
+            }
+        )
+    else:
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        device = torch.cuda.current_device()
+        logger.info(
+            "vLLM in-process weight transfer: addr=%s port=%d world_size=%d device=%d CVD=%s",
+            master_address,
+            master_port,
+            world_size,
+            device,
+            os.environ.get("CUDA_VISIBLE_DEVICES", ""),
+        )
+        model_update_groups = NCCLWeightTransferEngine.trainer_init(
+            {
+                "master_address": master_address,
+                "master_port": master_port,
+                "world_size": world_size,
+            }
+        )
 
     ray.get(refs)
     return model_update_groups
@@ -479,10 +504,16 @@ def update_weights_from_distributed(
         (name, (param.data if hasattr(param, "data") else param).contiguous())
         for name, param in converted_named_tensors
     )
-    NCCLWeightTransferEngine.trainer_send_weights(
-        named_gpu_iter,
-        NCCLTrainerSendWeightsArgs(group=group, packed=packed),
-    )
+    if is_npu():
+        HCCLWeightTransferEngine.trainer_send_weights(
+            named_gpu_iter,
+            HCCLTrainerSendWeightsArgs(group=group, packed=packed),
+        )
+    else:
+        NCCLWeightTransferEngine.trainer_send_weights(
+            named_gpu_iter,
+            NCCLTrainerSendWeightsArgs(group=group, packed=packed),
+        )
 
     return refs
 

--- a/vime/backends/vllm_utils/arguments.py
+++ b/vime/backends/vllm_utils/arguments.py
@@ -253,6 +253,7 @@ def add_vllm_arguments(parser):
         action="store_false",
         help="Disable packed sync; send weights per bucket via in-process NCCL (non-packed mode).",
     )
+
     parser.set_defaults(vllm_weight_sync_packed=True)
 
     old_parser_add_argument = parser.add_argument
@@ -314,6 +315,40 @@ def validate_args(args):
         args.vllm_router_ip = _wrap_ipv6(args.vllm_router_ip)
 
 
+def _sanitize_non_primitive_defaults(args, user_provided: set[str]) -> None:
+    """Replace non-primitive default values with None.
+
+    vllm's ``AsyncEngineArgs.add_cli_args`` registers parameters whose defaults
+    are complex dataclass/config instances (e.g. ``EPLBConfig()``,
+    ``CompilationConfig()``).  When ``parse_known_args`` resolves those defaults
+    they become live Python objects on the returned Namespace.
+
+    The main ``parse_args`` in ``slime/utils/arguments.py`` later merges
+    *every* attribute from this Namespace into the global ``args`` via
+    ``setattr``.  Downstream code (megatron-bridge, model_provider, …) may
+    iterate ``vars(args)`` and choke on unrecognised types.
+
+    This function walks the parsed Namespace and replaces any non-primitive
+    *default* value (i.e. a dest the user did NOT explicitly provide) with
+    ``None``.  User-provided values are intentionally left intact — they are
+    forwarded to the vllm subprocess via ``_vllm_raw_values`` and do not need
+    the parsed object representation in the main args namespace.
+    """
+    _PRIMITIVE = (str, int, float, bool, type(None))
+
+    for key, value in list(vars(args).items()):
+        if key.startswith("_"):
+            continue
+        if key in user_provided:
+            continue
+        if isinstance(value, _PRIMITIVE):
+            continue
+        if isinstance(value, (list, tuple)):
+            if all(isinstance(v, _PRIMITIVE) for v in value):
+                continue
+        setattr(args, key, None)
+
+
 def vllm_parse_args():
     """Parse vllm flags via an independent ArgumentParser + parse_known_args.
 
@@ -337,6 +372,7 @@ def vllm_parse_args():
 
     args, _ = parser.parse_known_args()
     user_provided, raw_values = _detect_user_provided_dests(parser, sys.argv[1:])
+    _sanitize_non_primitive_defaults(args, user_provided)
     args._vllm_user_provided = user_provided
     args._vllm_raw_values = raw_values
     return args

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -1,6 +1,6 @@
 """Ray actor and launch helpers for vLLM OpenAI HTTP rollout.
 
-Per-Ray-actor ``server_args`` dict is built via :func:`_compute_server_args`,
+Per-Ray-actor ``server_args`` dict is built via :func:`compute_server_args`,
 then :func:`build_vllm_cmd_and_env` turns it into ``vllm serve`` CLI + subprocess env.
 :class:`VLLMEngine` manages the runtime HTTP control plane.
 User-facing vLLM knobs remain on ``train.py`` as ``--vllm-*`` (see ``arguments.py``).
@@ -25,6 +25,7 @@ import requests
 from vime.backends.vllm_utils.arguments import SKIPPED_DESTS, get_vllm_cli_action_table
 from vime.ray.ray_actor import RayActor
 from vime.utils.http_utils import get_host_info
+from vime.utils.common import is_npu
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +79,24 @@ def get_base_gpu_id(args, rank):
     return start_index
 
 
+def _to_local_gpu_id(physical_gpu_id: int) -> int:
+    if is_npu():
+        cvd = os.environ.get("ASCEND_RT_VISIBLE_DEVICES")
+    else:
+        cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if not cvd:
+        return physical_gpu_id
+    visible = [int(x) for x in cvd.split(",") if x.strip() != ""]
+    if physical_gpu_id in visible:
+        return visible.index(physical_gpu_id)
+    if 0 <= physical_gpu_id < len(visible):
+        return physical_gpu_id
+    raise RuntimeError(
+        f"GPU id {physical_gpu_id} is not valid under CUDA_VISIBLE_DEVICES={cvd}. "
+        f"Expected one of {visible} (physical) or 0..{len(visible)-1} (local)."
+    )
+
+
 @dataclasses.dataclass(frozen=True)
 class VllmEngineTopology:
     """Per-Ray-actor placement for one slice of a logical rollout engine."""
@@ -106,14 +125,25 @@ def _get_vllm_dp_size(args) -> int:
 
 
 def _resolve_vllm_parallel_sizes(args, *, gpus_per_engine: int) -> tuple[int, int]:
+    # Derive TP per-engine from THIS engine's GPU count (matches upstream slime's
+    # sglang_engine: tp = _gpus_per_engine // pp). Deliberately does NOT consult a global
+    # ``args.vllm_tp_size``: validate_args used to set that from the *global*
+    # rollout_num_gpus_per_engine, which shadowed this per-engine value and made a
+    # heterogeneous per-group engine (e.g. a tp=2 group) launch with the global TP —
+    # desyncing the weight-transfer rendezvous (the 300s "3/4 clients joined" hang).
     pp = _get_vllm_pp_size(args)
     dp = _get_vllm_dp_size(args)
-    if gpus_per_engine % (pp * dp) != 0:
-        raise ValueError(
-            f"num_gpus_per_engine ({gpus_per_engine}) must be divisible by "
-            f"vllm_pipeline_parallel_size * vllm_data_parallel_size ({pp} * {dp} = {pp * dp})"
+    if dp != 1:
+        raise NotImplementedError(
+            "vLLM data parallelism (vllm_data_parallel_size>1) is not wired in this base: TP is "
+            "computed as gpus_per_engine // pp (no DP term) and --data-parallel-size is not "
+            "forwarded. DP/EP support lands in a follow-up PR."
         )
-    tp = gpus_per_engine // (pp * dp)
+    if gpus_per_engine % pp != 0:
+        raise ValueError(
+            f"num_gpus_per_engine ({gpus_per_engine}) must be divisible by " f"vllm_pipeline_parallel_size ({pp})"
+        )
+    tp = gpus_per_engine // pp
     return tp, pp
 
 
@@ -213,6 +243,62 @@ def _apply_vllm_overrides(args, server_args: dict[str, Any], vllm_overrides: dic
             server_args[normalized] = value
             continue
         logger.debug("vllm_overrides: unrecognized key %s (rank=%s)", key, rank)
+
+
+def compute_server_args(
+    args,
+    rank,
+    dist_init_addr,
+    host,
+    port,
+    *,
+    worker_type: str = "regular",
+    base_gpu_id: int | None = None,
+    model_path: str | None = None,
+    vllm_overrides: dict | None = None,
+    num_gpus_per_engine: int | None = None,
+) -> dict[str, Any]:
+    """Build per-actor launch config for ``launch_server_process``."""
+    gpus_per_engine = num_gpus_per_engine or args.rollout_num_gpus_per_engine
+    if gpus_per_engine > args.num_gpus_per_node and gpus_per_engine % args.num_gpus_per_node != 0:
+        raise ValueError(
+            "vLLM multi-node rollout requires rollout_num_gpus_per_engine to be divisible by "
+            f"num_gpus_per_node, got rollout_num_gpus_per_engine={gpus_per_engine} "
+            f"num_gpus_per_node={args.num_gpus_per_node}."
+        )
+
+    topology = compute_vllm_engine_topology(args, rank, num_gpus_per_engine=gpus_per_engine)
+    base = base_gpu_id if base_gpu_id is not None else get_base_gpu_id(args, rank)
+    base = _to_local_gpu_id(base)
+
+    master_addr: str | None = None
+    master_port: int | None = None
+    if topology.multi_node:
+        if not dist_init_addr:
+            raise ValueError("dist_init_addr is required when launching a multi-node vLLM engine")
+        master_addr, master_port = parse_dist_init_addr(dist_init_addr)
+
+    server_args = {
+        "args": args,
+        "rank": rank,
+        "worker_type": worker_type,
+        "model_path": model_path or args.hf_checkpoint,
+        "host": _format_v6_uri(host),
+        "port": port,
+        "master_addr": master_addr,
+        "master_port": master_port,
+        "dist_init_addr": dist_init_addr,
+        "nnodes": topology.nnodes,
+        "node_rank": topology.node_rank,
+        "topology": topology,
+        "visible_devices": ",".join(str(base + i) for i in range(topology.local_num_gpus)),
+        "tp_size": topology.tensor_parallel_size,
+        "pp_size": topology.pipeline_parallel_size,
+        "dp_size": _get_vllm_dp_size(args),
+        "seed": getattr(args, "seed", 1234) + rank,
+    }
+    _apply_vllm_overrides(args, server_args, vllm_overrides, rank)
+    return server_args
 
 
 class _RobustJsonEncoder:
@@ -334,7 +420,10 @@ def build_vllm_subprocess_env(server_args: dict[str, Any]) -> dict[str, str]:
     env = os.environ.copy()
     env.pop("PYTORCH_CUDA_ALLOC_CONF", None)
     env.setdefault("NCCL_CUMEM_ENABLE", "0")
-    env["CUDA_VISIBLE_DEVICES"] = server_args["visible_devices"]
+    if is_npu():
+        env["ASCEND_RT_VISIBLE_DEVICES"] = server_args["visible_devices"]
+    else:
+        env["CUDA_VISIBLE_DEVICES"] = server_args["visible_devices"]
     env.setdefault("VLLM_SERVER_DEV_MODE", "1")
     if getattr(args, "colocate", False):
         import vime
@@ -385,7 +474,9 @@ def build_vllm_cmd_and_env(server_args: dict[str, Any]) -> tuple[list[str], dict
     if getattr(args, "fp16", False):
         cmd += ["--dtype", "float16"]
 
-    if getattr(args, "offload_rollout", False) and not getattr(args, "vllm_enable_sleep_mode", False):
+    if (getattr(args, "offload_rollout", False) or getattr(args, "colocate", False)) and not getattr(
+        args, "vllm_enable_sleep_mode", False
+    ):
         cmd += ["--enable-sleep-mode"]
         args.vllm_enable_sleep_mode = True
 
@@ -397,6 +488,11 @@ def build_vllm_cmd_and_env(server_args: dict[str, Any]) -> tuple[list[str], dict
 
     if getattr(args, "use_rollout_routing_replay", False):
         cmd += ["--enable-return-routed-experts"]
+    # Prefix-cache accounting: vLLM only emits usage.prompt_tokens_details.cached_tokens
+    # (the numerator behind rollout/prefix_cache_hit_rate) when the OpenAI frontend is
+    # started with this flag. It lives on FrontendArgs, not AsyncEngineArgs, so it is NOT
+    # reachable via --vllm-* auto-forwarding and must be set explicitly here.
+    cmd += ["--enable-prompt-tokens-details"]
 
     # gpu_memory_utilization: no vime-forced default. In colocate, training and rollout do not
     # occupy the GPU simultaneously (sleep/offload cycles), so vLLM's own default is fine. A user
@@ -443,24 +539,6 @@ def _exec_vllm_cmd(cmd: list[str], env: dict[str, str]) -> None:
     os.execvpe(cmd[0], cmd, env)
 
 
-def _normalize_vllm_wake_tags(tags: list[str] | None) -> list[str] | None:
-    if not tags:
-        return tags
-    normalized = [t for t in tags if t in _VLLM_WAKE_TAGS]
-    dropped = set(tags) - set(normalized)
-    if dropped:
-        logger.debug("vLLM wake_up: dropped tags not supported by vLLM: %s", sorted(dropped))
-    return normalized or None
-
-
-def launch_server_process(server_args: dict) -> multiprocessing.Process:
-    """Spawn ``vllm serve`` from a :func:`_compute_server_args` dict."""
-    cmd, env = build_vllm_cmd_and_env(server_args)
-    p = _spawn_ctx.Process(target=_exec_vllm_cmd, args=(cmd, env))
-    p.start()
-    return p
-
-
 def _wait_worker_process_alive(process: multiprocessing.Process, timeout_s: float = 300.0) -> None:
     """Non-head nodes have no HTTP health endpoint; ensure the subprocess stays up."""
     start = time.time()
@@ -472,10 +550,19 @@ def _wait_worker_process_alive(process: multiprocessing.Process, timeout_s: floa
 
 
 def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None) -> None:
-    """Wait until the vLLM server responds on ``GET /health``."""
+    """Wait until the vLLM server responds on ``GET /health`` (no time limit, SGLang-style).
+
+    Loops until /health returns 200, or — for a managed subprocess — until it dies (fail fast via
+    ``process.is_alive()``). There is no overall deadline, so a slow-but-healthy startup (a large
+    MoE / DP engine loading + compiling + capturing CUDA graphs across replicas) is never
+    spuriously timed out. The per-probe ``timeout=3`` bounds each individual request so a single
+    stuck socket cannot wedge the loop. In external mode (``process is None``) there is no liveness
+    signal, so a permanently unreachable URL loops indefinitely by design (the external engine is
+    caller-managed). Mirrors slime's SGLang backend _wait_server_healthy.
+    """
     while True:
         try:
-            response = requests.get(f"{base_url}/health")
+            response = requests.get(f"{base_url}/health", timeout=3)
             if response.status_code == 200:
                 return
         except requests.RequestException:
@@ -484,6 +571,24 @@ def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None)
         if process is not None and not process.is_alive():
             raise RuntimeError(f"vLLM server exited unexpectedly with code {process.exitcode}")
         time.sleep(2)
+
+
+def launch_server_process(server_args: dict) -> multiprocessing.Process:
+    """Spawn ``vllm serve`` from a :func:`compute_server_args` dict."""
+    cmd, env = build_vllm_cmd_and_env(server_args)
+    p = _spawn_ctx.Process(target=_exec_vllm_cmd, args=(cmd, env))
+    p.start()
+    return p
+
+
+def _normalize_vllm_wake_tags(tags: list[str] | None) -> list[str] | None:
+    if not tags:
+        return tags
+    normalized = [t for t in tags if t in _VLLM_WAKE_TAGS]
+    dropped = set(tags) - set(normalized)
+    if dropped:
+        logger.debug("vLLM wake_up: dropped tags not supported by vLLM: %s", sorted(dropped))
+    return normalized or None
 
 
 class VLLMEngine(RayActor):
@@ -495,6 +600,7 @@ class VLLMEngine(RayActor):
         rank: int,
         worker_type: str = "regular",
         base_gpu_id: int | None = None,
+        model_path: str | None = None,
         vllm_overrides: dict | None = None,
         num_gpus_per_engine: int | None = None,
     ):
@@ -502,6 +608,7 @@ class VLLMEngine(RayActor):
         self.rank = rank
         self.worker_type = worker_type
         self.base_gpu_id = base_gpu_id
+        self.model_path = model_path or args.hf_checkpoint
         self.vllm_overrides = vllm_overrides or {}
         self.num_gpus_per_engine = num_gpus_per_engine
         self.process: multiprocessing.Process | None = None
@@ -512,6 +619,9 @@ class VLLMEngine(RayActor):
 
     def _http_base(self) -> str:
         return f"http://{self.server_host}:{self.server_port}"
+
+    def _weight_transfer_http_timeout(self) -> float:
+        return float(self.args.vllm_weight_transfer_timeout_sec)
 
     def init(
         self,
@@ -530,7 +640,7 @@ class VLLMEngine(RayActor):
         gpus_per_engine = self.num_gpus_per_engine or self.args.rollout_num_gpus_per_engine
         host = host or get_host_info()[1]
 
-        self._server_args = _compute_server_args(
+        self._server_args = compute_server_args(
             self.args,
             self.rank,
             dist_init_addr,
@@ -538,6 +648,7 @@ class VLLMEngine(RayActor):
             port,
             worker_type=self.worker_type,
             base_gpu_id=self.base_gpu_id,
+            model_path=self.model_path,
             vllm_overrides=self.vllm_overrides,
             num_gpus_per_engine=gpus_per_engine,
         )
@@ -582,6 +693,7 @@ class VLLMEngine(RayActor):
         response = requests.post(
             f"http://{self.router_ip}:{self.router_port}/workers",
             json=payload,
+            timeout=30,
         )
         response.raise_for_status()
 
@@ -590,11 +702,14 @@ class VLLMEngine(RayActor):
             return
         worker_url = self._http_base()
         try:
-            all_workers = requests.get(f"http://{self.router_ip}:{self.router_port}/workers").json()["workers"]
+            all_workers = requests.get(f"http://{self.router_ip}:{self.router_port}/workers", timeout=30).json()[
+                "workers"
+            ]
             for worker in all_workers:
                 if worker["url"] == worker_url:
                     response = requests.delete(
                         f"http://{self.router_ip}:{self.router_port}/workers/{quote(worker_url, safe='')}",
+                        timeout=30,
                     )
                     response.raise_for_status()
                     return
@@ -621,7 +736,7 @@ class VLLMEngine(RayActor):
         treated as a mismatch (e.g. vLLM ``parallel_config`` may not surface ``nnodes``), so the
         check stays strict for reported fields without false-failing on unreported ones.
         """
-        response = requests.get(f"{self._http_base()}/server_info", params={"config_format": "json"})
+        response = requests.get(f"{self._http_base()}/server_info", params={"config_format": "json"}, timeout=30)
         body = _response_json(response)
         parallel_cfg = body.get("vllm_config", {}).get("parallel_config", {})
         if not parallel_cfg:
@@ -661,12 +776,17 @@ class VLLMEngine(RayActor):
         else:
             _wait_worker_process_alive(self.process)
 
-    def _make_request(self, endpoint: str, payload: dict | None = None) -> dict | None:
-        """Control-plane POST returning parsed JSON."""
+    def _make_request(self, endpoint: str, payload: dict | None = None, *, timeout: float) -> dict | None:
+        """Control-plane POST returning parsed JSON (mirrors SGLang's ``_make_request``).
+
+        The single choke point for control-plane POSTs: headless workers (node_rank>0) own no
+        HTTP server, so they no-op to None; otherwise POST and parse via the shared
+        ``_response_json`` (also reused by the query-param endpoints /sleep, /wake_up, ...).
+        """
         if self.node_rank != 0:
             return None
         url = f"{self._http_base()}/{endpoint.lstrip('/')}"
-        return _response_json(requests.post(url, json=payload or {}))
+        return _response_json(requests.post(url, json=payload or {}, timeout=timeout))
 
     def _post_vllm_update_weights_http(self, update_info: dict) -> dict:
         """POST ``/update_weights`` with ``{"update_info": ...}`` (vLLM RLHF control plane).
@@ -677,6 +797,7 @@ class VLLMEngine(RayActor):
         return self._make_request(
             "update_weights",
             {"update_info": update_info},
+            timeout=self._weight_transfer_http_timeout(),
         )
 
     def health_generate(self, timeout: float = 5.0) -> bool:
@@ -710,55 +831,28 @@ class VLLMEngine(RayActor):
         if flush_cache:
             self.flush_cache()
 
-        response = self._make_request(
-            "collective_rpc",
-            {"method": "update_weights_chunk", "kwargs": {"update_info": payload}},
-        )
+        response = self._post_vllm_update_weights_http(payload)
         if weight_version is not None:
             self._weight_version = str(weight_version)
         return response
 
-    def update_weights_chunk(self, update_info: dict) -> dict:
-        """POST ``/update_weights_chunk`` with a single named-tensor chunk.
-
-        Mirrors the SkyRL ``RemoteInferenceClient.update_weights_chunk`` API.
-        Must be called between :meth:`start_weight_update` and
-        :meth:`finish_weight_update`.
-
-        Unlike :meth:`update_weights`, ``update_info`` is the *inner* payload
-        dict (``names``, ``dtype_names``, ``shapes``, and one of
-        ``ipc_handles`` / ``ipc_handles_pickled`` for IPC, or ``packed`` for
-        NCCL) — **not** wrapped in ``{"update_info": ...}``.
-
-        If ``ipc_handles`` are present (raw CUDA callables produced by
-        ``reduce_tensor``), they are serialised with cloudpickle + base64 so
-        vLLM can deserialise them when
-        ``VLLM_ALLOW_INSECURE_SERIALIZATION=1`` is set.
-        """
-        if self.node_rank != 0:
-            return {"ok": True, "skipped": True}
-
-        import base64
-
-        import cloudpickle
-
-        payload = dict(update_info)
-        if payload.get("ipc_handles") is not None:
-            payload["ipc_handles_pickled"] = base64.b64encode(cloudpickle.dumps(payload.pop("ipc_handles"))).decode(
-                "utf-8"
-            )
-        response = self._make_request(
-            "collective_rpc",
-            {"method": "update_weights_chunk", "kwargs": {"update_info": payload}},
-        )
-        return response
-
     def flush_cache(self):
-        """Reset the prefix cache via ``POST /reset_prefix_cache``."""
+        """Clear prefix cache via ``POST /reset_prefix_cache``."""
         if self.node_rank != 0:
             return
-        params = {"reset_running_requests": False}
-        requests.post(f"{self._http_base()}/reset_prefix_cache", params=params).raise_for_status()
+        params = {"reset_running_requests": False, "reset_external": False}
+        for _ in range(60):
+            try:
+                response = requests.post(f"{self._http_base()}/reset_prefix_cache", params=params, timeout=60)
+                if response.status_code == 200:
+                    return
+            except requests.ConnectionError:
+                raise
+            except Exception as e:
+                logger.info("Error resetting vLLM prefix cache: %s", e)
+                time.sleep(1)
+                continue
+        raise TimeoutError("Timeout while resetting vLLM prefix cache (reset_prefix_cache).")
 
     def get_url(self):
         """Worker HTTP base URL, or ``None`` when ``node_rank != 0``."""
@@ -767,7 +861,7 @@ class VLLMEngine(RayActor):
         return self._http_base()
 
     def shutdown(self):
-        logger.info("Shutdown engine %s:%s...", self.server_host, self.server_port)
+        logger.info("Shutdown vLLM engine %s:%s...", self.server_host, self.server_port)
         self._deregister_worker_from_router()
         if self.args.rollout_external:
             return
@@ -816,25 +910,40 @@ class VLLMEngine(RayActor):
         return self._weight_version
 
     def release_memory_occupation(self, level: int = 1):
-        """Flush prefix cache, then ``POST /sleep?level={level}``."""
-        if self.node_rank != 0:
+        """``POST /sleep?level={level}`` when sleep mode is enabled.
+
+        level=1 (default) releases KV cache only.
+        level=0 releases both KV cache and model weights (required before IPC tensor injection).
+        Returns a no-op dict when ``--vllm-enable-sleep-mode`` was not set.
+        """
+        if self.node_rank != 0:  # /sleep bypasses _make_request (query params, not JSON body); guard explicitly.
             return None
         self.flush_cache()
+        if not getattr(self.args, "vllm_enable_sleep_mode", False):
+            return {"ok": True, "sleep_mode": False, "note": "vLLM sleep mode disabled; no /sleep call."}
+        # vLLM ``POST /sleep`` reads ``level`` from query params, not JSON body
+        # (``vllm.entrypoints.serve.sleep.api_router.sleep``).
         response = requests.post(
             f"{self._http_base()}/sleep",
             params={"level": level},
+            timeout=30,
         )
         return _response_json(response)
 
     def resume_memory_occupation(self, tags: list[str] | None = None):
-        """``POST /wake_up`` with vLLM-supported wake tags."""
-        if self.node_rank != 0:
+        """``POST /wake_up`` when sleep mode is on; else a no-op placeholder dict."""
+        if self.node_rank != 0:  # /wake_up bypasses _make_request (query params, not JSON body); guard explicitly.
             return None
+        if not getattr(self.args, "vllm_enable_sleep_mode", False):
+            return {"ok": True, "sleep_mode": False}
         tags = _normalize_vllm_wake_tags(tags)
+        # vLLM ``POST /wake_up`` uses ``query_params.getlist("tags")``, not JSON.
+        # Omit params when ``tags`` is empty so the server wakes all tags (see api_router.wake_up).
         wake_params: list[tuple[str, str]] | None = [("tags", t) for t in tags] if tags else None
         response = requests.post(
             f"{self._http_base()}/wake_up",
             params=wake_params,
+            timeout=30,
         )
         return _response_json(response)
 
@@ -844,10 +953,11 @@ class VLLMEngine(RayActor):
         For IPC mode the payload is ``{"init_info": {}}``; for NCCL use
         ``init_weights_update_group`` which constructs the payload from typed args.
         """
+        init_timeout_s = self._weight_transfer_http_timeout()
         last_error = None
         for attempt in range(1, 4):
             try:
-                return self._make_request("init_weight_transfer_engine", payload)
+                return self._make_request("init_weight_transfer_engine", payload, timeout=init_timeout_s)
             except Exception as e:
                 last_error = e
                 if attempt < 3:
@@ -857,16 +967,20 @@ class VLLMEngine(RayActor):
 
     def start_weight_update(self, is_checkpoint_format: bool = False) -> dict:
         """``POST /start_weight_update`` — signals vLLM to enter IPC weight-update mode."""
-        return self._make_request("start_weight_update", {"is_checkpoint_format": is_checkpoint_format})
+        return self._make_request(
+            "start_weight_update",
+            {"is_checkpoint_format": is_checkpoint_format},
+            timeout=self._weight_transfer_http_timeout(),
+        )
 
     def finish_weight_update(self) -> dict:
         """``POST /finish_weight_update`` — signals vLLM to exit IPC weight-update mode.
 
         Purely a state-machine bookend now; ``_weight_version`` is recorded by
-        ``update_weights_from_tensor`` (the IPC data-carrying RPC), matching vime's
+        ``update_weights_from_tensor`` (the IPC data-carrying RPC), matching slime's
         single-RPC version-with-data semantics.
         """
-        return self._make_request("finish_weight_update", {})
+        return self._make_request("finish_weight_update", {}, timeout=self._weight_transfer_http_timeout())
 
     def check_weights(self, action: str):
         """No vLLM ``weights_checker`` route; return a placeholder dict."""
@@ -888,10 +1002,11 @@ class VLLMEngine(RayActor):
                 "world_size": world_size,
             }
         }
+        init_timeout_s = self._weight_transfer_http_timeout()
         last_error = None
         for attempt in range(1, 4):
             try:
-                return self._make_request("init_weight_transfer_engine", payload)
+                return self._make_request("init_weight_transfer_engine", payload, timeout=init_timeout_s)
             except Exception as e:
                 last_error = e
                 if attempt < 3:
@@ -943,6 +1058,7 @@ class VLLMEngine(RayActor):
                 "method": "reload_weights",
                 "kwargs": {"weights_path": model_path, "is_checkpoint_format": True},
             },
+            timeout=600,
         )
         return _response_json(response)
 
@@ -954,6 +1070,7 @@ class VLLMEngine(RayActor):
             f"{self._http_base()}/pause",
             params={"mode": "keep", "clear_cache": "false"},
             json={},
+            timeout=120,
         )
         response.raise_for_status()
         return response
@@ -962,7 +1079,7 @@ class VLLMEngine(RayActor):
         """``POST /resume`` to continue generation after pause."""
         if self.node_rank != 0:
             return None
-        response = requests.post(f"{self._http_base()}/resume", json={})
+        response = requests.post(f"{self._http_base()}/resume", json={}, timeout=120)
         response.raise_for_status()
         return response
 
@@ -1001,7 +1118,7 @@ class VLLMEngine(RayActor):
             )
         ):
             logger.warning("vLLM start_profile: extra kwargs may be ignored by server; see vLLM profiling docs.")
-        response = requests.post(f"{self._http_base()}/start_profile", json={})
+        response = requests.post(f"{self._http_base()}/start_profile", json={}, timeout=30)
         response.raise_for_status()
         return response
 
@@ -1009,7 +1126,7 @@ class VLLMEngine(RayActor):
         """POST ``/stop_profile`` to stop an active server-side profile."""
         if self.node_rank != 0:
             return None
-        response = requests.post(f"{self._http_base()}/stop_profile", json={})
+        response = requests.post(f"{self._http_base()}/stop_profile", json={}, timeout=30)
         response.raise_for_status()
         return response
 
@@ -1020,59 +1137,5 @@ class VLLMEngine(RayActor):
                 self.args.rollout_external,
             )
             return
-        logger.info("Simulating crash on engine %s:%s...", self.server_host, self.server_port)
+        logger.info("Simulating crash on vLLM engine %s:%s...", self.server_host, self.server_port)
         self.shutdown()
-
-
-def _compute_server_args(
-    args,
-    rank,
-    dist_init_addr,
-    host,
-    port,
-    *,
-    worker_type: str = "regular",
-    base_gpu_id: int | None = None,
-    vllm_overrides: dict | None = None,
-    num_gpus_per_engine: int | None = None,
-) -> dict[str, Any]:
-    """Build per-actor launch config for ``launch_server_process``."""
-    gpus_per_engine = num_gpus_per_engine or args.rollout_num_gpus_per_engine
-    if gpus_per_engine > args.num_gpus_per_node and gpus_per_engine % args.num_gpus_per_node != 0:
-        raise ValueError(
-            "vLLM multi-node rollout requires rollout_num_gpus_per_engine to be divisible by "
-            f"num_gpus_per_node, got rollout_num_gpus_per_engine={gpus_per_engine} "
-            f"num_gpus_per_node={args.num_gpus_per_node}."
-        )
-
-    topology = compute_vllm_engine_topology(args, rank, num_gpus_per_engine=gpus_per_engine)
-    base = base_gpu_id if base_gpu_id is not None else get_base_gpu_id(args, rank)
-
-    master_addr: str | None = None
-    master_port: int | None = None
-    if topology.multi_node:
-        if not dist_init_addr:
-            raise ValueError("dist_init_addr is required when launching a multi-node vLLM engine")
-        master_addr, master_port = parse_dist_init_addr(dist_init_addr)
-
-    server_args = {
-        "args": args,
-        "rank": rank,
-        "worker_type": worker_type,
-        "model_path": args.hf_checkpoint,
-        "host": _format_v6_uri(host),
-        "port": port,
-        "master_addr": master_addr,
-        "master_port": master_port,
-        "dist_init_addr": dist_init_addr,
-        "nnodes": topology.nnodes,
-        "node_rank": topology.node_rank,
-        "topology": topology,
-        "visible_devices": ",".join(str(base + i) for i in range(topology.local_num_gpus)),
-        "tp_size": topology.tensor_parallel_size,
-        "pp_size": topology.pipeline_parallel_size,
-        "dp_size": _get_vllm_dp_size(args),
-        "seed": getattr(args, "seed", 1234) + rank,
-    }
-    _apply_vllm_overrides(args, server_args, vllm_overrides, rank)
-    return server_args

--- a/vime/ray/actor_group.py
+++ b/vime/ray/actor_group.py
@@ -5,6 +5,7 @@ from ray.util.placement_group import PlacementGroup
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from vime.ray.utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST
+from vime.utils.common import is_npu
 
 
 class RayTrainGroup:
@@ -89,7 +90,8 @@ class RayTrainGroup:
 
         actor_impl = MegatronTrainRayActor
 
-        TrainRayActor = ray.remote(num_gpus=1, runtime_env={"env_vars": env_vars})(actor_impl)
+        TrainRayActor = ray.remote(runtime_env={"env_vars": env_vars})(actor_impl)
+        device_name = "NPU" if is_npu() else "GPU"
 
         # Create worker actors
         self._actor_handlers = []
@@ -97,11 +99,11 @@ class RayTrainGroup:
         for rank in range(world_size):
             actor = TrainRayActor.options(
                 num_cpus=num_gpus_per_actor,
-                num_gpus=num_gpus_per_actor,
                 scheduling_strategy=PlacementGroupSchedulingStrategy(
                     placement_group=pg,
                     placement_group_bundle_index=reordered_bundle_indices[rank],
                 ),
+                resources={device_name:num_gpus_per_actor}
             ).remote(world_size, rank, master_addr, master_port)
             if rank == 0:
                 master_addr, master_port = ray.get(actor.get_master_addr_and_port.remote())

--- a/vime/ray/placement_group.py
+++ b/vime/ray/placement_group.py
@@ -9,13 +9,19 @@ from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from .actor_group import RayTrainGroup
 from .rollout import RolloutManager
 
+from vime.utils.common import is_npu
+
 logger = logging.getLogger(__name__)
 
 
-@ray.remote(num_gpus=1)
+# @ray.remote(num_gpus=1)
+@ray.remote
 class InfoActor:
     def get_ip_and_gpu_id(self):
-        return ray.util.get_node_ip_address(), ray.get_gpu_ids()[0]
+        if is_npu():
+            return ray.util.get_node_ip_address(), ray.get_runtime_context().get_accelerator_ids()["NPU"][0]
+        else:
+            return ray.util.get_node_ip_address(), ray.get_gpu_ids()[0]
 
 
 def sort_key(x):
@@ -36,12 +42,13 @@ def sort_key(x):
             # representation that allows for sorting.
             node_ip_parts = [ord(c) for c in node_identifier]
 
-    return (node_ip_parts, gpu_id)
+    return (node_ip_parts, int(gpu_id))
 
 
 def _create_placement_group(num_gpus):
     """Create a placement group with the specified number of GPUs."""
-    bundles = [{"GPU": 1, "CPU": 1} for _ in range(num_gpus)]
+    device_name = "NPU" if is_npu() else "GPU"
+    bundles = [{device_name: 1, "CPU": 1} for _ in range(num_gpus)]
     pg = placement_group(bundles, strategy="PACK")
     num_bundles = len(bundles)
 
@@ -54,7 +61,8 @@ def _create_placement_group(num_gpus):
                 scheduling_strategy=PlacementGroupSchedulingStrategy(
                     placement_group=pg,
                     placement_group_bundle_index=i,
-                )
+                ),
+                resources={device_name:1}
             ).remote()
         )
     gpu_ids = ray.get([actor.get_ip_and_gpu_id.remote() for actor in info_actors])
@@ -185,9 +193,11 @@ def create_training_models(args, pgs, rollout_manager):
 
 
 def create_rollout_manager(args, pg):
+    device_name = "NPU" if is_npu() else "GPU"
     rollout_manager = RolloutManager.options(
         num_cpus=1,
-        num_gpus=0,
+        # num_gpus=0,
+        resources={device_name:0}
     ).remote(args, pg)
 
     # calculate num_rollout from num_epoch

--- a/vime/ray/rollout.py
+++ b/vime/ray/rollout.py
@@ -33,6 +33,7 @@ from vime.utils.types import Sample
 from ..utils.metric_utils import has_repetition
 from .rollout_validation import validate_server_group_gpu_indices
 from .utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST, Lock
+from vime.utils.common import is_npu
 
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("httpcore").setLevel(logging.WARNING)
@@ -106,6 +107,7 @@ class ServerGroup:
         RolloutRayActor = ray.remote(VLLMEngine)
 
         rollout_engines = []
+        device_name = "NPU" if is_npu() else "GPU"
         for i in range(len(self.all_engines)):
             if self.all_engines[i] is not None:
                 continue
@@ -132,11 +134,11 @@ class ServerGroup:
             }
             rollout_engine = RolloutRayActor.options(
                 num_cpus=num_cpus,
-                num_gpus=num_gpus,
                 scheduling_strategy=scheduling_strategy,
                 runtime_env={
                     "env_vars": env_vars,
                 },
+                resources={device_name:num_gpus}
             ).remote(
                 self.args,
                 rank=global_rank,
@@ -387,7 +389,8 @@ class RolloutManager:
             self.servers = start_rollout_servers(args, pg)
 
         init_tracking(args, primary=False)
-        self.rollout_engine_lock = Lock.options(num_cpus=1, num_gpus=0).remote()
+        device_name = "NPU" if is_npu() else "GPU"
+        self.rollout_engine_lock = Lock.options(num_cpus=1, num_gpus=0, resources={device_name:0}).remote()
         self.rollout_id = -1
 
         self._health_monitors = []

--- a/vime/ray/train_actor.py
+++ b/vime/ray/train_actor.py
@@ -13,17 +13,23 @@ from vime.ray.ray_actor import RayActor
 from vime.utils.distributed_utils import init_gloo_group
 from vime.utils.logging_utils import configure_logger
 from vime.utils.memory_utils import clear_memory, print_memory
+from vime.utils.common import is_npu
 
 logger = logging.getLogger(__name__)
 
 
 def get_local_gpu_id():
-    cvd = os.environ.get("CUDA_VISIBLE_DEVICES", None)
-    if cvd is None:
-        return ray.get_gpu_ids()[0]
+    if is_npu():
+        env_var = "ASCEND_RT_VISIBLE_DEVICES"
+        device_ids = ray.get_runtime_context().get_accelerator_ids()["NPU"]
     else:
-        return cvd.split(",").index(str(ray.get_gpu_ids()[0]))
-
+        env_var = "CUDA_VISIBLE_DEVICES"
+        device_ids = ray.get_gpu_ids()
+    cvd = os.environ.get(env_var, None)
+    if cvd is None:
+        return device_ids[0]
+    else:
+        return cvd.split(",").index(str(device_ids[0]))
 
 class TrainRayActor(RayActor):
     def __init__(self, world_size, rank, master_addr, master_port):
@@ -56,7 +62,10 @@ class TrainRayActor(RayActor):
         torch.serialization.add_safe_globals([vime.utils.eval_config.EvalDatasetConfig])
 
         local_rank = int(os.environ.get("LOCAL_RANK", 0))
-        torch.cuda.set_device(f"cuda:{local_rank}")
+        if is_npu():
+            torch.npu.set_device(f"npu:{local_rank}")
+        else:
+            torch.cuda.set_device(f"cuda:{local_rank}")
 
         backend = args.distributed_backend
 

--- a/vime/utils/arguments.py
+++ b/vime/utils/arguments.py
@@ -98,7 +98,7 @@ def get_vime_extra_args_provider(add_custom_arguments=None):
                 ),
             )
 
-            reset_arg(parser, "--distributed-backend", type=str, default="nccl")
+            reset_arg(parser, "--distributed-backend", type=str, default="hccl")
             reset_arg(parser, "--distributed-timeout-minutes", type=int, default=10)
 
             return parser

--- a/vime/utils/common.py
+++ b/vime/utils/common.py
@@ -1,0 +1,12 @@
+import torch
+
+def is_npu() -> bool:
+    if not hasattr(torch, "npu"):
+        return False
+
+    if not torch.npu.is_available():
+        raise RuntimeError(
+            "torch_npu detected, but NPU device is not available or visible."
+        )
+
+    return True

--- a/vime/utils/external_utils/command_utils.py
+++ b/vime/utils/external_utils/command_utils.py
@@ -180,6 +180,110 @@ def execute_train(
         )
 
 
+def execute_train_npu(
+    train_args: str,
+    megatron_model_type: str | None,
+    train_script: str = "train.py",
+    before_ray_job_submit=None,
+    extra_env_vars=None,
+    config: ExecuteTrainConfig | None = None,
+):
+    if extra_env_vars is None:
+        extra_env_vars = {}
+    if config is None:
+        config = ExecuteTrainConfig()
+    external_ray = get_bool_env_var("SLIME_SCRIPT_EXTERNAL_RAY")
+    master_addr = os.environ.get("MASTER_ADDR", "127.0.0.1")
+
+    train_backend_fsdp = "--train-backend fsdp" in train_args
+    assert train_backend_fsdp == (megatron_model_type is None)
+
+    exec_command(
+        "pkill -9 sglang; "
+        "sleep 3; "
+        f"{'' if external_ray else 'ray stop --force; '}"
+        f"{'' if external_ray else 'pkill -9 ray; '}"
+        # cannot be run in CI, o/w kill the parent script
+        # TODO: do we really need this kill? (or can we instead kill slime)
+        # "pkill -9 python; "
+        "pkill -9 slime; "
+        "sleep 3; "
+        f"{'' if external_ray else 'pkill -9 ray; '}"
+        # "pkill -9 python; "
+        "pkill -9 slime; "
+        "pkill -9 redis; "
+        "true; "
+    )
+
+    if not external_ray:
+        exec_command(
+            # will prevent ray from buffering stdout/stderr
+            f"export PYTHONBUFFERED=16 && "
+            f"ray start --head --node-ip-address {master_addr} --disable-usage-stats"
+        )
+
+    if (f := before_ray_job_submit) is not None:
+        f()
+
+    runtime_env_json = json.dumps(
+        {
+            "env_vars": {
+                # "PYTHONPATH": "/root/Megatron-LM/",
+                "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+                "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES": "1",
+                "ASCEND_TOOLKIT_HOME": "/usr/local/CANN9.0.0/ascend-toolkit/latest/",
+                "ASCEND_OPP_PATH": "/usr/local/CANN9.0.0/ascend-toolkit/latest/opp/",
+                "ASCEND_AICPU_PATH": "/usr/local/CANN9.0.0/ascend-toolkit/latest/",
+                "ASCEND_HOME_PATH": "/usr/local/CANN9.0.0/ascend-toolkit/latest/",
+                "set_env_path": "/usr/local/CANN9.0.0/nnal/atb/set_env.sh",
+                "HYDRA_FULL_ERROR": "1",
+                "HCCL_HOST_SOCKET_PORT_RANGE": "60000-60050",
+                "HCCL_NPU_SOCKET_PORT_RANGE": "61000-61050",
+                # If setting this in FSDP, the computation communication overlapping may have issues
+                **(
+                    {}
+                    if train_backend_fsdp
+                    else {
+                        "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+                    }
+                ),
+                "NCCL_NVLS_ENABLE": str(int(check_has_nvlink())),
+                "no_proxy": f"127.0.0.1,{master_addr}",
+                # This is needed by megatron / torch distributed in multi-node setup
+                "MASTER_ADDR": master_addr,
+                **(
+                    {
+                        "CUDA_ENABLE_COREDUMP_ON_EXCEPTION": "1",
+                        "CUDA_COREDUMP_SHOW_PROGRESS": "1",
+                        "CUDA_COREDUMP_GENERATION_FLAGS": "skip_nonrelocated_elf_images,skip_global_memory,skip_shared_memory,skip_local_memory,skip_constbank_memory",
+                        "CUDA_COREDUMP_FILE": "/root/shared_data/cuda_coredump_%h.%p.%t",
+                    }
+                    if config.cuda_core_dump
+                    else {}
+                ),
+                **extra_env_vars,
+                **_parse_extra_env_vars(config.extra_env_vars),
+            }
+        }
+    )
+
+    if get_bool_env_var("SLIME_SCRIPT_ENABLE_RAY_SUBMIT", "1"):
+        cmd_megatron_model_source = (
+            f'source "{repo_base_dir}/scripts/models/{megatron_model_type}.sh" && '
+            if megatron_model_type is not None
+            else ""
+        )
+        exec_command(
+            f"export no_proxy=127.0.0.1 && export PYTHONBUFFERED=16 && "
+            f"{cmd_megatron_model_source}"
+            f'ray job submit --address="http://127.0.0.1:8265" '
+            f"--runtime-env-json='{runtime_env_json}' "
+            f"-- python3 {train_script} "
+            f"{'${MODEL_ARGS[@]}' if megatron_model_type is not None else ''} "
+            f"{train_args}"
+        )
+
+
 def _parse_extra_env_vars(text: str):
     try:
         return json.loads(text)

--- a/vime/utils/memory_utils.py
+++ b/vime/utils/memory_utils.py
@@ -4,34 +4,60 @@ import logging
 import psutil
 import torch
 import torch.distributed as dist
+from vime.utils.common import is_npu
 
 logger = logging.getLogger(__name__)
 
 
 def clear_memory(clear_host_memory: bool = False):
-    torch.cuda.synchronize()
+    if is_npu():
+        torch.npu.synchronize()
+    else:
+        torch.cuda.synchronize()
     gc.collect()
     torch.cuda.empty_cache()
+    if is_npu():
+        torch.npu.empty_cache()
     if clear_host_memory:
-        torch._C._host_emptyCache()
+        if is_npu():
+            torch.npu.empty_cache()
+        else:
+            torch._C._host_emptyCache()
 
 
 def available_memory():
-    device = torch.cuda.current_device()
-    free, total = torch.cuda.mem_get_info(device)
-    vm = psutil.virtual_memory()
-    return {
-        "gpu": str(device),
-        "total_GB": _byte_to_gb(total),
-        "free_GB": _byte_to_gb(free),
-        "used_GB": _byte_to_gb(total - free),
-        "allocated_GB": _byte_to_gb(torch.cuda.memory_allocated(device)),
-        "reserved_GB": _byte_to_gb(torch.cuda.memory_reserved(device)),
-        "host_total_GB": _byte_to_gb(vm.total),
-        "host_available_GB": _byte_to_gb(vm.available),
-        "host_used_GB": _byte_to_gb(vm.used),
-        "host_free_GB": _byte_to_gb(vm.free),
-    }
+    if is_npu():
+        device = torch.npu.current_device()
+        free, total = torch.npu.mem_get_info(device)
+        vm = psutil.virtual_memory()
+        return {
+            "gpu": str(device),
+            "total_GB": _byte_to_gb(total),
+            "free_GB": _byte_to_gb(free),
+            "used_GB": _byte_to_gb(total - free),
+            "allocated_GB": _byte_to_gb(torch.npu.memory_allocated(device)),
+            "reserved_GB": _byte_to_gb(torch.npu.memory_reserved(device)),
+            "host_total_GB": _byte_to_gb(vm.total),
+            "host_available_GB": _byte_to_gb(vm.available),
+            "host_used_GB": _byte_to_gb(vm.used),
+            "host_free_GB": _byte_to_gb(vm.free),
+        }
+    else:
+        device = torch.cuda.current_device()
+        free, total = torch.cuda.mem_get_info(device)
+        vm = psutil.virtual_memory()
+        return {
+            "gpu": str(device),
+            "total_GB": _byte_to_gb(total),
+            "free_GB": _byte_to_gb(free),
+            "used_GB": _byte_to_gb(total - free),
+            "allocated_GB": _byte_to_gb(torch.cuda.memory_allocated(device)),
+            "reserved_GB": _byte_to_gb(torch.cuda.memory_reserved(device)),
+            "host_total_GB": _byte_to_gb(vm.total),
+            "host_available_GB": _byte_to_gb(vm.available),
+            "host_used_GB": _byte_to_gb(vm.used),
+            "host_free_GB": _byte_to_gb(vm.free),
+        }
 
 
 def _byte_to_gb(n: int):

--- a/vime/utils/reloadable_process_group.py
+++ b/vime/utils/reloadable_process_group.py
@@ -6,6 +6,7 @@ import torch
 import torch.distributed as dist
 
 from vime.utils.memory_utils import available_memory, clear_memory, print_memory
+from vime.utils.common import is_npu
 
 logger = logging.getLogger(__name__)
 
@@ -181,10 +182,13 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
         reloadable_groups = ReloadableProcessGroup.GROUPS.get(pid, [])
         logger.info(f"Reloading {len(reloadable_groups)} process groups in pid {pid}")
         old_new_group = old_new_group_dict.get(pid)
+        backend = "nccl"
+        if is_npu():
+            backend = "hccl"
         for reloadable_group in reloadable_groups:
             if reloadable_group.group is not None:
                 continue
-            group = old_new_group(ranks=reloadable_group.group_info["ranks"], backend="nccl")
+            group = old_new_group(ranks=reloadable_group.group_info["ranks"], backend=backend)
             reloadable_group.group = group
 
     def rank(self) -> int:


### PR DESCRIPTION
### related vllm_ascend pr: 
https://github.com/vllm-project/vllm-ascend/pull/9378
https://github.com/vllm-project/vllm-ascend/pull/9152 
### train script:

```bash
export SLIME_SCRIPT_TRAIN_BACKEND=megatron
export PYTHONPATH="/usr/local/Megatron-Bridge/src:/usr/local/Megatron-LM/:$PYTHONPATH"
export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
export CUDA_DEVICE_MAX_CONNECTIONS=1
export RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1
export HCCL_HOST_SOCKET_PORT_RANGE=60000-60050
export HCCL_NPU_SOCKET_PORT_RANGE=61000-61050
export HYDRA_FULL_ERROR=1
export MASTER_PORT=$(shuf -i 20000-65000 -n 1)  # or any free port
export DISABLE_L2_CACHE=1
export VLLM_ASCEND_ENABLE_NZ=0
source /usr/local/CANN9.0.0/ascend-toolkit/set_env.sh
source /usr/local/CANN9.0.0/nnal/atb/set_env.sh

SCRIPT_DIR="/usr/local/vime/scripts"
source "${SCRIPT_DIR}/models/qwen3-4B.sh"
LOG_FILE="/usr/local/vime/train_qwen3_4b_vllm.log"

python train.py \
  --train-backend megatron \
  --actor-num-nodes 1 \
  --actor-num-gpus-per-node 4 \
  --rollout-num-gpus 4 \
  --rollout-num-gpus-per-engine 4 \
  ${MODEL_ARGS[@]} \
  \
  --hf-checkpoint /home/model/Qwen3-4B-Instruct-2507/ \
  \
  --prompt-data /home/model/dataset/dapo-math-17k/dapo-math-17k.jsonl \
  --input-key prompt \
  --label-key label \
  --apply-chat-template \
  --rollout-shuffle \
  --rm-type math \
  \
  --rollout-backend vllm \
  --vllm-weight-sync-mode native \
  --vllm-gpu-memory-utilization 0.6 \
  --vllm_enforce_eager \
  --vllm-enable-sleep-mode \
  --vllm-max-model-len 4096 \
  \
  --num-rollout 200 \
  --rollout-batch-size 32 \
  --n-samples-per-prompt 8 \
  --rollout-max-response-len 2048 \
  --rollout-temperature 1.0 \
  --global-batch-size 256 \
  --balance-data \
  \
  --advantage-estimator grpo \
  --kl-loss-coef 0.0 \
  --kl-loss-type low_var_kl \
  --kl-coef 0.00 \
  --entropy-coef 0.0 \
  --eps-clip 0.2 \
  --eps-clip-high 0.28 \
  \
  --optimizer adam \
  --lr 1e-6 \
  --lr-decay-style constant \
  --weight-decay 0.1 \
  --adam-beta1 0.9 \
  --adam-beta2 0.98 \
  \
  --tensor-model-parallel-size 4 \
  --pipeline-model-parallel-size 1 \
  --context-parallel-size 1 \
  --expert-model-parallel-size 1 \
  --expert-tensor-parallel-size 1 \
  --recompute-granularity full \
  --recompute-method uniform \
  --recompute-num-layers 1 \
  --use-dynamic-batch-size \
  --max-tokens-per-gpu 8192 \
  --load /home/model/Qwen3-4B-Instruct-2507/  \
  --megatron-to-hf-mode bridge  \
  \
  --attention-dropout 0.0 \
  --hidden-dropout 0.0 \
  --accumulate-allreduce-grads-in-fp32 \
  --attention-softmax-in-fp32 \
  --attention-backend flash \
  --micro-batch-size 1 \
  --use-flash-attn \
  \
  --train-memory-margin-bytes 2147483648 \
  2>&1 | tee -a "$LOG_FILE" 
```
### test on qwen3_4b
<img width="1329" height="356" alt="Snipaste_2026-06-08_11-43-23" src="https://github.com/user-attachments/assets/14fda2f8-179d-42f9-8f17-da6794eff01a" />


