### PR TITLE
[Bugfix] enable --vllm-enable-expert-parallel wherever vLLM deepep is used (FP8 MoE fix)

### DIFF
--- a/tests/test_qwen3_30B_A3B.py
+++ b/tests/test_qwen3_30B_A3B.py
@@ -99,7 +99,13 @@ def execute():
     )
 
     if USE_DEEPEP:
-        vllm_args += "--vllm-all2all-backend deepep_high_throughput "
+        # deepep is an expert-parallel all2all backend, so enable EP. Without EP the MoE
+        # expert FFN is tensor-sharded across the engine's TP ranks (moe_ffn/TP = 768/8 = 96),
+        # which an FP8 block-quantized checkpoint rejects ("output_size of gate's and up's
+        # weight = 96 is not divisible by block_n = 128"). EP keeps each expert's gate/up
+        # whole (768, divisible by 128). Mirrors the proven DP+EP rollout config in the PD
+        # tests (test_qwen3.6_35B_A3B_pd_mooncake / test_glm4.7_30B_A3B_pd_mooncake).
+        vllm_args += "--vllm-all2all-backend deepep_high_throughput --vllm-enable-expert-parallel "
 
     ci_args = "--ci-test "
 

--- a/tests/test_qwen3_30B_A3B.py
+++ b/tests/test_qwen3_30B_A3B.py
@@ -99,12 +99,6 @@ def execute():
     )
 
     if USE_DEEPEP:
-        # deepep is an expert-parallel all2all backend, so enable EP. Without EP the MoE
-        # expert FFN is tensor-sharded across the engine's TP ranks (moe_ffn/TP = 768/8 = 96),
-        # which an FP8 block-quantized checkpoint rejects ("output_size of gate's and up's
-        # weight = 96 is not divisible by block_n = 128"). EP keeps each expert's gate/up
-        # whole (768, divisible by 128). Mirrors the proven DP+EP rollout config in the PD
-        # tests (test_qwen3.6_35B_A3B_pd_mooncake / test_glm4.7_30B_A3B_pd_mooncake).
         vllm_args += "--vllm-all2all-backend deepep_high_throughput --vllm-enable-expert-parallel "
 
     ci_args = "--ci-test "

--- a/tests/test_qwen3_30B_A3B_r3.py
+++ b/tests/test_qwen3_30B_A3B_r3.py
@@ -99,7 +99,13 @@ def execute():
     )
 
     if USE_DEEPEP:
-        vllm_args += "--vllm-all2all-backend deepep_high_throughput "
+        # deepep is an expert-parallel all2all backend, so enable EP. Without EP the MoE
+        # expert FFN is tensor-sharded across the engine's TP ranks (moe_ffn/TP = 768/8 = 96),
+        # which an FP8 block-quantized checkpoint rejects ("output_size of gate's and up's
+        # weight = 96 is not divisible by block_n = 128"). EP keeps each expert's gate/up
+        # whole (768, divisible by 128). Mirrors the proven DP+EP rollout config in the PD
+        # tests (test_qwen3.6_35B_A3B_pd_mooncake / test_glm4.7_30B_A3B_pd_mooncake).
+        vllm_args += "--vllm-all2all-backend deepep_high_throughput --vllm-enable-expert-parallel "
 
     ci_args = "--ci-test "
 

--- a/tests/test_qwen3_30B_A3B_r3.py
+++ b/tests/test_qwen3_30B_A3B_r3.py
@@ -99,12 +99,6 @@ def execute():
     )
 
     if USE_DEEPEP:
-        # deepep is an expert-parallel all2all backend, so enable EP. Without EP the MoE
-        # expert FFN is tensor-sharded across the engine's TP ranks (moe_ffn/TP = 768/8 = 96),
-        # which an FP8 block-quantized checkpoint rejects ("output_size of gate's and up's
-        # weight = 96 is not divisible by block_n = 128"). EP keeps each expert's gate/up
-        # whole (768, divisible by 128). Mirrors the proven DP+EP rollout config in the PD
-        # tests (test_qwen3.6_35B_A3B_pd_mooncake / test_glm4.7_30B_A3B_pd_mooncake).
         vllm_args += "--vllm-all2all-backend deepep_high_throughput --vllm-enable-expert-parallel "
 
     ci_args = "--ci-test "


