### PR TITLE
fix(debug-rollout): derive num_gpus_per_node in colocate debug_rollout_only

### DIFF
--- a/vime/utils/arguments.py
+++ b/vime/utils/arguments.py
@@ -1739,18 +1739,6 @@ def vime_validate_args(args):
     if args.debug_rollout_only:
         if args.colocate and (not args.rollout_num_gpus):
             args.rollout_num_gpus = args.actor_num_gpus_per_node * args.actor_num_nodes
-            # debug_rollout_only forces colocate=False below (to skip train-side
-            # offload / memory logic), but the rollout engines still physically
-            # share the actor's nodes. The colocate branch further down derives
-            # num_gpus_per_node from actor_num_gpus_per_node for exactly this
-            # reason, yet it is gated on args.colocate and so never runs here.
-            # Without it, --num-gpus-per-node keeps its 8-GPU/node default; on
-            # hardware with a different per-node count (e.g. 4x GB200/node) the
-            # rollout-engine addr/port allocation computes node_index via
-            # num_gpus_per_node and maps every engine to node 0, so worker-node
-            # engines are handed the head node's IP and fail to bind
-            # (OSError: [Errno 99] Cannot assign requested address). Derive the
-            # real per-node count here too.
             if args.num_gpus_per_node != args.actor_num_gpus_per_node:
                 logger.info(
                     f"debug_rollout_only colocate: overriding num_gpus_per_node "

--- a/vime/utils/arguments.py
+++ b/vime/utils/arguments.py
@@ -1739,6 +1739,25 @@ def vime_validate_args(args):
     if args.debug_rollout_only:
         if args.colocate and (not args.rollout_num_gpus):
             args.rollout_num_gpus = args.actor_num_gpus_per_node * args.actor_num_nodes
+            # debug_rollout_only forces colocate=False below (to skip train-side
+            # offload / memory logic), but the rollout engines still physically
+            # share the actor's nodes. The colocate branch further down derives
+            # num_gpus_per_node from actor_num_gpus_per_node for exactly this
+            # reason, yet it is gated on args.colocate and so never runs here.
+            # Without it, --num-gpus-per-node keeps its 8-GPU/node default; on
+            # hardware with a different per-node count (e.g. 4x GB200/node) the
+            # rollout-engine addr/port allocation computes node_index via
+            # num_gpus_per_node and maps every engine to node 0, so worker-node
+            # engines are handed the head node's IP and fail to bind
+            # (OSError: [Errno 99] Cannot assign requested address). Derive the
+            # real per-node count here too.
+            if args.num_gpus_per_node != args.actor_num_gpus_per_node:
+                logger.info(
+                    f"debug_rollout_only colocate: overriding num_gpus_per_node "
+                    f"{args.num_gpus_per_node} -> actor_num_gpus_per_node "
+                    f"{args.actor_num_gpus_per_node} (per-physical-node GPU count)."
+                )
+                args.num_gpus_per_node = args.actor_num_gpus_per_node
         else:
             args.actor_num_gpus_per_node = min(8, args.rollout_num_gpus)
             args.actor_num_nodes = args.rollout_num_gpus // args.actor_num_gpus_per_node


### PR DESCRIPTION
## Problem

In `--debug-rollout-only` runs (e.g. eval), the rollout engines still physically share the actor's nodes, but `args.colocate` is forced to `False` (to skip train-side offload/memory logic) **before** the `if args.colocate:` block that derives `num_gpus_per_node` from `actor_num_gpus_per_node`. So that derivation is skipped and `--num-gpus-per-node` keeps its **8-GPU/node default**.

On hardware with a different per-node GPU count (e.g. **4x GB200/node**), `_allocate_rollout_engine_addr_and_ports_normal` computes:

```
num_engines_per_node = num_gpus_per_node // rollout_num_gpus_per_engine   # 8 // 1 = 8 (wrong; should be 4)
node_index          = local_rank // num_engines_per_node                  # rank // 8
```

A 4-node / 16-engine run then collapses to **2 logical node groups** (ranks 0-7 -> group 0, 8-15 -> group 1). The allocator samples only the group-leader engine's IP and assigns it to all engines in the group, so engines physically on the *other* two nodes are handed the wrong host. Their vLLM server binds fine (`0.0.0.0:port`) but `_register_worker_with_router` / `_wait_server_healthy` dial the wrong IP and hang -- only **8/16 engines** join the router and the rollout never starts:

```
OSError: [Errno 99] Cannot assign requested address
-> vLLM server exited unexpectedly with code 1
```

## Fix

Derive `num_gpus_per_node = actor_num_gpus_per_node` inside the colocate branch of the `debug_rollout_only` handling, mirroring the existing colocate-mode derivation a few lines below. Same root cause and fix as the colocate path; it was simply unreachable in `debug_rollout_only` because `colocate` is cleared first.

This is exactly equivalent to passing `--num-gpus-per-node <actor_num_gpus_per_node>` by hand (the documented workaround); the change just applies it automatically so the opaque bind failure can't bite.

## Notes

- Single-node 8-GPU runs are a no-op: `actor_num_gpus_per_node == 8 == default`, so the override does nothing.
- Only the colocate branch (`args.colocate and not args.rollout_num_gpus`) is touched; the non-colocate debug path that recomputes `actor_num_gpus_per_node` from `rollout_num_gpus` is unchanged.

AI assistance (Claude) was used for this change.