### PR TITLE
test: make tests/unit + tests/utils pass in pure-CPU CI (no GPU)

### DIFF
--- a/tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_distributed.py
+++ b/tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_distributed.py
@@ -15,15 +15,45 @@ import torch
 MODULE_PATH = "vime.backends.megatron_utils.update_weight.update_weight_from_distributed"
 
 
+# Modules stubbed by _install_stubs(). These are installed ONLY for the duration of this
+# module's tests (inside the fixture) and restored on teardown. Installing them at import
+# time (top level) left a fake ``vllm`` (with no ``.engine``) in sys.modules, which broke
+# COLLECTION of sibling test modules (e.g. test_vllm_engine.py -> ModuleNotFoundError
+# 'vllm.engine'). pytest imports all test modules in one process before running fixtures,
+# so the stub leak must be confined to test runtime, not collection.
+_STUBBED_MODULES = (
+    "megatron",
+    "megatron.core",
+    "megatron.core.parallel_state",
+    "megatron.core.transformer",
+    "megatron.core.transformer.transformer_layer",
+    "ray",
+    "ray.actor",
+    "vime.utils.distributed_utils",
+    "vllm",
+    "vllm.distributed",
+    "vllm.distributed.weight_transfer",
+    "vllm.distributed.weight_transfer.nccl_engine",
+)
+
+
 @pytest.fixture(scope="module")
 def upw():
-    previous = sys.modules.pop(MODULE_PATH, None)
+    saved = {k: sys.modules.get(k) for k in (*_STUBBED_MODULES, MODULE_PATH)}
+    # Pop first so _install_stubs()'s setdefault() actually installs the stubs (hermetic),
+    # then drop the module-under-test so it re-imports against the stubs.
+    for k in _STUBBED_MODULES:
+        sys.modules.pop(k, None)
+    _install_stubs()
+    sys.modules.pop(MODULE_PATH, None)
     try:
         yield importlib.import_module(MODULE_PATH)
     finally:
-        sys.modules.pop(MODULE_PATH, None)
-        if previous is not None:
-            sys.modules[MODULE_PATH] = previous
+        for k, original in saved.items():
+            if original is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = original
 
 
 def _install_stubs():
@@ -100,9 +130,6 @@ def _install_stubs():
     sys.modules.setdefault("vllm.distributed", distributed_mod)
     sys.modules.setdefault("vllm.distributed.weight_transfer", weight_transfer_mod)
     sys.modules.setdefault("vllm.distributed.weight_transfer.nccl_engine", nccl_mod)
-
-
-_install_stubs()
 
 
 @dataclass
@@ -501,6 +528,7 @@ def test_connect_rollout_engines_always_uses_vllm_trainer_init(upw, monkeypatch)
     _patch_nccl_on_module(monkeypatch, upw, init_seen=seen)
     monkeypatch.setattr(upw.torch.cuda, "synchronize", lambda: None)
     monkeypatch.setattr(upw.torch.cuda, "empty_cache", lambda: None)
+    monkeypatch.setattr(upw.torch.cuda, "current_device", lambda: 0)
     monkeypatch.setattr(upw.ray, "get", lambda refs: refs)
     monkeypatch.setattr(upw.ray._private.services, "get_node_ip_address", lambda: "127.0.0.1")
 

--- a/tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py
+++ b/tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py
@@ -78,13 +78,50 @@ def _install_stubs():
     return hf_iter_stub, upw_dist_mod
 
 
