### PR TITLE
fix(rollout): isolate per-trajectory exceptions in generate_and_rm_group

### DIFF
--- a/vime/rollout/vllm_rollout.py
+++ b/vime/rollout/vllm_rollout.py
@@ -480,17 +480,42 @@ async def generate_and_rm_group(
         if sample.session_id is None:
             sample.session_id = str(uuid.uuid4())
 
-    tasks = []
+    pairs = []
     for idx, sample in enumerate(group):
         current_sampling_params = sampling_params.copy()
         if getattr(args, "vllm_enable_deterministic_inference", False):
             seed = state.group_sampling_seeds[idx]
             current_sampling_params["seed"] = seed
-        tasks.append(
-            asyncio.create_task(generate_and_rm(args, sample, current_sampling_params, evaluation=evaluation))
+        pairs.append(
+            (sample, asyncio.create_task(generate_and_rm(args, sample, current_sampling_params, evaluation=evaluation)))
         )
 
-    group = await asyncio.gather(*tasks)
+    # Per-trajectory exception isolation. Without return_exceptions=True a single
+    # trajectory raising an unhandled exception cancels the whole gather and crashes
+    # the entire rollout via CancelledError (which also swallows the root cause).
+    # This is benign for plain RLVR rollouts where generate_and_rm never raises, but
+    # agentic rollouts can raise after the custom generate() returns (e.g. trajectory
+    # token-merge / prefix-drift edge cases outside generate()'s own try/except).
+    # Log the real traceback and substitute an ABORTED resolved=False placeholder
+    # (same fan-out list shape) so one bad sample cannot take down the batch.
+    results = await asyncio.gather(*[t for _, t in pairs], return_exceptions=True)
+    group = []
+    for sample, res in zip([s for s, _ in pairs], results):
+        if isinstance(res, BaseException):
+            logger.error(
+                "[generate_and_rm_group] trajectory crashed, isolating idx=%s: %r",
+                getattr(sample, "index", "?"), res, exc_info=res,
+            )
+            sample.tokens = [0, 0]
+            sample.response = ""
+            sample.response_length = 1
+            sample.loss_mask = [0]
+            sample.rollout_log_probs = [0.0]
+            sample.reward = 0.0
+            sample.status = Sample.Status.ABORTED
+            group.append([sample])
+        else:
+            group.append(res)
 
     if not state.aborted and args.group_rm:
         with trace_span(group, "group_reward_model"):


### PR DESCRIPTION
## Problem

`generate_and_rm_group` gathers per-trajectory tasks with a bare `asyncio.gather(*tasks)` (no `return_exceptions=True`). If **any single trajectory** raises an unhandled exception, gather cancels the siblings and propagates, crashing the **entire rollout** via `CancelledError` — which also **swallows the root exception** (logs show only CancelledError, not what actually failed).

This is benign for plain RLVR rollouts (where `generate_and_rm` reliably catches its own errors), which is why it has not surfaced before. But **agentic rollouts** can raise *after* the custom `generate()` returns — e.g. trajectory token-merge / prefix-drift edge cases that run outside `generate()`'s own try/except. Observed on a 500-instance SWE-bench eval: a single bad trajectory (~1 in 350-400) reproducibly took down all 500 (crashed ~321 and ~373 on two runs), with only a `CancelledError` in the logs.

## Fix

Catch per-trajectory exceptions at the group gather:
- `return_exceptions=True` so one failure no longer cancels the batch.
- `logger.error(..., exc_info=res)` to surface the **real** traceback (currently swallowed by CancelledError).
- Substitute an `ABORTED` / `resolved=False` placeholder with the same fan-out list shape, reusing the existing `_abort()` sample contract (`tokens=[0,0]`, `loss_mask=[0]`, `status=ABORTED`, `reward=0.0`).

`ABORTED` is already a first-class status that downstream short-circuits (reward-model skip at `generate_and_rm`, routing-replay skip), so the placeholder introduces no new sample shape — it is identical to what every timeout / missing-image abort already produces.

## Notes
- Same latent gap exists upstream in **slime** (`slime/rollout/sglang_rollout.py`) and **miles** (`inference_rollout_common.py`) — both have the identical bare gather; worth porting there too.
- **AI-assisted** (Claude); **not yet human-reviewed or runtime-validated** — opening for review. A patched eval run is in flight but has not yet passed the prior crash point, so end-to-end confirmation is still pending. Change is local to the gather and reuses the existing abort contract.
