### PR TITLE
fix(vllm_rollout): guard routed_experts value, not just key presence

### DIFF
--- a/vime/rollout/vllm_rollout.py
+++ b/vime/rollout/vllm_rollout.py
@@ -373,11 +373,6 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         sample.rollout_log_probs = []
     sample.rollout_log_probs += new_response_log_probs
 
-    # Guard the value, not just key presence: unlike sglang (which omits the key when
-    # routed experts are not requested), the vLLM engine includes ``routed_experts: null``
-    # in the response. A bare ``in`` check would pass and ``None.encode()`` would crash the
-    # rollout for every MoE model without rollout-routing-replay. ``.get(...) is not None``
-    # handles both key-absent and key-present-but-null.
     if choice.get("routed_experts") is not None:
         raw = base64.b64decode(choice["routed_experts"].encode("ascii"), validate=True)
         arr = np.load(io.BytesIO(raw), allow_pickle=False)

--- a/vime/rollout/vllm_rollout.py
+++ b/vime/rollout/vllm_rollout.py
@@ -373,7 +373,12 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         sample.rollout_log_probs = []
     sample.rollout_log_probs += new_response_log_probs
 
-    if "routed_experts" in choice:
+    # Guard the value, not just key presence: unlike sglang (which omits the key when
+    # routed experts are not requested), the vLLM engine includes ``routed_experts: null``
+    # in the response. A bare ``in`` check would pass and ``None.encode()`` would crash the
+    # rollout for every MoE model without rollout-routing-replay. ``.get(...) is not None``
+    # handles both key-absent and key-present-but-null.
+    if choice.get("routed_experts") is not None:
         raw = base64.b64decode(choice["routed_experts"].encode("ascii"), validate=True)
         arr = np.load(io.BytesIO(raw), allow_pickle=False)
         sample.rollout_routed_experts = np.ascontiguousarray(arr.astype(np.int32, copy=True)).reshape(


### PR DESCRIPTION
## Bug
Running the CI suite on `inferactinc/public:vime-latest` @ current `main`, `test_qwen3.5_0.8B_gsm8k_async_short` (and any MoE-model rollout) crashes mid-rollout:

```
ray::RolloutManager.generate() ...
  File ".../vime/rollout/vllm_rollout.py", line 377, in generate
    raw = base64.b64decode(choice["routed_experts"].encode("ascii"), validate=True)
AttributeError: 'NoneType' object has no attribute 'encode'
```

## Root cause (a #178 regression)
PR #178 aligned `vllm_rollout.py` with slime's `sglang_rollout.py`, copying the parse guard `if "routed_experts" in choice:`. But the response shapes differ:

- **slime/sglang**: only requests routed experts under `--use-rollout-routing-replay` (`payload["return_routed_experts"] = True`) and **omits the key** otherwise → `if "routed_experts" in output["meta_info"]:` is sufficient.
- **vime/vLLM**: the engine **includes `routed_experts: null`** in every choice. The bare `in` check passes with a `None` value, so `.encode("ascii")` raises.

This breaks every MoE-model rollout that is not using rollout-routing-replay (gsm8k Qwen3.5-0.8B, etc.).

## Fix
Gate on the value, not just key presence — mirrors slime's effective behavior and handles both key-absent and key-present-but-null:

```python
if choice.get("routed_experts") is not None:
```

## Verification
gsm8k smoke test re-run on `vime-latest` (h200) in progress; will confirm green in a comment. Change is a 1-line guard + comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)