-_HF_ITER_STUB, _UPW_DIST_MOD = _install_stubs()
+# Placeholder iterator stored on freshly-built instances; every test that drives a real
+# update overrides obj._hf_weight_iterator with its own MagicMock, so this only needs to be
+# a non-None object.
+_HF_ITER_STUB = MagicMock()
+_HF_ITER_STUB.get_hf_weight_chunks.return_value = iter([])
+
+# Modules stubbed by _install_stubs(), plus torch.distributed attributes it overwrites.
+# These are installed ONLY for this module's tests (inside the fixture) and restored on
+# teardown. Installing at import time leaked the stubs into sibling modules' COLLECTION (and
+# left MagicMocks on torch.distributed), one source of the cross-test order-pollution.
+_STUBBED_MODULES = (
+    "megatron",
+    "megatron.core",
+    "ray",
+    "ray.actor",
+    "vime.utils.distributed_utils",
+    "vime.backends.megatron_utils.update_weight.hf_weight_iterator_base",
+    "vime.backends.megatron_utils.update_weight.update_weight_from_distributed",
+)
+_DIST_ATTRS = ("get_rank", "get_world_size", "get_process_group_ranks", "barrier", "all_gather_object")
 
 
 @pytest.fixture(scope="module")
 def upw_vllm():
+    import torch.distributed as _dist
+
+    saved_mods = {k: sys.modules.get(k) for k in (*_STUBBED_MODULES, MODULE_PATH)}
+    saved_dist = {a: getattr(_dist, a, None) for a in _DIST_ATTRS}
+    # Pop first so _install_stubs()'s setdefault() actually installs stubs (hermetic).
+    for k in _STUBBED_MODULES:
+        sys.modules.pop(k, None)
+    _install_stubs()
     sys.modules.pop(MODULE_PATH, None)
-    return importlib.import_module(MODULE_PATH)
+    try:
+        yield importlib.import_module(MODULE_PATH)
+    finally:
+        for k, original in saved_mods.items():
+            if original is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = original
+        for a, original in saved_dist.items():
+            if original is not None:
+                setattr(_dist, a, original)
 
 
 @dataclass

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -12,6 +12,27 @@ import torch
 from vime.backends.vllm_utils import vllm_engine as mod
 
 
+@pytest.fixture(autouse=True)
+def _seed_vllm_cli_action_table_cache():
+    """Skip the device-probing rebuild of the vLLM CLI action table on CPU.
+
+    ``get_vllm_cli_action_table()`` builds its table via ``AsyncEngineArgs.add_cli_args``,
+    which probes the accelerator and raises ``RuntimeError: Failed to infer device type``
+    on a GPU-less host. The table only drives which ``vllm_*`` values are forwarded to the
+    ``vllm serve`` subprocess; the cmd/topology/sleep-mode assertions in this module exercise
+    vime's own explicit flag logic, not forwarding. Seed an empty (already-built) cache so the
+    rebuild is skipped, and restore the original on teardown so we never leak across modules.
+    """
+    import vime.backends.vllm_utils.arguments as _args
+
+    saved = _args._VLLM_CLI_ACTION_TABLE_CACHE
+    _args._VLLM_CLI_ACTION_TABLE_CACHE = {}
+    try:
+        yield
+    finally:
+        _args._VLLM_CLI_ACTION_TABLE_CACHE = saved
+
+
 class _MockResponse:
     def __init__(self, *, json_data: dict | None = None, text: str = "", status_code: int = 200):
         self._json_data = json_data

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,13 +2,23 @@
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 from unittest.mock import MagicMock
 
 
 def _ensure_ray_stub() -> None:
+    # Only stub ray when it is genuinely absent (bare-deps dev machine). When the real ray is
+    # installed (as in the CI image), a bare MagicMock stub shadows it and breaks unrelated
+    # submodule imports like ``from ray.util.placement_group import placement_group`` in
+    # sibling test packages — this conftest's module-level mutation leaks session-wide.
     if "ray" in sys.modules:
         return
+    try:
+        if importlib.util.find_spec("ray") is not None:
+            return
+    except (ImportError, ValueError):
+        pass
     ray = MagicMock()
     sys.modules["ray"] = ray
     sys.modules["ray._private"] = MagicMock()

--- a/tests/unit/rollout/conftest.py
+++ b/tests/unit/rollout/conftest.py
@@ -2,19 +2,37 @@
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 import types
 from unittest.mock import MagicMock
 
 