### PR DESCRIPTION
## Root cause

Several CI configs enable the vLLM **deepep** all2all backend
(`--vllm-all2all-backend deepep_high_throughput`) but never pass
`--vllm-enable-expert-parallel`. deepep *is* an expert-parallel all2all
backend, so without EP the MoE expert FFN gets tensor-sharded across the
engine's TP ranks. On the Qwen3-30B-A3B FP8 block-quantized checkpoint this
crashes at vLLM engine init:

```
ValueError: The output_size of gate's and up's weight = 96 is not
            divisible by weight quantization block_n = 128.
```

`moe_ffn_hidden_size = 768`, `768 / TP8 = 96`, and 96 is not divisible by the
FP8 block size `block_n = 128`. Enabling EP keeps each expert's gate/up whole
(768, divisible by 128). This pure-TP config was inherited from the slime
(sglang) era and never adapted for vLLM's FP8 MoE.

## Fix

Add `--vllm-enable-expert-parallel` to the `if USE_DEEPEP:` branch wherever a
vLLM deepep all2all backend is set.

| Changed file | Line | slime counterpart | slime EP evidence |
|---|---|---|---|
| `tests/test_qwen3_30B_A3B.py` | 108 | `reference/slime/tests/test_qwen3_30B_A3B.py` | `:102` `--sglang-moe-a2a-backend deepep --sglang-deepep-mode auto` (sglang's deepep a2a backend engages expert parallelism inherently) |
| `tests/test_qwen3_30B_A3B_r3.py` | 108 | `reference/slime/tests/test_qwen3_30B_A3B_r3.py` | `:102` `--sglang-moe-a2a-backend deepep --sglang-deepep-mode auto` (same) |

### slime cross-check verdict

In slime, the deepep branch sets `--sglang-moe-a2a-backend deepep`. sglang's
deepep a2a backend is an expert-parallel dispatch path — selecting it engages
EP for the MoE rollout engine. The vLLM translation
(`--vllm-all2all-backend deepep_high_throughput`) dropped the implicit EP that
sglang's deepep backend provided; vLLM requires EP to be made explicit via
`--vllm-enable-expert-parallel`. EP genuinely belongs in these configs and was
lost during the sglang→vLLM translation, not invented here.

This also mirrors the already-correct PD tests
(`tests/test_qwen3.6_35B_A3B_pd_mooncake.py:99`,
`tests/test_glm4.7_30B_A3B_pd_mooncake.py:112`), which pair their vLLM rollout
DP/EP config with `--vllm-enable-expert-parallel`.

## Scope of search

A repo-wide grep (`--vllm-all2all-backend deepep*` / `vllm_all2all_backend` /
`all2all`) found **only** these two files setting a vLLM deepep backend
without EP. The other `deepep` hits are all TRAIN-side megatron flags
(`--moe-enable-deepep` / `--moe-token-dispatcher-type flex`) in
`scripts/run-glm4.7-30B-A3B.sh`, `scripts/run-glm4.7-355B-A32B.sh`, and
`examples/coding_agent_rl/run_qwen36_35b_a3b_swe_8nodes.sh` — these are
unrelated to the rollout/vLLM all2all backend and were left untouched. The
`*_pd_mooncake.py` PD tests already set `--vllm-enable-expert-parallel`
correctly and were left untouched.

## Verification

`python3 -m py_compile` passes on both changed tests. The CI configs
`mg_qwen3_30B_deepep_fp8` + `mg_qwen3_30B_r3_deepep_fp8` are being GPU-verified
separately on h200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
