### PR TITLE
translation(agent): replace SGLang parsers with vLLM parsers (#107 follow-up)

### DIFF
--- a/examples/coding_agent_rl/README.md
+++ b/examples/coding_agent_rl/README.md
@@ -162,9 +162,6 @@ That last case is the important correctness guard. A re-tokenization mismatch
 can make a string-level conversation look continuous while token-level
 provenance is broken. vime keeps the context needed to continue the agent, but
 does not backprop through tokens whose sampled origin can no longer be proven.
-The unit tests in `tests/test_agent_trajectory.py` cover matched prefixes,
-skipped turns, split-output drift, changed token counts, and prompt-base
-restarts.
 
 ## Fan-out Semantics
 

--- a/examples/coding_agent_rl/README.md
+++ b/examples/coding_agent_rl/README.md
@@ -86,13 +86,15 @@ ROLLOUT_ARGS=(
 )
 ```
 
-claude-code's tool invocations are parsed from the model output. By default the
-adapter uses the built-in XML tool-call fallback (`parse_xml_tool_uses`), which
-handles the `<tool_call><function=...>` text Qwen3-Coder emits, so no extra
-engine-side parser configuration is required. (The adapter can optionally
-delegate to SGLang's reasoning/function-call parsers when
-`vllm_tool_call_parser` / `vllm_reasoning_parser` are set on `args`, but this is
-not used by this example and is not wired into vime's vLLM arguments.)
+The vLLM server must expose Qwen3.6's tool-call and reasoning parsers so claude-code's tool invocations are parsed correctly:
+
+```bash
+VLLM_ARGS=(
+   --vllm-tool-call-parser qwen3_coder
+   --vllm-reasoning-parser qwen3
+   ...
+)
+```
 
 ## SWE-specific Environment Knobs
 

--- a/examples/coding_agent_rl/README.md
+++ b/examples/coding_agent_rl/README.md
@@ -121,6 +121,9 @@ All set in the launcher; tune per cluster.
 only during generation: each turn clamps the generation length to the remaining
 context. Trajectory merge/export keeps the emitted segments and does not drop
 them for length.
+The Anthropic adapter reuses `--vllm-tool-call-parser` and
+`--vllm-reasoning-parser` for output parsing, so those flags must match the
+served model.
 
 ## String-in, Token-out Trajectories
 
@@ -159,6 +162,9 @@ That last case is the important correctness guard. A re-tokenization mismatch
 can make a string-level conversation look continuous while token-level
 provenance is broken. vime keeps the context needed to continue the agent, but
 does not backprop through tokens whose sampled origin can no longer be proven.
+The unit tests in `tests/test_agent_trajectory.py` cover matched prefixes,
+skipped turns, split-output drift, changed token counts, and prompt-base
+restarts.
 
 ## Fan-out Semantics
 

--- a/examples/coding_agent_rl/run_qwen36_35b_a3b_swe_8nodes.sh
+++ b/examples/coding_agent_rl/run_qwen36_35b_a3b_swe_8nodes.sh
@@ -198,30 +198,18 @@ OPTIMIZER_ARGS=(
    --use-precision-aware-optimizer
 )
 
-# ============ rollout engine (vLLM) ============
-# sglang->vLLM arg map (see translation_guide.md "Arg map"):
-#   --sglang-mem-fraction-static  -> --vllm-gpu-memory-utilization
-#   --sglang-dp-size N            -> --vllm-data-parallel-size N
-#   --sglang-ep-size N            -> --vllm-enable-expert-parallel (boolean)
-#   --sglang-{enable-dp-attention,enable-dp-lm-head,moe-dense-tp-size,
-#             mamba-scheduler-strategy}  -> sglang-only, no vLLM equivalent (dropped)
-#   --sglang-{tool-call,reasoning}-parser -> no vLLM arg; coding_agent_rl uses the
-#             XML tool-call fallback (parsers=None), so these are dropped.
-#   --sglang-speculative-* per-field flags -> a single --vllm-speculative-config
-#             JSON dict (commented below; supply your EAGLE draft model to enable).
+# ============ rollout engine ============
 VLLM_ARGS=(
    --rollout-num-gpus 64
    --rollout-num-gpus-per-engine ${ROLLOUT_TP_SIZE}
    --vllm-gpu-memory-utilization ${ROLLOUT_MEM_UTILIZATION}
    --vllm-data-parallel-size ${ROLLOUT_DP_SIZE}
    --vllm-enable-expert-parallel
+   --vllm-tool-call-parser qwen3_coder
+   --vllm-reasoning-parser qwen3
+   --vllm-speculative-config '{"method":"mtp","num_speculative_tokens":3}'
    --prefill-num-servers 1
 )
-# Speculative decoding (EAGLE): vLLM takes one JSON dict rather than the
-# sglang per-field flags. Uncomment and point "model" at your draft checkpoint.
-# VLLM_ARGS+=(
-#    --vllm-speculative-config '{"method":"eagle","num_speculative_tokens":4,"model":"/path/to/eagle_draft"}'
-# )
 
 MISC_ARGS=(
    --attention-dropout 0.0

--- a/vime/agent/adapters/anthropic.py
+++ b/vime/agent/adapters/anthropic.py
@@ -311,6 +311,7 @@ def _build_reply(target: Chain, output_ids: list[int], finish: str, app) -> tupl
     raw_output = tok.decode(output_ids, skip_special_tokens=False) if output_ids else ""
     parsed = parse_model_output(
         raw_output,
+        tokenizer=tok,
         tools_schema=target.tools_schema,
         tool_parser_name=app[TOOL_PARSER_KEY],
         reasoning_parser_name=app[REASONING_PARSER_KEY],

--- a/vime/agent/adapters/openai.py
+++ b/vime/agent/adapters/openai.py
@@ -299,6 +299,7 @@ def _parse_turn(target: Chain, turn: TurnRecord, app) -> ParsedModelOutput:
     raw_output = tok.decode(turn.output_ids, skip_special_tokens=False) if turn.output_ids else ""
     return parse_model_output(
         raw_output,
+        tokenizer=tok,
         tools_schema=target.tools_schema,
         tool_parser_name=app[TOOL_PARSER_KEY],
         reasoning_parser_name=app[REASONING_PARSER_KEY],

--- a/vime/agent/parsing.py
+++ b/vime/agent/parsing.py
@@ -24,32 +24,29 @@ class ParsedModelOutput:
 def parse_model_output(
     raw_output: str,
     *,
+    tokenizer,
     tools_schema: list[dict] | None,
     tool_parser_name: str | None,
     reasoning_parser_name: str | None,
 ) -> ParsedModelOutput:
     """Parse raw model text into reasoning, visible text, and tool uses.
 
-    When ``reasoning_parser_name`` / ``tool_parser_name`` are set the heavy
-    format-specific work is delegated to SGLang's reasoning and function-call
-    parsers (imported lazily, so they are only required when explicitly
-    enabled). The coding-agent example leaves both unset and relies on the XML
-    fallback, which covers the Anthropic-style tool-call text that some
-    coding-agent models still emit occasionally.
+    The heavy format-specific work is delegated to vLLM's reasoning and
+    tool-call parsers. The XML fallback covers Anthropic-style tool-call
+    text that some coding-agent models still emit occasionally.
     """
     reasoning, body_text = "", raw_output
     if reasoning_parser_name:
-        from sglang.srt.parser.reasoning_parser import ReasoningParser
+        from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+        from vllm.reasoning import ReasoningParserManager
 
-        r, b = ReasoningParser(
-            model_type=reasoning_parser_name,
-            stream_reasoning=False,
-        ).parse_non_stream(raw_output)
+        parser = ReasoningParserManager.get_reasoning_parser(reasoning_parser_name)(tokenizer)
+        r, b = parser.extract_reasoning(raw_output, ChatCompletionRequest(messages=[]))
         reasoning, body_text = r or "", b or ""
         if not reasoning and "</think>" in body_text:
             reasoning, body_text = body_text.split("</think>", 1)
 
-    body_text, tool_uses = parse_tool_uses(body_text, tools_schema, tool_parser_name)
+    body_text, tool_uses = parse_tool_uses(body_text, tools_schema, tool_parser_name, tokenizer)
     return ParsedModelOutput(
         reasoning=reasoning,
         text=(body_text or "").strip(),
@@ -61,27 +58,29 @@ def parse_tool_uses(
     body_text: str,
     tools_schema: list[dict] | None,
     tool_parser_name: str | None,
+    tokenizer=None,
 ) -> tuple[str, list[dict[str, Any]]]:
     """Parse tool calls from body text and return visible text plus tool uses."""
     tool_uses: list[dict[str, Any]] = []
     if tool_parser_name and tools_schema:
-        from sglang.srt.entrypoints.openai.protocol import Function, Tool
-        from sglang.srt.function_call.function_call_parser import FunctionCallParser
+        from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+        from vllm.tool_parsers import ToolParserManager
 
-        sg_tools = [Tool(type="function", function=Function(**d["function"])) for d in tools_schema]
-        parser = FunctionCallParser(tools=sg_tools, tool_call_parser=tool_parser_name)
-        calls = []
-        if parser.has_tool_call(body_text):
-            try:
-                body_text, calls = parser.parse_non_stream(body_text)
-            except Exception:
-                logger.exception("[agent.parsing] sglang tool-call parsing failed; falling back")
-        for c in calls:
-            try:
-                args = json.loads(c.parameters or "{}")
-            except json.JSONDecodeError:
-                args = {"_raw_arguments": c.parameters}
-            tool_uses.append({"name": c.name or "tool", "input": args})
+        request = ChatCompletionRequest(messages=[], tools=tools_schema)
+        parser = ToolParserManager.get_tool_parser(tool_parser_name)(tokenizer, tools=request.tools)
+        info = None
+        try:
+            info = parser.extract_tool_calls(body_text, request)
+        except Exception:
+            logger.exception("[agent.parsing] vllm tool-call parsing failed; falling back")
+        if info is not None and info.tools_called:
+            body_text = info.content or ""
+            for call in info.tool_calls:
+                try:
+                    args = json.loads(call.function.arguments or "{}")
+                except json.JSONDecodeError:
+                    args = {"_raw_arguments": call.function.arguments}
+                tool_uses.append({"name": call.function.name or "tool", "input": args})
 
     if not tool_uses and tools_schema:
         body_text, tool_uses = parse_xml_tool_uses(body_text, tools_schema)

--- a/vime/agent/parsing.py
+++ b/vime/agent/parsing.py
@@ -58,7 +58,7 @@ def parse_tool_uses(
     body_text: str,
     tools_schema: list[dict] | None,
     tool_parser_name: str | None,
-    tokenizer=None,
+    tokenizer,
 ) -> tuple[str, list[dict[str, Any]]]:
     """Parse tool calls from body text and return visible text plus tool uses."""
     tool_uses: list[dict[str, Any]] = []

--- a/vime/backends/vllm_utils/arguments.py
+++ b/vime/backends/vllm_utils/arguments.py
@@ -361,9 +361,6 @@ _VIME_ORCHESTRATION_DESTS = frozenset(
         "vllm_server_concurrency",
         "vllm_enable_deterministic_inference",
         "vllm_weight_sync_packed",
-        # agent-adapter tool-call parser name; consumed by examples/coding_agent_rl
-        # generate.py, never a `vllm serve` flag. (vllm_reasoning_parser is a real
-        # AsyncEngineArgs flag and is intentionally NOT excluded here.)
         "vllm_tool_call_parser",
         # vime-only flags for fine-grained deployment; consumed in vime/ray/rollout.py
         # (start_rollout_servers / _resolve_vllm_config) and must NOT be forwarded to

--- a/vime/backends/vllm_utils/arguments.py
+++ b/vime/backends/vllm_utils/arguments.py
@@ -234,6 +234,19 @@ def add_vllm_arguments(parser):
             "true determinism — seed alone does not control kernel selection."
         ),
     )
+    # vime-only orchestration knob: not part of vllm's engine CLI. Names the
+    # vLLM tool-call parser the agent adapter uses to parse model output (vime
+    # runs the engine in raw token-generation mode, so the adapter parses
+    # client-side). Mirrors slime's --sglang-tool-call-parser; read by
+    # examples/coding_agent_rl. (--vllm-reasoning-parser is NOT hand-added — it
+    # is auto-generated from AsyncEngineArgs.reasoning_parser.)
+    parser.add_argument(
+        "--vllm-tool-call-parser",
+        dest="vllm_tool_call_parser",
+        type=str,
+        default=None,
+        help="vLLM tool-call parser name for agent output parsing (e.g. qwen3_coder).",
+    )
     # vime-only orchestration knob: not part of vllm's CLI but read by
     # UpdateWeightFromDistributed._use_vllm_packed() to choose packed
     # broadcast vs per-bucket NCCL for dense models.
@@ -357,6 +370,10 @@ _VIME_ORCHESTRATION_DESTS = frozenset(
         "vllm_server_concurrency",
         "vllm_enable_deterministic_inference",
         "vllm_weight_sync_packed",
+        # agent-adapter tool-call parser name; consumed by examples/coding_agent_rl
+        # generate.py, never a `vllm serve` flag. (vllm_reasoning_parser is a real
+        # AsyncEngineArgs flag and is intentionally NOT excluded here.)
+        "vllm_tool_call_parser",
         # vime-only flags for fine-grained deployment; consumed in vime/ray/rollout.py
         # (start_rollout_servers / _resolve_vllm_config) and must NOT be forwarded to
         # the per-engine "vllm serve" subprocess.

--- a/vime/backends/vllm_utils/arguments.py
+++ b/vime/backends/vllm_utils/arguments.py
@@ -234,12 +234,6 @@ def add_vllm_arguments(parser):
             "true determinism — seed alone does not control kernel selection."
         ),
     )
-    # vime-only orchestration knob: not part of vllm's engine CLI. Names the
-    # vLLM tool-call parser the agent adapter uses to parse model output (vime
-    # runs the engine in raw token-generation mode, so the adapter parses
-    # client-side). Mirrors slime's --sglang-tool-call-parser; read by
-    # examples/coding_agent_rl. (--vllm-reasoning-parser is NOT hand-added — it
-    # is auto-generated from AsyncEngineArgs.reasoning_parser.)
     parser.add_argument(
         "--vllm-tool-call-parser",
         dest="vllm_tool_call_parser",
@@ -247,9 +241,6 @@ def add_vllm_arguments(parser):
         default=None,
         help="vLLM tool-call parser name for agent output parsing (e.g. qwen3_coder).",
     )
-    # vime-only orchestration knob: not part of vllm's CLI but read by
-    # UpdateWeightFromDistributed._use_vllm_packed() to choose packed
-    # broadcast vs per-bucket NCCL for dense models.
     _vllm_packed = parser.add_mutually_exclusive_group()
     _vllm_packed.add_argument(
         "--vllm-weight-sync-packed",


### PR DESCRIPTION
Split out of #196 (part 1 of 2). The riskier half: the agent parsing/tokenizer translation that was missed in the #107 sync.

## What
vime's agent output parsing still depended on **SGLang's** reasoning/tool parsers. This swaps them for **vLLM's**, mirroring slime's structure:

- **`vime/agent/parsing.py`** — use `vllm.reasoning.ReasoningParserManager` and `vllm.tool_parsers.ToolParserManager` (both require a tokenizer, unlike sglang's); build a `ChatCompletionRequest` with validated tools; keep the `</think>` reasoning fallback and the XML tool-call fallback. `try/except` is scoped **only** around `extract_tool_calls`, matching slime's `try` around its `parse_non_stream` — no broad import/construct guards.
- **`vime/agent/adapters/{anthropic,openai}.py`** — pass `tokenizer=` to `parse_model_output` (forced by the vLLM parser API).
- **`vime/backends/vllm_utils/arguments.py`** — add `--vllm-tool-call-parser` (orchestration-only dest, mirrors slime's `--sglang-tool-call-parser`); `--vllm-reasoning-parser` is auto-generated from `AsyncEngineArgs`.
- **`examples/coding_agent_rl/{README.md,run_*.sh}`** — wire `qwen3_coder` tool parser + `qwen3` reasoning parser so the example exercises the vLLM path; enable MTP speculative decoding via `--vllm-speculative-config` (mirrors slime's EAGLE block, ported to vLLM's single-JSON form); trim the didactic sglang→vLLM arg-map comment back to slime's plain "rollout engine" header.

## Why split
#196 mixed this code translation with a large batch of mechanical/cosmetic doc+symbol cleanup. This PR isolates the part that actually changes parsing behavior so it can be reviewed carefully; the cosmetic remainder is the sibling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)