+def _real_module_available(name: str) -> bool:
+    """True if the real module is importable, so we should NOT shadow it with a stub.
+
+    These conftest stubs install bare ``sys.modules`` entries at import time and never
+    clean up, so they leak to sibling test packages (e.g. ``tests/utils``). When the real
+    dependency is installed (as in the CI image), a bare stub like ``vllm_router`` (no
+    submodules) breaks unrelated imports such as ``from vllm_router.launch_router import``.
+    Only stub when the real package is genuinely absent (bare-deps dev machines).
+    """
+    if name in sys.modules:
+        return True
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
 def _ensure_vllm_router_stub() -> None:
-    if "vllm_router" in sys.modules:
+    if _real_module_available("vllm_router"):
         return
     sys.modules["vllm_router"] = types.ModuleType("vllm_router")
 
 
 def _ensure_pil_stub() -> None:
-    if "PIL" in sys.modules:
+    if _real_module_available("PIL"):
         return
     pil = types.ModuleType("PIL")
     image_mod = types.ModuleType("PIL.Image")
@@ -24,7 +42,7 @@ def _ensure_pil_stub() -> None:
 
 
 def _ensure_transformers_stub() -> None:
-    if "transformers" in sys.modules:
+    if _real_module_available("transformers"):
         return
     mod = types.ModuleType("transformers")
     mod.AutoTokenizer = type(
@@ -43,13 +61,13 @@ def _ensure_transformers_stub() -> None:
 
 
 def _ensure_aiohttp_stub() -> None:
-    if "aiohttp" in sys.modules:
+    if _real_module_available("aiohttp"):
         return
     sys.modules["aiohttp"] = MagicMock()
 
 
 def _ensure_pylatexenc_stub() -> None:
-    if "pylatexenc" in sys.modules:
+    if _real_module_available("pylatexenc"):
         return
     pylatexenc = types.ModuleType("pylatexenc")
     latex2text = types.ModuleType("pylatexenc.latex2text")

--- a/tests/unit/rollout/test_vllm_rollout.py
+++ b/tests/unit/rollout/test_vllm_rollout.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import io
-import logging
 from argparse import Namespace
 from contextlib import contextmanager
 from unittest.mock import AsyncMock
@@ -179,12 +178,6 @@ def test_prepare_prompt_ids_multimodal_via_processor():
 
 
 @pytest.mark.unit
-def test_base_dataset_prompt_ids_ignores_sample_tokens():
-    sample = Sample(prompt="abc", tokens=[99, 99, 99])
-    assert mod._base_dataset_prompt_ids(sample, _FakeTokenizer(), None) == [97, 98, 99]
-
-
-@pytest.mark.unit
 def test_get_model_url_named_router_and_fallback():
     args = Namespace(
         vllm_router_ip="127.0.0.1",
@@ -196,126 +189,6 @@ def test_get_model_url_named_router_and_fallback():
     assert mod.get_model_url(args, "ref", "/v1/chat/completions/render") == (
         "http://10.0.0.2:9001/v1/chat/completions/render"
     )
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize(
-    ("finish_reason", "expected_type"),
-    [
-        ("length", "length"),
-        ("abort", "abort"),
-        ("cancelled", "abort"),
-        ("stop", "stop"),
-    ],
-)
-def test_vllm_meta_from_generate_choice_finish_reason(finish_reason, expected_type):
-    args = Namespace()
-    meta = mod._vllm_meta_from_generate_choice(
-        args,
-        {"finish_reason": finish_reason},
-        {"prompt_tokens": 3, "completion_tokens": 2},
-    )
-    assert meta["finish_reason"] == {"type": expected_type}
-    assert meta["prompt_tokens"] == 3
-    assert meta["completion_tokens"] == 2
-
-
-@pytest.mark.unit
-def test_vllm_meta_from_generate_choice_preserves_dict_finish_reason():
-    args = Namespace()
-    fr = {"type": "custom", "detail": "x"}
-    meta = mod._vllm_meta_from_generate_choice(args, {"finish_reason": fr}, None)
-    assert meta["finish_reason"] is fr
-
-
-@pytest.mark.unit
-def test_decode_vllm_routed_experts_roundtrip():
-    arr = np.arange(24, dtype=np.int32).reshape(2, 3, 4)
-    buf = io.BytesIO()
-    np.save(buf, arr)
-    encoded = base64.b64encode(buf.getvalue()).decode("ascii")
-    decoded = mod._decode_vllm_routed_experts(encoded)
-    np.testing.assert_array_equal(decoded, arr)
-
-
-@pytest.mark.unit
-def test_apply_vllm_routed_experts_requires_base64_choice_field_and_exact_rows():
-    # sample.tokens includes prompt+gen; routed_experts rows must be len(tokens)-1.
-    sample = Sample(tokens=[1, 2, 3, 4])
-    args = Namespace(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1)
-    routed = np.zeros((len(sample.tokens) - 1, 2, 1), dtype=np.int32)
-    mod._apply_vllm_routed_experts(args, sample, {"routed_experts": _encode_routed(routed)})
-    assert sample.rollout_routed_experts is not None
-    assert sample.rollout_routed_experts.shape == (3, 2, 1)
-
-
-@pytest.mark.unit
-def test_apply_vllm_routed_experts_raises_on_row_mismatch():
-    sample = Sample(tokens=[1, 2, 3, 4])
-    args = Namespace(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1)
-    routed = np.zeros((1, 2, 1), dtype=np.int32)  # should be 3 rows
-    with pytest.raises(RuntimeError, match="rows"):
-        mod._apply_vllm_routed_experts(args, sample, {"routed_experts": _encode_routed(routed)})
-
-
-@pytest.mark.unit
-def test_inference_generate_tokens_and_logprobs_full_content():
-    choice = {
-        "token_ids": [1, 2],
-        "logprobs": {"content": [{"logprob": -0.1}, {"logprob": -0.2}]},
-    }
-    tids, lps = mod._inference_generate_tokens_and_logprobs(choice)
-    assert tids == [1, 2]
-    assert lps == pytest.approx([-0.1, -0.2])
-
-
-@pytest.mark.unit
-def test_inference_generate_tokens_and_logprobs_pads_partial_content():
-    choice = {
-        "token_ids": [1, 2, 3],
-        "logprobs": {"content": [{"logprob": -0.5}]},
-    }
-    tids, lps = mod._inference_generate_tokens_and_logprobs(choice)
-    assert tids == [1, 2, 3]
-    assert lps == pytest.approx([-0.5, 0.0, 0.0])
-
-
-@pytest.mark.unit
-def test_inference_generate_tokens_and_logprobs_empty_when_not_int_list():
-    tids, lps = mod._inference_generate_tokens_and_logprobs({"token_ids": ["a"]})
-    assert tids == []
-    assert lps == []
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize(
-    ("tokens", "logprobs", "expected_lps"),
-    [
-        ([1, 2], [-0.1, -0.2], [-0.1, -0.2]),
-        ([1, 2, 3], [-0.1, -0.2, -0.3, -0.4], [-0.1, -0.2, -0.3]),
-        ([1, 2, 3], [-0.1], [-0.1, 0.0, 0.0]),
-        ([], [1.0], []),
-    ],
-)
-def test_align_engine_tokens_and_logprobs(tokens, logprobs, expected_lps):
-    out_toks, out_lps = mod._align_engine_tokens_and_logprobs(tokens, logprobs)
-    assert out_toks == tokens
-    assert out_lps == expected_lps
-
-
-@pytest.mark.unit
-def test_warn_if_sampling_filters_may_affect_logprobs(caplog):
-    caplog.set_level(logging.WARNING, logger=mod.logger.name)
-    mod._warn_if_sampling_filters_may_affect_logprobs({"top_p": 0.9, "top_k": -1})
-    assert "processed_logprobs may make rollout logprobs differ" in caplog.text
-
-
-@pytest.mark.unit
-def test_warn_if_sampling_filters_may_affect_logprobs_skips_defaults(caplog):
-    caplog.set_level(logging.WARNING, logger=mod.logger.name)
-    mod._warn_if_sampling_filters_may_affect_logprobs({"top_p": 1.0, "top_k": -1})
-    mod._warn_if_sampling_filters_may_affect_logprobs({"top_p": 1.0, "top_k": 0})
-    assert caplog.text == ""
 
 
 @pytest.mark.unit
@@ -383,42 +256,6 @@ def test_mm_render_response_to_generate_body_invalid_shape():
 
 
 @pytest.mark.unit
-def test_router_worker_urls_workers_endpoint(monkeypatch):
-    monkeypatch.setattr(mod, "get", AsyncMock(return_value={"workers": [{"url": "http://w1"}, {"url": "http://w2"}]}))
-    args = Namespace(vllm_router_ip="127.0.0.1", vllm_router_port=7000)
-    urls = asyncio.run(mod._router_worker_urls(args))
-    assert urls == ["http://w1", "http://w2"]
-
-
-@pytest.mark.unit
-def test_router_worker_urls_falls_back_to_list_workers(monkeypatch):
-    async def fake_get(url: str):
-        if url.endswith("/workers"):
-            raise RuntimeError("not found")
-        return {"urls": ["http://w3"]}
-
-    monkeypatch.setattr(mod, "get", fake_get)
-    args = Namespace(vllm_router_ip="127.0.0.1", vllm_router_port=7000)
-    urls = asyncio.run(mod._router_worker_urls(args))
-    assert urls == ["http://w3"]
-
-
-@pytest.mark.unit
-def test_resume_vllm_workers_posts_to_each_url(monkeypatch):
-    post_mock = AsyncMock(return_value={"ok": True})
-    monkeypatch.setattr(mod, "post", post_mock)
-    asyncio.run(mod._resume_vllm_workers(["http://a/", "http://b"]))
-    assert post_mock.await_count == 2
-    endpoints = [call.args[0] for call in post_mock.await_args_list]
-    assert endpoints == ["http://a/resume", "http://b/resume"]
-
-
-@pytest.mark.unit
-def test_resume_vllm_workers_noop_on_empty_urls():
-    asyncio.run(mod._resume_vllm_workers([]))
-
-
-@pytest.mark.unit
 def test_prepare_prompt_ids_reuses_tokens_with_multimodal_train_inputs():
     sample = Sample(
         prompt="hi",
@@ -430,79 +267,9 @@ def test_prepare_prompt_ids_reuses_tokens_with_multimodal_train_inputs():
 
 
 @pytest.mark.unit
-def test_base_dataset_prompt_ids_multimodal_via_processor():
-    sample = Sample(prompt="hi", multimodal_inputs={"images": ["img"]})
-    assert mod._base_dataset_prompt_ids(sample, _FakeTokenizer(), _FakeProcessor()) == [10, 20, 30]
-
-
-@pytest.mark.unit
 def test_get_model_url_without_named_routers():
     args = Namespace(vllm_router_ip="10.0.0.3", vllm_router_port=9000)
     assert mod.get_model_url(args, "any") == "http://10.0.0.3:9000/inference/v1/generate"
-
-
-@pytest.mark.unit
-def test_vllm_meta_from_generate_choice_defaults_to_stop():
-    meta = mod._vllm_meta_from_generate_choice(Namespace(), {}, None)
-    assert meta == {"finish_reason": {"type": "stop"}}
-
-
-@pytest.mark.unit
-def test_apply_vllm_routed_experts_disabled_or_missing():
-    sample = Sample(tokens=[1, 2, 3])
-    mod._apply_vllm_routed_experts(Namespace(use_rollout_routing_replay=False), sample, {})
-    assert sample.rollout_routed_experts is None
-    with pytest.raises(RuntimeError, match="routing replay"):
-        mod._apply_vllm_routed_experts(Namespace(use_rollout_routing_replay=True), sample, {})
-
-
-@pytest.mark.unit
-def test_apply_vllm_routed_experts_skips_bad_shape():
-    arr = np.zeros((2, 2), dtype=np.int32)
-    sample = Sample(tokens=[1, 2, 3])
-    args = Namespace(use_rollout_routing_replay=True)
-    with pytest.raises(RuntimeError, match="routing replay"):
-        mod._apply_vllm_routed_experts(args, sample, {"routed_experts": _encode_routed(arr)})
-
-
-@pytest.mark.unit
-def test_apply_vllm_routed_experts_trims_when_too_many_rows():
-    # New contract: require exact rows, no trimming.
-    arr = np.zeros((9, 2, 1), dtype=np.int32)
-    sample = Sample(tokens=[1, 2, 3])
-    args = Namespace(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1)
-    with pytest.raises(RuntimeError, match="rows"):
-        mod._apply_vllm_routed_experts(args, sample, {"routed_experts": _encode_routed(arr)})
-
-
-@pytest.mark.unit
-def test_apply_vllm_routed_experts_raises_when_too_few_rows():
-    arr = np.zeros((1, 2, 1), dtype=np.int32)
-    sample = Sample(tokens=[1, 2, 3])
-    args = Namespace(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1)
-    with pytest.raises(RuntimeError, match="routing replay"):
-        mod._apply_vllm_routed_experts(args, sample, {"routed_experts": _encode_routed(arr)})
-
-
-@pytest.mark.unit
-def test_apply_vllm_routed_experts_skips_layer_topk_mismatch():
-    arr = np.zeros((2, 3, 4), dtype=np.int32)
-    sample = Sample(tokens=[1, 2, 3])
-    args = Namespace(use_rollout_routing_replay=True, num_layers=2, moe_router_topk=1)
-    with pytest.raises(RuntimeError, match="routing replay"):
-        mod._apply_vllm_routed_experts(args, sample, {"routed_experts": _encode_routed(arr)})
-
-
-@pytest.mark.unit
-def test_inference_generate_tokens_empty_list():
-    assert mod._inference_generate_tokens_and_logprobs({"token_ids": []}) == ([], [])
-
-
-@pytest.mark.unit
-def test_inference_generate_tokens_without_logprobs_dict():
-    tids, lps = mod._inference_generate_tokens_and_logprobs({"token_ids": [1, 2]})
-    assert tids == [1, 2]
-    assert lps == [0.0, 0.0]
 
 
 @pytest.mark.unit
@@ -552,31 +319,6 @@ def test_generate_text_path_updates_sample(patch_generate_state, monkeypatch):
     body = post_mock.await_args_list[0].args[1]
     assert body["token_ids"] == [97, 98, 99]
     assert body["sampling_params"]["max_tokens"] == 8
-
-
-@pytest.mark.unit
-def test_generate_partial_continuation_uses_full_tokens(patch_generate_state, monkeypatch):
-    post_mock = AsyncMock(return_value=_generate_response([60]))
-    monkeypatch.setattr(mod, "post", post_mock)
-
-    sample = Sample(index=0, prompt="abc", response="x", tokens=[97, 98, 99, 40, 41])
-    asyncio.run(mod.generate(_rollout_args(), sample, _default_sampling_params(max_new_tokens=5)))
-
-    body = post_mock.await_args_list[0].args[1]
-    assert body["token_ids"] == [97, 98, 99, 40, 41]
-    assert body["sampling_params"]["max_tokens"] == 3
-
-
-@pytest.mark.unit
-def test_generate_truncated_when_continuation_budget_zero(patch_generate_state, monkeypatch):
-    post_mock = AsyncMock()
-    monkeypatch.setattr(mod, "post", post_mock)
-
-    sample = Sample(index=0, prompt="abc", response="done", tokens=[97, 98, 99, 40, 41])
-    result = asyncio.run(mod.generate(_rollout_args(), sample, _default_sampling_params(max_new_tokens=2)))
-
-    assert result.status == Sample.Status.TRUNCATED
-    post_mock.assert_not_called()
 
 
 @pytest.mark.unit
@@ -787,30 +529,3 @@ def test_eval_rollout_passk_requests_do_not_share_session_ids(patch_generate_sta
     assert None not in seen_session_ids
     assert len(set(seen_session_ids)) == 2
     assert result[dataset_cfg.name]["samples"][0].session_id != result[dataset_cfg.name]["samples"][1].session_id
-
-
-@pytest.mark.unit
-def test_abort_pauses_workers_and_resumes(patch_generate_state, monkeypatch):
-    async def _run_abort():
-        state = _PatchedGenerateState(_rollout_args(partial_rollout=False))
-
-        async def done_group():
-            return [Sample(index=0, prompt="p", response="x")]
-
-        task = asyncio.create_task(done_group())
-        await asyncio.sleep(0)
-        state.pendings = {task}
-        monkeypatch.setattr(mod, "GenerateState", lambda args: state)
-        monkeypatch.setattr(mod, "_router_worker_urls", AsyncMock(return_value=["http://worker/"]))
-        pause_mock = AsyncMock(return_value={"ok": True})
-        resume_mock = AsyncMock(return_value={"ok": True})
-        monkeypatch.setattr(mod, "post", pause_mock)
-        monkeypatch.setattr(mod, "_resume_vllm_workers", resume_mock)
-
-        aborted = await mod.abort(_rollout_args(), rollout_id=3)
-        assert aborted == []
-        pause_mock.assert_awaited()
-        assert "pause?mode=abort" in pause_mock.await_args_list[0].args[0]
-        resume_mock.assert_awaited_once()
-
-    asyncio.run(_run_abort())


### PR DESCRIPTION
## Problem
The always-on `e2e-test-unit` CI job runs `pytest tests/unit tests/utils` **CPU-only** (`# CPU/mock only -> no --gpus`), but on a GPU-less host the suite **aborts collection and fails 38 tests**. Verified on `inferactinc/public:vime-latest` @ current `main` (`ae5d6b04`).

## Root causes & fixes (test-only — no source changes)

**1. Stale helper tests (28) — `test_vllm_rollout.py`**
PR #178 rewrote `vllm_rollout.py` to mirror slime's `sglang_rollout.py`, inlining/removing granular private helpers (`_apply_vllm_routed_experts`, `_decode_vllm_routed_experts`, `_inference_generate_tokens_and_logprobs`, `_align_engine_tokens_and_logprobs`, `_vllm_meta_from_generate_choice`, `_router_worker_urls`, `_resume_vllm_workers`, `_base_dataset_prompt_ids`, `_warn_if_sampling_filters_may_affect_logprobs`) and the in-`generate` partial-continuation budget. 28 tests still called those removed functions. Their behavior is already covered by the surviving `test_generate_*` integration tests (e.g. `test_generate_applies_routed_experts`, `test_generate_multimodal_render_then_generate`). Removed the obsolete tests; kept the 26 that exercise the current API.

**2. Device probe (4) — `test_vllm_engine.py` (3) + `test_update_weight_from_distributed.py` (1)**
`get_vllm_cli_action_table()` rebuilds via `AsyncEngineArgs.add_cli_args`, which probes the accelerator and raises `RuntimeError: Failed to infer device type` on a GPU-less host. Added an autouse fixture seeding the (already-built) action-table cache so the rebuild is skipped (the table only drives `vllm serve` flag forwarding; the assertions test vime's explicit flag logic). Mocked `torch.cuda.current_device` in the update_weight connect test.

**3. Import-time `sys.modules` pollution**
The `update_weight` tests ran `_install_stubs()` at **module top level**, leaving a fake `vllm` (no `.engine`) in `sys.modules` that broke **collection** of `test_vllm_engine.py` (`ModuleNotFoundError: vllm.engine`). pytest imports all modules in one process before running fixtures, so the leak must be confined to runtime — moved stub installation into the module-scoped fixtures with save/restore. The `ray` / `vllm_router` conftest stubs now defer to the real package via `importlib.util.find_spec`, so a bare non-package stub no longer leaks session-wide into sibling test packages (`tests/utils`).

## Result
`pytest tests/unit tests/utils` → **162 passed, 0 failed** on pure CPU (was: collection abort + 38 failures). ruff / autoflake / isort / black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)