### PR TITLE
fix(vllm_engine): change release_memory_occupation default to level=2

### DIFF
--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -815,7 +815,7 @@ class VLLMEngine(RayActor):
             )
         return self._weight_version
 
-    def release_memory_occupation(self, level: int = 1):
+    def release_memory_occupation(self, level: int = 2):
         """Flush prefix cache, then ``POST /sleep?level={level}``."""
         if self.node_rank != 0:
             return None


### PR DESCRIPTION
## Summary

Change `VLLMEngine.release_memory_occupation` default from `level=1` to `level=2`. **1 line changed.**

## Why

`level=1` offloads ~78 GB of model weights to CPU RAM per engine on every rollout→train transition. In colocate training the trainer calls `update_weights()` to push new weights back anyway, so the CPU backup is unnecessary waste.

`level=2` discards GPU weights with no CPU backup. All call sites that don't pass an explicit `level` get the better default automatically.

## Validation

GLM-4.5-Air 106B colocate, GB200 ×16 (4 nodes × 4 GPU), 100-step run:

| | level=1 (before) | level=2 (after) |
|---|---|---|
| host_used_GB peak | 841/882 GB (95%) → Ray OOM | ~520 GB (59%) ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)