### PR TITLE
refactor(tau-bench): align with slime structure

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,4 +9,5 @@ These examples provide concrete examples to leverage vime in your own RL workflo
 - **[geo3k_vlm](./geo3k_vlm)**: Training VLMs on a single-turn reasoning task using GRPO on the GEO3K dataset.
 - **[geo3k_vlm_multi_turn](./geo3k_vlm_multi_turn)**: VLM multi-turn training on Geo3k dataset.
 - **[multi_agent](./multi_agent)**: Example of running multi-agent RL with `vime`.
+- **[tau-bench](./tau-bench)**: Multi-turn tool-use agent training in tau-bench environments.
 - **[train_infer_mismatch_helper](./train_infer_mismatch_helper)**: Algorithmic methods for rollout correction (e.g., TIS, MIS).

--- a/examples/tau-bench/README.md
+++ b/examples/tau-bench/README.md
@@ -1,0 +1,54 @@
+# Tau-Bench Multi-Turn Tool Use
+
+Multi-turn tool-use RL training in [tau-bench](https://github.com/JD-ETH/tau-bench) environments with vime vLLM rollout.
+
+## Setup
+
+```bash
+pip install -e /path/to/vime --no-deps --no-build-isolation
+
+git clone https://github.com/JD-ETH/tau-bench.git /path/to/tau-bench-src
+cd /path/to/tau-bench-src && git checkout feature/litellm-retry
+pip install -e . --no-deps && pip install litellm
+
+cd /path/to/vime/examples/tau-bench
+python tau1_mock.py --local_dir /path/to/datasets/tau-bench/
+```
+
+Model (Qwen3-4B-Instruct-2507):
+
+```bash
+export MODEL_ARGS_ROTARY_BASE=5000000
+source scripts/models/qwen3-4B.sh
+PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
+  "${MODEL_ARGS[@]}" \
+  --hf-checkpoint /path/to/Qwen3-4B-Instruct-2507 \
+  --save /path/to/Qwen3-4B-Instruct-2507_torch_dist
+```
+
+## Run
+
+```bash
+cd /path/to/vime
+bash examples/tau-bench/run_qwen3_4B.sh
+```
+
+Key flags (set in `run_qwen3_4B.sh`):
+
+- `--custom-generate-function-path generate_with_tau.generate`
+- `--custom-rm-path generate_with_tau.batched_tau_bench_rm`
+- Ray `PYTHONPATH` must include **`examples/tau-bench`** (before vime root)
+- `--vllm-max-model-len 16384` and `--rollout-max-context-len 16384`
+- `unset PYTORCH_CUDA_ALLOC_CONF` before colocate / non-colocate train
+
+Default tau settings (formerly in yaml) are applied inside `generate_with_tau._ensure_tau_args`:
+
+- `max_turns=10`, `tau_env=retail`, local vLLM user sim via `openai/local-qwen3-4b`
+
+To use Gemini as user simulator, pass overrides on the train command line, e.g.:
+
+```bash
+--tau-user-model gemini-2.0-flash-lite --tau-user-model-provider gemini
+```
+
+(Requires `GEMINI_API_KEY` in the Ray runtime env.)

--- a/examples/tau-bench/README.md
+++ b/examples/tau-bench/README.md
@@ -1,54 +1,74 @@
-# Tau-Bench Multi-Turn Tool Use
+# Tau bench
+This example shows vime training in an agentic multi-turn tool use environment.
 
-Multi-turn tool-use RL training in [tau-bench](https://github.com/JD-ETH/tau-bench) environments with vime vLLM rollout.
 
-## Setup
+## Environment Setup
+Install vime and tau-bench dependencies:
 
 ```bash
-pip install -e /path/to/vime --no-deps --no-build-isolation
-
-git clone https://github.com/JD-ETH/tau-bench.git /path/to/tau-bench-src
-cd /path/to/tau-bench-src && git checkout feature/litellm-retry
-pip install -e . --no-deps && pip install litellm
-
-cd /path/to/vime/examples/tau-bench
-python tau1_mock.py --local_dir /path/to/datasets/tau-bench/
+cd /root/
+git clone https://github.com/vllm-project/vime.git
+cd vime
+pip install -e . --no-deps --no-build-isolation
+# for tau bench
+cd /root/
+git clone https://github.com/JD-ETH/tau-bench.git tau-bench-src
+cd tau-bench-src
+git checkout feature/litellm-retry
+pip install -e . --no-deps
+pip install litellm
 ```
 
-Model (Qwen3-4B-Instruct-2507):
+Use the following script to generate mock data for vime training.
 
 ```bash
-export MODEL_ARGS_ROTARY_BASE=5000000
-source scripts/models/qwen3-4B.sh
+cd /root/vime/examples/tau-bench
+python tau1_mock.py --local_dir /root/tau-bench/
+```
+
+Initialize the Qwen3-4B-Instruct-2507 model needed for tool use:
+
+```bash
+# hf checkpoint
+hf download Qwen/Qwen3-4B-Instruct-2507 --local-dir /root/Qwen3-4B-Instruct-2507
+
+# mcore checkpoint
+cd /root/vime
+source scripts/models/qwen3-4B-Instruct-2507.sh
 PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
-  "${MODEL_ARGS[@]}" \
-  --hf-checkpoint /path/to/Qwen3-4B-Instruct-2507 \
-  --save /path/to/Qwen3-4B-Instruct-2507_torch_dist
+    ${MODEL_ARGS[@]} \
+    --hf-checkpoint /root/Qwen3-4B-Instruct-2507 \
+    --save /root/Qwen3-4B-Instruct-2507_torch_dist
 ```
 
-## Run
+## Running the Script
+
+Configure user simulation for tau-bench (defaults are applied in `generate_with_tau._ensure_tau_args`):
+
+```python
+# Defaults (override via train.py CLI flags):
+#   tau_env=retail
+#   tau_user_model=openai/local-qwen3-4b
+#   tau_user_model_provider=openai
+#   tau_task_split=train
+#   tau_user_strategy=llm
+#   max_turns=10
+#
+# Gemini user simulator example:
+#   export GEMINI_API_KEY="YOUR KEY"
+#   --tau-user-model gemini-2.0-flash-lite --tau-user-model-provider gemini
+#
+# Local mock user (no external API), set in run_qwen3_4B.sh:
+#   export TAU_BENCH_MOCK=1
+```
+
+Rollout uses vLLM (`/v1/chat/completions/render` + `/inference/v1/generate`).
+Tool calls are parsed locally via `vllm_tool_parser.py` and `openai_tool_adapter.py`.
+
+And run:
+
 
 ```bash
-cd /path/to/vime
+cd /root/vime
 bash examples/tau-bench/run_qwen3_4B.sh
 ```
-
-Key flags (set in `run_qwen3_4B.sh`):
-
-- `--custom-generate-function-path generate_with_tau.generate`
-- `--custom-rm-path generate_with_tau.batched_tau_bench_rm`
-- Ray `PYTHONPATH` must include **`examples/tau-bench`** (before vime root)
-- `--vllm-max-model-len 16384` and `--rollout-max-context-len 16384`
-- `unset PYTORCH_CUDA_ALLOC_CONF` before colocate / non-colocate train
-
-Default tau settings (formerly in yaml) are applied inside `generate_with_tau._ensure_tau_args`:
-
-- `max_turns=10`, `tau_env=retail`, local vLLM user sim via `openai/local-qwen3-4b`
-
-To use Gemini as user simulator, pass overrides on the train command line, e.g.:
-
-```bash
---tau-user-model gemini-2.0-flash-lite --tau-user-model-provider gemini
-```
-
-(Requires `GEMINI_API_KEY` in the Ray runtime env.)

--- a/examples/tau-bench/README.md
+++ b/examples/tau-bench/README.md
@@ -1,25 +1,24 @@
-# Tau bench
-This example shows vime training in an agentic multi-turn tool use environment.
+# Tau bench 
+This example shows vime training in an agentic multi-turn tool use environment. 
 
 
-## Environment Setup
+## Environment Setup 
 Install vime and tau-bench dependencies:
 
 ```bash
 cd /root/
 git clone https://github.com/vllm-project/vime.git
 cd vime
-pip install -e . --no-deps --no-build-isolation
-# for tau bench
-cd /root/
-git clone https://github.com/JD-ETH/tau-bench.git tau-bench-src
-cd tau-bench-src
-git checkout feature/litellm-retry
 pip install -e . --no-deps
-pip install litellm
+# for tau bench 
+cd /root/
+git clone https://github.com/JD-ETH/tau-bench.git
+cd tau-bench
+git checkout feature/litellm-retry
+pip install -e . --no-deps 
 ```
 
-Use the following script to generate mock data for vime training.
+Use the following script to generate mock data for vime training. 
 
 ```bash
 cd /root/vime/examples/tau-bench
@@ -43,27 +42,22 @@ PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
 
 ## Running the Script
 
-Configure user simulation for tau-bench (defaults are applied in `generate_with_tau._ensure_tau_args`):
+You need to configure your litellm API in `generate_with_tau.py` for user simulation:
 
 ```python
-# Defaults (override via train.py CLI flags):
-#   tau_env=retail
-#   tau_user_model=openai/local-qwen3-4b
-#   tau_user_model_provider=openai
-#   tau_task_split=train
-#   tau_user_strategy=llm
-#   max_turns=10
-#
-# Gemini user simulator example:
-#   export GEMINI_API_KEY="YOUR KEY"
-#   --tau-user-model gemini-2.0-flash-lite --tau-user-model-provider gemini
-#
-# Local mock user (no external API), set in run_qwen3_4B.sh:
-#   export TAU_BENCH_MOCK=1
+TAU_CONFIGS = {
+    "env": "retail",  # Select between ["retail", "airline"]
+    "agent": "tool-calling",  # Select between ["tool-calling", "act", "react", "few-shot"], only tool-calling implemented for now
+    "user_model": "gemini-2.0-flash-lite",  # Cheap Model for user simulator
+    "user_model_provider": "gemini",
+    "task_split": "train",  # Select between ["train", "test", "dev"] for retail, ["test"] for airline
+    "user_strategy": "llm",  # Select between ["llm", "react", "verify", "reflection"]
+    "model_provider": "auto_router", # Unused, required
+    "model": "qwen3-4b", # Unused, reqired
+}
+# Replace with your actual API key for user sim    
+GEMINI_API_KEY = "YOUR KEY" 
 ```
-
-Rollout uses vLLM (`/v1/chat/completions/render` + `/inference/v1/generate`).
-Tool calls are parsed locally via `vllm_tool_parser.py` and `openai_tool_adapter.py`.
 
 And run:
 

--- a/examples/tau-bench/generate_with_tau.py
+++ b/examples/tau-bench/generate_with_tau.py
@@ -1,578 +1,153 @@
-"""Tau-bench multi-turn custom rollout for vime (vLLM render + generate).
+"""
+Tau-Bench Integration for vime Training
 
-Combines tau env interaction, tool parsing (``vllm_tool_parser``), and vLLM
-multi-turn rollout in one entry point: ``generate_with_tau.generate``.
+This module provides the main interface for training agents in tau-bench environments
+using the vime framework. It handles agent-environment interactions and converts
+results to the format expected by vime's training pipeline.
 """
 
-from __future__ import annotations
-
-import json
 import logging
 import os
-import uuid
 from typing import Any
 
-from openai_tool_adapter import create_openai_adapter
-from tau_bench.agents.tool_calling_agent import RESPOND_ACTION_NAME
 from tau_bench.envs import get_env
-from tau_bench.types import Action, RunConfig
+from tau_bench.types import RunConfig
+from trainable_agents import InteractionResult, Status, agent_factory
 
-from vime.rollout.vllm_rollout import (
-    GenerateState,
-    _apply_vllm_routed_experts,
-    _build_inference_sampling_params,
-    _coerce_flat_int_token_ids,
-    _inference_generate_tokens_and_logprobs,
-    _mm_render_response_to_generate_body,
-)
-from vime.utils.http_utils import post
 from vime.utils.types import Sample
 
+# Set up logger for this module
 logger = logging.getLogger(__name__)
 
-# Defaults formerly in tau_bench_config.yaml
-_TAU_DEFAULT_MAX_TURNS = 10
+# Tau-bench configuration
+TAU_CONFIGS = {
+    "env": "retail",  # Select between ["retail", "airline"]
+    "agent": "tool-calling",  # Select between ["tool-calling", "act", "react", "few-shot"]
+    "user_model": "gemini-2.5-flash-lite",  # Cheap Model for user simulator
+    "task_split": "train",  # Select between ["train", "test", "dev"] for retail
+    "user_strategy": "llm",  # Select between ["llm", "react", "verify", "reflection"]
+    "model_provider": "auto_router",  # Unused, required
+    "model": "qwen3-4b",  # Unused, required
+    "user_model_provider": "gemini",
+}
+# Replace with your actual API key for user sim
+GEMINI_API_KEY = "NONE"
+os.environ["GEMINI_API_KEY"] = GEMINI_API_KEY
+tau_config = RunConfig(**TAU_CONFIGS)
 
 
-def _ensure_tau_args(args: Any) -> None:
-    if getattr(args, "max_turns", None) is None:
-        args.max_turns = _TAU_DEFAULT_MAX_TURNS
-    for key, value in (
-        ("tau_env", "retail"),
-        ("tau_user_model", "openai/local-qwen3-4b"),
-        ("tau_user_model_provider", "openai"),
-        ("tau_task_split", "train"),
-        ("tau_user_strategy", "llm"),
-    ):
-        if getattr(args, key, None) is None:
-            setattr(args, key, value)
+def res_to_sample(res: InteractionResult, task_index: int) -> Sample:
+    """
+    Convert InteractionResult to Sample format for vime training.
 
+    This function transforms the tau-bench interaction result into the format
+    expected by vime's training pipeline, handling status mapping and response
+    length calculation.
 
-async def tau_bench_rm(args, sample: Sample, **kwargs) -> float:
-    return sample.reward if sample.reward is not None else 0.0
+    Args:
+        res: InteractionResult from tau-bench agent
+        task_index: Index of the task being processed
 
+    Returns:
+        Sample object for vime training
+    """
+    # Map tau-bench status to vime status
+    status_mapping = {
+        Status.COMPLETED: "completed",
+        Status.TRUNCATED: "truncated",
+        Status.ABORTED: "aborted",
+    }
+    status = status_mapping.get(res.status)
 
-async def batched_tau_bench_rm(args, samples, **kwargs) -> list[float] | float:
-    if isinstance(samples, Sample):
-        return samples.reward if samples.reward is not None else 0.0
-    rewards = [s.reward if s.reward is not None else 0.0 for s in samples]
-    max_r = max(rewards) if rewards else 1.0
-    if max_r > 0:
-        rewards = [r / max_r for r in rewards]
-    return rewards
+    # Debug logging for response tracking
+    logger.debug(
+        f"res_to_sample: response_length="
+        f"{res.response_length if hasattr(res, 'response_length') else 'None'}, "
+        f"loss_mask_len={len(res.loss_mask) if res.loss_mask else 'None'}, "
+        f"tokens_len={len(res.tokens) if res.tokens else 'None'}"
+    )
 
+    # Create sample with basic information
+    sample = Sample(
+        index=task_index,
+        prompt=res.prompt,
+        tokens=res.tokens,
+        response=res.response,
+        reward=res.reward,
+        loss_mask=res.loss_mask,
+        status=status,
+        metadata=res.info,
+    )
 
-class TauBenchEnv:
-    def __init__(
-        self,
-        *,
-        tau_config: RunConfig,
-        task_index: int | None = None,
-        max_turns: int = 30,
-    ):
-        self.tau_config = tau_config
-        self.task_index = task_index
-        self.max_turns = max_turns
-        self.turn = 0
-        self.total_reward = 0.0
-        self.info: dict[str, Any] = {}
-        self.env = None
-        self.openai_adapter = None
-        self.successful_tool_calls = 0
-        self.total_tool_calls = 0
-        self.format_correct_calls = 0
-
-    def reset(self):
-        self.turn = 0
-        self.total_reward = 0.0
-        self.info = {}
-        self.successful_tool_calls = 0
-        self.total_tool_calls = 0
-        self.format_correct_calls = 0
-
-        self.env = get_env(
-            env_name=self.tau_config.env,
-            user_strategy=self.tau_config.user_strategy,
-            user_model=self.tau_config.user_model,
-            user_provider=self.tau_config.user_model_provider,
-            task_split=self.tau_config.task_split,
-            task_index=self.task_index,
-        )
-
-        self.openai_adapter = create_openai_adapter(
-            tools_info=self.env.tools_info,
-            parser_type="qwen25",
-        )
-
-        env_reset_res = self.env.reset(task_index=self.task_index) if self.task_index is not None else self.env.reset()
-        observation = env_reset_res.observation
-        self.info = self._to_dict(env_reset_res.info)
-
-        return {
-            "obs_str": observation,
-            "role": "user",
-            "wiki": self.env.wiki,
-            "tools_info": self.env.tools_info,
-        }
-
-    def step(self, response_text: str):
-        self.turn += 1
-        is_final_turn = self.turn >= self.max_turns
-
-        logger.info(
-            f"[env_step_raw] first_20_bytes={response_text[:20].encode('utf-8').hex()}, len={len(response_text)}"
-        )
-        openai_result = self.openai_adapter.parse_response_to_openai_format(response_text)
-
-        if not openai_result["success"]:
-            logger.warning(f"Tool parsing failed: {openai_result.get('error')}")
-            return (
-                {
-                    "obs_str": "Failed to parse tool call. Please try again.",
-                    "role": "tool",
-                },
-                is_final_turn,
-                {"tool_executed": False, "parse_error": openai_result.get("error")},
-            )
-
-        parsed = openai_result["parsed_result"]
-        agent_content, calls = parsed["normal_text"], parsed["calls"]
-        logger.info(f"[env_step] response_text={repr(response_text[:200])}, calls={calls}, turn={self.turn}")
-
-        if calls:
-            self.format_correct_calls += 1
-
-        action = self._call_to_action(calls, agent_content)
-
-        is_tool_call = action.name != RESPOND_ACTION_NAME
-        if is_tool_call:
-            self.total_tool_calls += 1
-
-        try:
-            env_response = self.env.step(action)
-        except Exception as e:
-            logger.warning(f"Environment step failed: {e}")
-            return (
-                {
-                    "obs_str": f"Environment error: {e}",
-                    "role": "tool",
-                },
-                True,
-                {"tool_executed": False, "env_error": str(e)},
-            )
-
-        self.total_reward = env_response.reward
-        self.info.update(self._to_dict(env_response.info))
-
-        obs_lower = env_response.observation.lower() if env_response.observation else ""
-        logger.info(
-            f"[env_step] action={action.name}, is_tool_call={is_tool_call}, obs_start={repr(obs_lower[:50])}, done={env_response.done}"
-        )
-        if is_tool_call and not obs_lower.startswith(("error", "failed", "invalid", "not found")):
-            self.successful_tool_calls += 1
-            logger.info(f"[env_step] successful_tool_calls now={self.successful_tool_calls}")
-
-        if action.name != RESPOND_ACTION_NAME:
-            obs_role = "tool"
+    # Ensure response_length is set correctly
+    if hasattr(res, "response_length"):
+        sample.response_length = res.response_length
+    else:
+        # Fallback: calculate from loss_mask if available
+        if res.loss_mask:
+            # loss_mask only contains response part, so length equals response_length
+            sample.response_length = len(res.loss_mask)
+        elif res.tokens:
+            # If no loss_mask available, use total tokens as fallback
+            sample.response_length = len(res.tokens)
         else:
-            obs_role = "user"
-        obs_content = env_response.observation
+            sample.response_length = 0
+            logger.debug(f"res_to_sample: Set response_length={sample.response_length}")
 
-        done = env_response.done or is_final_turn
-
-        return (
-            {
-                "obs_str": obs_content,
-                "role": obs_role,
-                "reward": env_response.reward,
-            },
-            done,
-            {"tool_executed": True, "action": action.name},
-        )
-
-    def _call_to_action(self, calls: list[Any], text_response: str) -> Action:
-        action = Action(name=RESPOND_ACTION_NAME, kwargs={"content": text_response})
-        if calls:
-            if len(calls) > 1:
-                logger.debug("Multiple tool calls identified, only taking first.")
-            tool_call = calls[0]
-            try:
-                params = (
-                    json.loads(tool_call["parameters"])
-                    if isinstance(tool_call["parameters"], str)
-                    else tool_call["parameters"]
-                )
-                if not isinstance(params, dict):
-                    logger.warning(f"{params} does not follow dict structure for action")
-                else:
-                    action = Action(name=tool_call["name"], kwargs=params)
-            except json.JSONDecodeError as e:
-                logger.warning(f"Failed to parse parameters as JSON: {e}")
-        return action
-
-    def close(self):
-        pass
-
-    def format_observation(self, observation: dict) -> dict:
-        observation = observation or {}
-        content = observation.get("obs_str", "")
-        return {
-            "role": observation.get("role", "user"),
-            "content": content + "\n/no_think" if observation.get("role") == "user" else content,
-        }
-
-    @staticmethod
-    def _to_dict(info: Any) -> dict:
-        if hasattr(info, "model_dump"):
-            return info.model_dump()
-        if isinstance(info, dict):
-            return info
-        return {}
+    return sample
 
 
-def build_env(sample: Sample | None = None, args: Any | None = None, **_: Any) -> TauBenchEnv:
-    user_model = getattr(args, "tau_user_model", "openai/local-qwen3-4b")
-    user_model_provider = getattr(args, "tau_user_model_provider", "openai")
-    user_strategy = getattr(args, "tau_user_strategy", "llm")
+async def generate(args: dict[str, Any], sample: Sample, sampling_params: dict) -> Sample:
+    """
+    Generate a complete agent-environment interaction trajectory for tau-bench.
 
-    vllm_router_host = getattr(args, "vllm_router_ip", "127.0.0.1")
-    vllm_router_port = getattr(args, "vllm_router_port", 3250)
-    vllm_model_name = getattr(args, "vllm_model_name", getattr(args, "hf_checkpoint", ""))
+    This is the main entry point for vime training. It creates a tau-bench
+    environment, initializes a trainable agent, and executes a full interaction
+    trajectory. The result is converted to vime's Sample format for training.
 
-    if user_model_provider == "openai" and "local" in user_model:
-        os.environ["OPENAI_API_KEY"] = os.environ.get("OPENAI_API_KEY", "dummy")
-        os.environ["OPENAI_API_BASE"] = f"http://{vllm_router_host}:{vllm_router_port}/v1"
-        user_model = vllm_model_name
+    Args:
+        args: Rollout arguments from vime training pipeline
+        sample: Sample containing task index in prompt field
+        sampling_params: LLM sampling parameters
 
-    tau_config = RunConfig(
-        env=getattr(args, "tau_env", "retail"),
-        agent="tool-calling",
-        user_model=user_model,
-        user_model_provider=user_model_provider,
-        task_split=getattr(args, "tau_task_split", "train"),
-        user_strategy=user_strategy,
-        model_provider="auto_router",
-        model="qwen3-4b",
-    )
+    Returns:
+        Sample object containing the complete interaction trajectory
 
-    task_index = None
-    if sample is not None and sample.prompt is not None:
-        try:
-            task_index = int(sample.prompt)
-        except (ValueError, TypeError):
-            pass
-
-    max_turns = getattr(args, "max_turns", 30)
-    if max_turns is None:
-        max_turns = 30
-
-    return TauBenchEnv(
-        tau_config=tau_config,
-        task_index=task_index,
-        max_turns=max_turns,
-    )
-
-
-def _compute_process_reward(env, base_reward: float) -> float:
-    logger.info(
-        f"[process_reward] env_id={id(env)}, type={type(env).__name__}, "
-        f"successful_tools={getattr(env, 'successful_tool_calls', 'N/A')}, "
-        f"total_tools={getattr(env, 'total_tool_calls', 'N/A')}, "
-        f"format_correct={getattr(env, 'format_correct_calls', 'N/A')}"
-    )
-    reward = 0.0
-    if base_reward > 0:
-        reward += 1.0
-    if env.successful_tool_calls > 0:
-        reward += 0.1 * env.successful_tool_calls
-    if env.format_correct_calls > 0:
-        reward += 0.05 * env.format_correct_calls
-    reward = min(reward, 1.5)
-    logger.info(
-        f"process_reward: base={base_reward}, successful_tools={env.successful_tool_calls}, "
-        f"format_correct={env.format_correct_calls}, total_tools={env.total_tool_calls}, "
-        f"final_reward={reward}"
-    )
-    return reward
-
-
-def _build_tools_section(tools_info: list[dict]) -> str:
-    if not tools_info:
-        return ""
-    tools_json = json.dumps(tools_info, ensure_ascii=False)
-    parts = [
-        "",
-        "",
-        "# Tools",
-        "",
-        "You may call one or more functions to assist with the user query.",
-        "",
-        "You are provided with function signatures within <tools></tools> XML tags:",
-        "<tools>",
-        tools_json,
-        "</tools>",
-        "",
-        "For each function call, return a json object with function name and arguments within",
-        "<tool_call>",
-        '{"name": <function-name>, "arguments": <args-json-object>}',
-        "</tool_call>",
-        "XML tags.",
-    ]
-    return "\n".join(parts)
-
-
-def _messages_for_render(messages: list[dict]) -> list[dict]:
-    out: list[dict] = []
-    for msg in messages:
-        out.append({"role": msg["role"], "content": msg.get("content", "")})
-    return out
-
-
-async def generate(args: Any, sample: Sample, sampling_params) -> Sample:
+    Raises:
+        AssertionError: If partial rollout is requested (not supported)
+    """
+    # Validate arguments
     assert not args.partial_rollout, "Partial rollout is not supported for tau-bench interactions."
 
-    _ensure_tau_args(args)
+    # Extract task index from sample prompt
+    task_index = int(sample.prompt)
+    logger.info(f"Starting agent-environment interaction for task {task_index}")
 
-    state = GenerateState(args)
-    base_url = f"http://{args.vllm_router_ip}:{args.vllm_router_port}"
-
-    sample.metadata = sample.metadata or {}
-
-    headers = None
-    if getattr(args, "router_policy", None) == "consistent_hash":
-        sample.session_id = sample.session_id or str(uuid.uuid4())
-        headers = {"x-session-id": sample.session_id}
-
-    try:
-        env = build_env(sample=sample, args=args)
-    except TypeError:
-        env = build_env(sample, args)
-
-    initial_obs = env.reset()
-    wiki = initial_obs.get("wiki", "")
-    tools_info = initial_obs.get("tools_info", [])
-    tools_section = _build_tools_section(tools_info)
-
-    messages: list[dict] = [
-        {"role": "system", "content": wiki + tools_section + "\n/no_think"},
-        {"role": "user", "content": initial_obs.get("obs_str", "")},
-    ]
-
-    response_tokens: list[int] = []
-    sample.loss_mask = sample.loss_mask or []
-    sample.rollout_log_probs = sample.rollout_log_probs or []
-    sample.tokens = list(sample.tokens) if sample.tokens else []
-
-    sampling_params = sampling_params.copy()
-    sampling_params["repetition_penalty"] = 1.1
-    sampling_params.setdefault("stop", ["</tool_call>"])
-    inference_sampling_params = _build_inference_sampling_params(sampling_params)
-    logger.info(
-        f"inference_sampling_params keys={list(inference_sampling_params.keys())}, stop={inference_sampling_params.get('stop')}"
+    # Initialize tau-bench environment
+    env = get_env(
+        env_name=tau_config.env,
+        user_strategy=tau_config.user_strategy,
+        user_model=tau_config.user_model,
+        user_provider=tau_config.user_model_provider,
+        task_split=tau_config.task_split,
+        task_index=task_index,
     )
-    max_response_budget = sampling_params.get("max_new_tokens")
 
-    def remaining_budget() -> int | None:
-        return None if max_response_budget is None else max_response_budget - sample.response_length
+    # Create trainable agent
+    agent = agent_factory(
+        tools_info=env.tools_info,
+        wiki=env.wiki,
+        config=tau_config,
+        rollout_args=args,
+        sampling_params=sampling_params,
+    )
 
-    async def render() -> dict:
-        render_messages = _messages_for_render(messages)
-        payload = {"model": args.hf_checkpoint, "messages": render_messages}
-        render_data = await post(f"{base_url}/v1/chat/completions/render", payload, headers=headers)
-        return _mm_render_response_to_generate_body(render_data, args.hf_checkpoint)
+    # Execute agent-environment interaction
+    # Note: The sample.prompt field contains the task index for repeatability
+    interaction_result = await agent.asolve(env, agent.rollout_args, agent.sampling_params, task_index)
 
-    def append_response_window(
-        token_ids: list[int],
-        loss_mask: list[int],
-        log_probs: list[float] | None = None,
-    ) -> None:
-        if not token_ids:
-            return
-        if len(loss_mask) != len(token_ids):
-            raise ValueError(f"loss_mask length {len(loss_mask)} != token_ids length {len(token_ids)}")
-        sample.tokens.extend(token_ids)
-        sample.loss_mask.extend(loss_mask)
-        sample.rollout_log_probs.extend(log_probs if log_probs is not None else [0.0] * len(token_ids))
-        sample.response_length += len(token_ids)
+    # Convert to vime Sample format
+    result_sample = res_to_sample(interaction_result, task_index)
 
-    def sampling_params_for_turn() -> dict | None:
-        params = dict(inference_sampling_params)
-        max_tokens = remaining_budget()
-        if max_tokens is None:
-            return params
-        if max_tokens <= 0:
-            return None
-        params["max_tokens"] = max_tokens
-        return params
-
-    try:
-        pending_obs_offset: int | None = None
-        rendered_body = await render()
-        prompt_ids = _coerce_flat_int_token_ids(rendered_body.get("token_ids"))
-        if not sample.tokens:
-            sample.tokens = list(prompt_ids)
-        if args.rollout_max_context_len is not None:
-            max_response_budget = max(0, args.rollout_max_context_len - len(sample.tokens))
-
-        vllm_max_len = getattr(args, "vllm_max_model_len", 16384) or 16384
-        if len(prompt_ids) >= vllm_max_len - 64:
-            logger.info(f"prompt too long ({len(prompt_ids)} tokens >= {vllm_max_len - 64}), skipping task")
-            sample.reward = _compute_process_reward(env, 0.0)
-            sample.status = Sample.Status.TRUNCATED
-            return sample
-
-        for turn_idx in range(args.max_turns):
-            input_ids = _coerce_flat_int_token_ids(rendered_body.get("token_ids"))
-
-            if pending_obs_offset is not None:
-                obs_tokens = input_ids[pending_obs_offset:]
-                remaining = remaining_budget()
-                if remaining is not None and len(obs_tokens) > remaining:
-                    append_response_window(obs_tokens[: max(remaining, 0)], [0] * max(remaining, 0))
-                    sample.status = Sample.Status.TRUNCATED
-                    break
-                append_response_window(obs_tokens, [0] * len(obs_tokens))
-                pending_obs_offset = None
-
-            current_sampling_params = sampling_params_for_turn()
-            if current_sampling_params is None:
-                sample.status = Sample.Status.TRUNCATED
-                break
-
-            body = dict(rendered_body)
-            body["sampling_params"] = current_sampling_params
-            output = await post(f"{base_url}/inference/v1/generate", body, headers=headers)
-            choice = output["choices"][0]
-            finish_reason = choice.get("finish_reason") or "stop"
-            new_tokens, new_logprobs = _inference_generate_tokens_and_logprobs(choice)
-
-            if not new_tokens:
-                if finish_reason in ("abort", "cancelled"):
-                    sample.status = Sample.Status.ABORTED
-                    break
-
-            response_text = state.tokenizer.decode(new_tokens, skip_special_tokens=False) if new_tokens else ""
-            logger.info(
-                f"[turn={turn_idx}] finish_reason={finish_reason}, response_text={repr(response_text[:500])}, num_tokens={len(new_tokens)}"
-            )
-            train_tokens = list(new_tokens)
-            train_logprobs = list(new_logprobs)
-            train_loss_mask = [1] * len(train_tokens)
-
-            stop = current_sampling_params.get("stop")
-            if not stop:
-                stop = ["</tool_call>"]
-            stop_strings = (stop,) if isinstance(stop, str) else tuple(stop) if stop else ()
-            hit_stop_str = None
-            hit_stop_pos = len(response_text)
-            if stop_strings:
-                for ss in stop_strings:
-                    pos = response_text.find(ss)
-                    if pos != -1 and pos < hit_stop_pos:
-                        hit_stop_str = ss
-                        hit_stop_pos = pos
-            if hit_stop_str is not None:
-                truncated_text = response_text[: hit_stop_pos + len(hit_stop_str)]
-                trunc_token_count = 0
-                for t in range(1, len(train_tokens) + 1):
-                    partial = state.tokenizer.decode(train_tokens[:t], skip_special_tokens=False)
-                    if partial >= truncated_text:
-                        trunc_token_count = t
-                        break
-                if trunc_token_count == 0:
-                    trunc_token_count = len(train_tokens)
-                logger.info(
-                    f"[turn={turn_idx}] STOP_STRING_HIT: '{hit_stop_str}' at pos={hit_stop_pos}, "
-                    f"truncated from {len(train_tokens)} to {trunc_token_count} tokens, "
-                    f"text_truncated={repr(truncated_text[:200])}"
-                )
-                train_tokens = train_tokens[:trunc_token_count]
-                train_logprobs = train_logprobs[:trunc_token_count]
-                train_loss_mask = train_loss_mask[:trunc_token_count]
-                response_text = truncated_text
-                finish_reason = "stop"
-
-            eos_token_id = getattr(state.tokenizer, "eos_token_id", None)
-            append_stop_eos = (
-                stop
-                and eos_token_id is not None
-                and getattr(args, "append_eos_token_after_stop_str_in_multi_turn", True)
-            )
-            if append_stop_eos:
-                already_has_eos = bool(train_tokens and train_tokens[-1] == eos_token_id)
-                if stop_strings and response_text.endswith(stop_strings) and not already_has_eos:
-                    if getattr(args, "use_rollout_routing_replay", False):
-                        raise RuntimeError(
-                            "Routing replay is not supported when appending an artificial EOS after a stop string, "
-                            "because vLLM does not return routed experts for that extra token."
-                        )
-                    train_tokens.append(int(eos_token_id))
-                    train_logprobs.append(0.0)
-                    train_loss_mask.append(0)
-
-            response_tokens.extend(new_tokens)
-            append_response_window(train_tokens, train_loss_mask, train_logprobs)
-            _apply_vllm_routed_experts(args, sample, choice)
-
-            messages.append({"role": "assistant", "content": response_text})
-
-            if finish_reason == "length":
-                sample.status = Sample.Status.TRUNCATED
-                break
-            if finish_reason in ("abort", "cancelled"):
-                sample.status = Sample.Status.ABORTED
-                break
-
-            observation, done, step_info = env.step(response_text)
-
-            if done:
-                base_reward = observation.get("reward", 0.0)
-                sample.reward = _compute_process_reward(env, base_reward)
-                sample.status = Sample.Status.COMPLETED
-                break
-
-            next_user_message = env.format_observation(observation)
-            messages.append(next_user_message)
-
-            if turn_idx + 1 >= args.max_turns:
-                sample.reward = _compute_process_reward(env, 0.0)
-                sample.status = Sample.Status.TRUNCATED
-                break
-
-            pending_obs_offset = len(input_ids) + len(train_tokens)
-            max_ctx = args.rollout_max_context_len or 8192
-            if len(sample.tokens) >= max_ctx - 64:
-                logger.info(
-                    f"[turn={turn_idx}] context overflow: {len(sample.tokens)} tokens >= {max_ctx - 64}, truncating"
-                )
-                sample.reward = _compute_process_reward(env, 0.0)
-                sample.status = Sample.Status.TRUNCATED
-                break
-            rendered_body = await render()
-            rendered_ids = _coerce_flat_int_token_ids(rendered_body.get("token_ids"))
-            is_prefix_stable = rendered_ids[:pending_obs_offset] == sample.tokens[:pending_obs_offset]
-            sample.metadata["multiturn_render"] = {
-                "prefix_stable": is_prefix_stable,
-                "prefix_len": pending_obs_offset,
-                "sample_len": len(sample.tokens),
-                "rendered_len": len(rendered_ids),
-                "turn": turn_idx + 1,
-            }
-            if getattr(args, "strict_multiturn_render_token_match", False) and not is_prefix_stable:
-                raise RuntimeError(
-                    "Full conversation render is not prefix-stable with the generated token stream: "
-                    f"{sample.metadata['multiturn_render']}"
-                )
-
-        sample.response = state.tokenizer.decode(response_tokens, skip_special_tokens=False)
-        sample.response_length = len(sample.loss_mask)
-        if sample.reward is None:
-            sample.reward = _compute_process_reward(env, getattr(env, "total_reward", 0.0))
-        if sample.status == Sample.Status.PENDING:
-            sample.status = Sample.Status.COMPLETED
-        return sample
-    finally:
-        try:
-            env.close()
-        except Exception:
-            pass
+    logger.info(f"Finished agent-environment interaction for task {task_index}")
+    return result_sample

--- a/examples/tau-bench/generate_with_tau.py
+++ b/examples/tau-bench/generate_with_tau.py
@@ -1,4 +1,8 @@
-"""Tau-bench multi-turn custom rollout for vime (vLLM render + generate)."""
+"""Tau-bench multi-turn custom rollout for vime (vLLM render + generate).
+
+Combines tau env interaction, tool parsing (``vllm_tool_parser``), and vLLM
+multi-turn rollout in one entry point: ``generate_with_tau.generate``.
+"""
 
 from __future__ import annotations
 
@@ -562,10 +566,10 @@ async def generate(args: Any, sample: Sample, sampling_params) -> Sample:
 
         sample.response = state.tokenizer.decode(response_tokens, skip_special_tokens=False)
         sample.response_length = len(sample.loss_mask)
+        if sample.reward is None:
+            sample.reward = _compute_process_reward(env, getattr(env, "total_reward", 0.0))
         if sample.status == Sample.Status.PENDING:
             sample.status = Sample.Status.COMPLETED
-        if sample.reward is None or sample.reward == 0.0:
-            sample.reward = _compute_process_reward(env, 0.0)
         return sample
     finally:
         try:

--- a/examples/tau-bench/generate_with_tau.py
+++ b/examples/tau-bench/generate_with_tau.py
@@ -1,0 +1,574 @@
+"""Tau-bench multi-turn custom rollout for vime (vLLM render + generate)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from typing import Any
+
+from openai_tool_adapter import create_openai_adapter
+from tau_bench.agents.tool_calling_agent import RESPOND_ACTION_NAME
+from tau_bench.envs import get_env
+from tau_bench.types import Action, RunConfig
+
+from vime.rollout.vllm_rollout import (
+    GenerateState,
+    _apply_vllm_routed_experts,
+    _build_inference_sampling_params,
+    _coerce_flat_int_token_ids,
+    _inference_generate_tokens_and_logprobs,
+    _mm_render_response_to_generate_body,
+)
+from vime.utils.http_utils import post
+from vime.utils.types import Sample
+
+logger = logging.getLogger(__name__)
+
+# Defaults formerly in tau_bench_config.yaml
+_TAU_DEFAULT_MAX_TURNS = 10
+
+
+def _ensure_tau_args(args: Any) -> None:
+    if getattr(args, "max_turns", None) is None:
+        args.max_turns = _TAU_DEFAULT_MAX_TURNS
+    for key, value in (
+        ("tau_env", "retail"),
+        ("tau_user_model", "openai/local-qwen3-4b"),
+        ("tau_user_model_provider", "openai"),
+        ("tau_task_split", "train"),
+        ("tau_user_strategy", "llm"),
+    ):
+        if getattr(args, key, None) is None:
+            setattr(args, key, value)
+
+
+async def tau_bench_rm(args, sample: Sample, **kwargs) -> float:
+    return sample.reward if sample.reward is not None else 0.0
+
+
+async def batched_tau_bench_rm(args, samples, **kwargs) -> list[float] | float:
+    if isinstance(samples, Sample):
+        return samples.reward if samples.reward is not None else 0.0
+    rewards = [s.reward if s.reward is not None else 0.0 for s in samples]
+    max_r = max(rewards) if rewards else 1.0
+    if max_r > 0:
+        rewards = [r / max_r for r in rewards]
+    return rewards
+
+
+class TauBenchEnv:
+    def __init__(
+        self,
+        *,
+        tau_config: RunConfig,
+        task_index: int | None = None,
+        max_turns: int = 30,
+    ):
+        self.tau_config = tau_config
+        self.task_index = task_index
+        self.max_turns = max_turns
+        self.turn = 0
+        self.total_reward = 0.0
+        self.info: dict[str, Any] = {}
+        self.env = None
+        self.openai_adapter = None
+        self.successful_tool_calls = 0
+        self.total_tool_calls = 0
+        self.format_correct_calls = 0
+
+    def reset(self):
+        self.turn = 0
+        self.total_reward = 0.0
+        self.info = {}
+        self.successful_tool_calls = 0
+        self.total_tool_calls = 0
+        self.format_correct_calls = 0
+
+        self.env = get_env(
+            env_name=self.tau_config.env,
+            user_strategy=self.tau_config.user_strategy,
+            user_model=self.tau_config.user_model,
+            user_provider=self.tau_config.user_model_provider,
+            task_split=self.tau_config.task_split,
+            task_index=self.task_index,
+        )
+
+        self.openai_adapter = create_openai_adapter(
+            tools_info=self.env.tools_info,
+            parser_type="qwen25",
+        )
+
+        env_reset_res = self.env.reset(task_index=self.task_index) if self.task_index is not None else self.env.reset()
+        observation = env_reset_res.observation
+        self.info = self._to_dict(env_reset_res.info)
+
+        return {
+            "obs_str": observation,
+            "role": "user",
+            "wiki": self.env.wiki,
+            "tools_info": self.env.tools_info,
+        }
+
+    def step(self, response_text: str):
+        self.turn += 1
+        is_final_turn = self.turn >= self.max_turns
+
+        logger.info(
+            f"[env_step_raw] first_20_bytes={response_text[:20].encode('utf-8').hex()}, len={len(response_text)}"
+        )
+        openai_result = self.openai_adapter.parse_response_to_openai_format(response_text)
+
+        if not openai_result["success"]:
+            logger.warning(f"Tool parsing failed: {openai_result.get('error')}")
+            return (
+                {
+                    "obs_str": "Failed to parse tool call. Please try again.",
+                    "role": "tool",
+                },
+                is_final_turn,
+                {"tool_executed": False, "parse_error": openai_result.get("error")},
+            )
+
+        parsed = openai_result["parsed_result"]
+        agent_content, calls = parsed["normal_text"], parsed["calls"]
+        logger.info(f"[env_step] response_text={repr(response_text[:200])}, calls={calls}, turn={self.turn}")
+
+        if calls:
+            self.format_correct_calls += 1
+
+        action = self._call_to_action(calls, agent_content)
+
+        is_tool_call = action.name != RESPOND_ACTION_NAME
+        if is_tool_call:
+            self.total_tool_calls += 1
+
+        try:
+            env_response = self.env.step(action)
+        except Exception as e:
+            logger.warning(f"Environment step failed: {e}")
+            return (
+                {
+                    "obs_str": f"Environment error: {e}",
+                    "role": "tool",
+                },
+                True,
+                {"tool_executed": False, "env_error": str(e)},
+            )
+
+        self.total_reward = env_response.reward
+        self.info.update(self._to_dict(env_response.info))
+
+        obs_lower = env_response.observation.lower() if env_response.observation else ""
+        logger.info(
+            f"[env_step] action={action.name}, is_tool_call={is_tool_call}, obs_start={repr(obs_lower[:50])}, done={env_response.done}"
+        )
+        if is_tool_call and not obs_lower.startswith(("error", "failed", "invalid", "not found")):
+            self.successful_tool_calls += 1
+            logger.info(f"[env_step] successful_tool_calls now={self.successful_tool_calls}")
+
+        if action.name != RESPOND_ACTION_NAME:
+            obs_role = "tool"
+        else:
+            obs_role = "user"
+        obs_content = env_response.observation
+
+        done = env_response.done or is_final_turn
+
+        return (
+            {
+                "obs_str": obs_content,
+                "role": obs_role,
+                "reward": env_response.reward,
+            },
+            done,
+            {"tool_executed": True, "action": action.name},
+        )
+
+    def _call_to_action(self, calls: list[Any], text_response: str) -> Action:
+        action = Action(name=RESPOND_ACTION_NAME, kwargs={"content": text_response})
+        if calls:
+            if len(calls) > 1:
+                logger.debug("Multiple tool calls identified, only taking first.")
+            tool_call = calls[0]
+            try:
+                params = (
+                    json.loads(tool_call["parameters"])
+                    if isinstance(tool_call["parameters"], str)
+                    else tool_call["parameters"]
+                )
+                if not isinstance(params, dict):
+                    logger.warning(f"{params} does not follow dict structure for action")
+                else:
+                    action = Action(name=tool_call["name"], kwargs=params)
+            except json.JSONDecodeError as e:
+                logger.warning(f"Failed to parse parameters as JSON: {e}")
+        return action
+
+    def close(self):
+        pass
+
+    def format_observation(self, observation: dict) -> dict:
+        observation = observation or {}
+        content = observation.get("obs_str", "")
+        return {
+            "role": observation.get("role", "user"),
+            "content": content + "\n/no_think" if observation.get("role") == "user" else content,
+        }
+
+    @staticmethod
+    def _to_dict(info: Any) -> dict:
+        if hasattr(info, "model_dump"):
+            return info.model_dump()
+        if isinstance(info, dict):
+            return info
+        return {}
+
+
+def build_env(sample: Sample | None = None, args: Any | None = None, **_: Any) -> TauBenchEnv:
+    user_model = getattr(args, "tau_user_model", "openai/local-qwen3-4b")
+    user_model_provider = getattr(args, "tau_user_model_provider", "openai")
+    user_strategy = getattr(args, "tau_user_strategy", "llm")
+
+    vllm_router_host = getattr(args, "vllm_router_ip", "127.0.0.1")
+    vllm_router_port = getattr(args, "vllm_router_port", 3250)
+    vllm_model_name = getattr(args, "vllm_model_name", getattr(args, "hf_checkpoint", ""))
+
+    if user_model_provider == "openai" and "local" in user_model:
+        os.environ["OPENAI_API_KEY"] = os.environ.get("OPENAI_API_KEY", "dummy")
+        os.environ["OPENAI_API_BASE"] = f"http://{vllm_router_host}:{vllm_router_port}/v1"
+        user_model = vllm_model_name
+
+    tau_config = RunConfig(
+        env=getattr(args, "tau_env", "retail"),
+        agent="tool-calling",
+        user_model=user_model,
+        user_model_provider=user_model_provider,
+        task_split=getattr(args, "tau_task_split", "train"),
+        user_strategy=user_strategy,
+        model_provider="auto_router",
+        model="qwen3-4b",
+    )
+
+    task_index = None
+    if sample is not None and sample.prompt is not None:
+        try:
+            task_index = int(sample.prompt)
+        except (ValueError, TypeError):
+            pass
+
+    max_turns = getattr(args, "max_turns", 30)
+    if max_turns is None:
+        max_turns = 30
+
+    return TauBenchEnv(
+        tau_config=tau_config,
+        task_index=task_index,
+        max_turns=max_turns,
+    )
+
+
+def _compute_process_reward(env, base_reward: float) -> float:
+    logger.info(
+        f"[process_reward] env_id={id(env)}, type={type(env).__name__}, "
+        f"successful_tools={getattr(env, 'successful_tool_calls', 'N/A')}, "
+        f"total_tools={getattr(env, 'total_tool_calls', 'N/A')}, "
+        f"format_correct={getattr(env, 'format_correct_calls', 'N/A')}"
+    )
+    reward = 0.0
+    if base_reward > 0:
+        reward += 1.0
+    if env.successful_tool_calls > 0:
+        reward += 0.1 * env.successful_tool_calls
+    if env.format_correct_calls > 0:
+        reward += 0.05 * env.format_correct_calls
+    reward = min(reward, 1.5)
+    logger.info(
+        f"process_reward: base={base_reward}, successful_tools={env.successful_tool_calls}, "
+        f"format_correct={env.format_correct_calls}, total_tools={env.total_tool_calls}, "
+        f"final_reward={reward}"
+    )
+    return reward
+
+
+def _build_tools_section(tools_info: list[dict]) -> str:
+    if not tools_info:
+        return ""
+    tools_json = json.dumps(tools_info, ensure_ascii=False)
+    parts = [
+        "",
+        "",
+        "# Tools",
+        "",
+        "You may call one or more functions to assist with the user query.",
+        "",
+        "You are provided with function signatures within <tools></tools> XML tags:",
+        "<tools>",
+        tools_json,
+        "</tools>",
+        "",
+        "For each function call, return a json object with function name and arguments within",
+        "<tool_call>",
+        '{"name": <function-name>, "arguments": <args-json-object>}',
+        "</tool_call>",
+        "XML tags.",
+    ]
+    return "\n".join(parts)
+
+
+def _messages_for_render(messages: list[dict]) -> list[dict]:
+    out: list[dict] = []
+    for msg in messages:
+        out.append({"role": msg["role"], "content": msg.get("content", "")})
+    return out
+
+
+async def generate(args: Any, sample: Sample, sampling_params) -> Sample:
+    assert not args.partial_rollout, "Partial rollout is not supported for tau-bench interactions."
+
+    _ensure_tau_args(args)
+
+    state = GenerateState(args)
+    base_url = f"http://{args.vllm_router_ip}:{args.vllm_router_port}"
+
+    sample.metadata = sample.metadata or {}
+
+    headers = None
+    if getattr(args, "router_policy", None) == "consistent_hash":
+        sample.session_id = sample.session_id or str(uuid.uuid4())
+        headers = {"x-session-id": sample.session_id}
+
+    try:
+        env = build_env(sample=sample, args=args)
+    except TypeError:
+        env = build_env(sample, args)
+
+    initial_obs = env.reset()
+    wiki = initial_obs.get("wiki", "")
+    tools_info = initial_obs.get("tools_info", [])
+    tools_section = _build_tools_section(tools_info)
+
+    messages: list[dict] = [
+        {"role": "system", "content": wiki + tools_section + "\n/no_think"},
+        {"role": "user", "content": initial_obs.get("obs_str", "")},
+    ]
+
+    response_tokens: list[int] = []
+    sample.loss_mask = sample.loss_mask or []
+    sample.rollout_log_probs = sample.rollout_log_probs or []
+    sample.tokens = list(sample.tokens) if sample.tokens else []
+
+    sampling_params = sampling_params.copy()
+    sampling_params["repetition_penalty"] = 1.1
+    sampling_params.setdefault("stop", ["</tool_call>"])
+    inference_sampling_params = _build_inference_sampling_params(sampling_params)
+    logger.info(
+        f"inference_sampling_params keys={list(inference_sampling_params.keys())}, stop={inference_sampling_params.get('stop')}"
+    )
+    max_response_budget = sampling_params.get("max_new_tokens")
+
+    def remaining_budget() -> int | None:
+        return None if max_response_budget is None else max_response_budget - sample.response_length
+
+    async def render() -> dict:
+        render_messages = _messages_for_render(messages)
+        payload = {"model": args.hf_checkpoint, "messages": render_messages}
+        render_data = await post(f"{base_url}/v1/chat/completions/render", payload, headers=headers)
+        return _mm_render_response_to_generate_body(render_data, args.hf_checkpoint)
+
+    def append_response_window(
+        token_ids: list[int],
+        loss_mask: list[int],
+        log_probs: list[float] | None = None,
+    ) -> None:
+        if not token_ids:
+            return
+        if len(loss_mask) != len(token_ids):
+            raise ValueError(f"loss_mask length {len(loss_mask)} != token_ids length {len(token_ids)}")
+        sample.tokens.extend(token_ids)
+        sample.loss_mask.extend(loss_mask)
+        sample.rollout_log_probs.extend(log_probs if log_probs is not None else [0.0] * len(token_ids))
+        sample.response_length += len(token_ids)
+
+    def sampling_params_for_turn() -> dict | None:
+        params = dict(inference_sampling_params)
+        max_tokens = remaining_budget()
+        if max_tokens is None:
+            return params
+        if max_tokens <= 0:
+            return None
+        params["max_tokens"] = max_tokens
+        return params
+
+    try:
+        pending_obs_offset: int | None = None
+        rendered_body = await render()
+        prompt_ids = _coerce_flat_int_token_ids(rendered_body.get("token_ids"))
+        if not sample.tokens:
+            sample.tokens = list(prompt_ids)
+        if args.rollout_max_context_len is not None:
+            max_response_budget = max(0, args.rollout_max_context_len - len(sample.tokens))
+
+        vllm_max_len = getattr(args, "vllm_max_model_len", 16384) or 16384
+        if len(prompt_ids) >= vllm_max_len - 64:
+            logger.info(f"prompt too long ({len(prompt_ids)} tokens >= {vllm_max_len - 64}), skipping task")
+            sample.reward = _compute_process_reward(env, 0.0)
+            sample.status = Sample.Status.TRUNCATED
+            return sample
+
+        for turn_idx in range(args.max_turns):
+            input_ids = _coerce_flat_int_token_ids(rendered_body.get("token_ids"))
+
+            if pending_obs_offset is not None:
+                obs_tokens = input_ids[pending_obs_offset:]
+                remaining = remaining_budget()
+                if remaining is not None and len(obs_tokens) > remaining:
+                    append_response_window(obs_tokens[: max(remaining, 0)], [0] * max(remaining, 0))
+                    sample.status = Sample.Status.TRUNCATED
+                    break
+                append_response_window(obs_tokens, [0] * len(obs_tokens))
+                pending_obs_offset = None
+
+            current_sampling_params = sampling_params_for_turn()
+            if current_sampling_params is None:
+                sample.status = Sample.Status.TRUNCATED
+                break
+
+            body = dict(rendered_body)
+            body["sampling_params"] = current_sampling_params
+            output = await post(f"{base_url}/inference/v1/generate", body, headers=headers)
+            choice = output["choices"][0]
+            finish_reason = choice.get("finish_reason") or "stop"
+            new_tokens, new_logprobs = _inference_generate_tokens_and_logprobs(choice)
+
+            if not new_tokens:
+                if finish_reason in ("abort", "cancelled"):
+                    sample.status = Sample.Status.ABORTED
+                    break
+
+            response_text = state.tokenizer.decode(new_tokens, skip_special_tokens=False) if new_tokens else ""
+            logger.info(
+                f"[turn={turn_idx}] finish_reason={finish_reason}, response_text={repr(response_text[:500])}, num_tokens={len(new_tokens)}"
+            )
+            train_tokens = list(new_tokens)
+            train_logprobs = list(new_logprobs)
+            train_loss_mask = [1] * len(train_tokens)
+
+            stop = current_sampling_params.get("stop")
+            if not stop:
+                stop = ["</tool_call>"]
+            stop_strings = (stop,) if isinstance(stop, str) else tuple(stop) if stop else ()
+            hit_stop_str = None
+            hit_stop_pos = len(response_text)
+            if stop_strings:
+                for ss in stop_strings:
+                    pos = response_text.find(ss)
+                    if pos != -1 and pos < hit_stop_pos:
+                        hit_stop_str = ss
+                        hit_stop_pos = pos
+            if hit_stop_str is not None:
+                truncated_text = response_text[: hit_stop_pos + len(hit_stop_str)]
+                trunc_token_count = 0
+                for t in range(1, len(train_tokens) + 1):
+                    partial = state.tokenizer.decode(train_tokens[:t], skip_special_tokens=False)
+                    if partial >= truncated_text:
+                        trunc_token_count = t
+                        break
+                if trunc_token_count == 0:
+                    trunc_token_count = len(train_tokens)
+                logger.info(
+                    f"[turn={turn_idx}] STOP_STRING_HIT: '{hit_stop_str}' at pos={hit_stop_pos}, "
+                    f"truncated from {len(train_tokens)} to {trunc_token_count} tokens, "
+                    f"text_truncated={repr(truncated_text[:200])}"
+                )
+                train_tokens = train_tokens[:trunc_token_count]
+                train_logprobs = train_logprobs[:trunc_token_count]
+                train_loss_mask = train_loss_mask[:trunc_token_count]
+                response_text = truncated_text
+                finish_reason = "stop"
+
+            eos_token_id = getattr(state.tokenizer, "eos_token_id", None)
+            append_stop_eos = (
+                stop
+                and eos_token_id is not None
+                and getattr(args, "append_eos_token_after_stop_str_in_multi_turn", True)
+            )
+            if append_stop_eos:
+                already_has_eos = bool(train_tokens and train_tokens[-1] == eos_token_id)
+                if stop_strings and response_text.endswith(stop_strings) and not already_has_eos:
+                    if getattr(args, "use_rollout_routing_replay", False):
+                        raise RuntimeError(
+                            "Routing replay is not supported when appending an artificial EOS after a stop string, "
+                            "because vLLM does not return routed experts for that extra token."
+                        )
+                    train_tokens.append(int(eos_token_id))
+                    train_logprobs.append(0.0)
+                    train_loss_mask.append(0)
+
+            response_tokens.extend(new_tokens)
+            append_response_window(train_tokens, train_loss_mask, train_logprobs)
+            _apply_vllm_routed_experts(args, sample, choice)
+
+            messages.append({"role": "assistant", "content": response_text})
+
+            if finish_reason == "length":
+                sample.status = Sample.Status.TRUNCATED
+                break
+            if finish_reason in ("abort", "cancelled"):
+                sample.status = Sample.Status.ABORTED
+                break
+
+            observation, done, step_info = env.step(response_text)
+
+            if done:
+                base_reward = observation.get("reward", 0.0)
+                sample.reward = _compute_process_reward(env, base_reward)
+                sample.status = Sample.Status.COMPLETED
+                break
+
+            next_user_message = env.format_observation(observation)
+            messages.append(next_user_message)
+
+            if turn_idx + 1 >= args.max_turns:
+                sample.reward = _compute_process_reward(env, 0.0)
+                sample.status = Sample.Status.TRUNCATED
+                break
+
+            pending_obs_offset = len(input_ids) + len(train_tokens)
+            max_ctx = args.rollout_max_context_len or 8192
+            if len(sample.tokens) >= max_ctx - 64:
+                logger.info(
+                    f"[turn={turn_idx}] context overflow: {len(sample.tokens)} tokens >= {max_ctx - 64}, truncating"
+                )
+                sample.reward = _compute_process_reward(env, 0.0)
+                sample.status = Sample.Status.TRUNCATED
+                break
+            rendered_body = await render()
+            rendered_ids = _coerce_flat_int_token_ids(rendered_body.get("token_ids"))
+            is_prefix_stable = rendered_ids[:pending_obs_offset] == sample.tokens[:pending_obs_offset]
+            sample.metadata["multiturn_render"] = {
+                "prefix_stable": is_prefix_stable,
+                "prefix_len": pending_obs_offset,
+                "sample_len": len(sample.tokens),
+                "rendered_len": len(rendered_ids),
+                "turn": turn_idx + 1,
+            }
+            if getattr(args, "strict_multiturn_render_token_match", False) and not is_prefix_stable:
+                raise RuntimeError(
+                    "Full conversation render is not prefix-stable with the generated token stream: "
+                    f"{sample.metadata['multiturn_render']}"
+                )
+
+        sample.response = state.tokenizer.decode(response_tokens, skip_special_tokens=False)
+        sample.response_length = len(sample.loss_mask)
+        if sample.status == Sample.Status.PENDING:
+            sample.status = Sample.Status.COMPLETED
+        if sample.reward is None or sample.reward == 0.0:
+            sample.reward = _compute_process_reward(env, 0.0)
+        return sample
+    finally:
+        try:
+            env.close()
+        except Exception:
+            pass

--- a/examples/tau-bench/openai_tool_adapter.py
+++ b/examples/tau-bench/openai_tool_adapter.py
@@ -2,13 +2,15 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
-from tool_parser import parse_tools
+from vllm_tool_parser import parse_tools
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class OpenAIToolCall:
+    """OpenAI format tool call structure."""
+
     id: str
     type: str = "function"
     function: dict[str, Any] = field(default_factory=dict)
@@ -16,17 +18,34 @@ class OpenAIToolCall:
 
 @dataclass
 class OpenAIAssistantMessage:
+    """OpenAI format assistant message structure."""
+
     role: str = "assistant"
     content: str | None = None
     tool_calls: list[OpenAIToolCall] | None = None
 
 
 class OpenAICompatibleToolCallAdapter:
+    """
+    Adapter that converts vLLM tool-call parsing results to OpenAI compatible format.
+
+    Wired through ``vllm_tool_parser.parse_tools``.
+    """
+
     def __init__(self, tools_info: list[dict[str, Any]], parser_type: str = "qwen25"):
         self.tools_info = tools_info
         self.parser_type = parser_type
 
     def parse_response_to_openai_format(self, response: str) -> dict[str, Any]:
+        """
+        Parse a vLLM rollout response to OpenAI compatible format.
+
+        Args:
+            response: Raw response text from the vLLM generate endpoint.
+
+        Returns:
+            Dictionary containing OpenAI format message and parsing results.
+        """
         try:
             parsed = parse_tools(response, self.tools_info, self.parser_type)
             normal_text = parsed["normal_text"]
@@ -61,4 +80,5 @@ class OpenAICompatibleToolCallAdapter:
 def create_openai_adapter(
     tools_info: list[dict[str, Any]], parser_type: str = "qwen25"
 ) -> OpenAICompatibleToolCallAdapter:
+    """Factory function to create an OpenAI compatible tool-call adapter."""
     return OpenAICompatibleToolCallAdapter(tools_info, parser_type)

--- a/examples/tau-bench/openai_tool_adapter.py
+++ b/examples/tau-bench/openai_tool_adapter.py
@@ -1,24 +1,28 @@
+import json
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 from vllm_tool_parser import parse_tools
+from tau_bench.agents.tool_calling_agent import RESPOND_ACTION_NAME
+from tau_bench.types import Action
 
+# Set up logger for this module
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class OpenAIToolCall:
-    """OpenAI format tool call structure."""
+    """OpenAI format tool call structure"""
 
     id: str
     type: str = "function"
-    function: dict[str, Any] = field(default_factory=dict)
+    function: dict[str, Any] = None
 
 
 @dataclass
 class OpenAIAssistantMessage:
-    """OpenAI format assistant message structure."""
+    """OpenAI format assistant message structure"""
 
     role: str = "assistant"
     content: str | None = None
@@ -27,58 +31,145 @@ class OpenAIAssistantMessage:
 
 class OpenAICompatibleToolCallAdapter:
     """
-    Adapter that converts vLLM tool-call parsing results to OpenAI compatible format.
+    Adapter class that converts vllm tool call parsing results to OpenAI compatible format
 
-    Wired through ``vllm_tool_parser.parse_tools``.
+    This class encapsulates existing tool call parsing and action conversion logic,
+    and provides OpenAI format output interface.
     """
 
     def __init__(self, tools_info: list[dict[str, Any]], parser_type: str = "qwen25"):
+        """
+        Initialize adapter
+
+        Args:
+            tools_info: List of tool information
+            parser_type: Parser type, defaults to "qwen25"
+        """
         self.tools_info = tools_info
         self.parser_type = parser_type
 
     def parse_response_to_openai_format(self, response: str) -> dict[str, Any]:
         """
-        Parse a vLLM rollout response to OpenAI compatible format.
+        Parse vllm response to OpenAI compatible format
 
         Args:
-            response: Raw response text from the vLLM generate endpoint.
+            response: Raw response text from vllm
 
         Returns:
-            Dictionary containing OpenAI format message and parsing results.
+            Dictionary containing OpenAI format message and parsing results
+
+        Raises:
+            Exception: Thrown when parsing fails
         """
         try:
+            # Use existing parser to parse tool calls
             parsed = parse_tools(response, self.tools_info, self.parser_type)
+
+            # Extract parsing results
             normal_text = parsed["normal_text"]
             calls = parsed["calls"]
+
+            # Convert to OpenAI format
             openai_message = self._convert_to_openai_message(normal_text, calls)
+
             return {"openai_message": openai_message, "parsed_result": parsed, "success": True}
+
         except Exception as e:
-            logger.warning(f"Parsing failed with error: {e}")
+            logger.warning(f"Parsing failed with error: {str(e)}")
             return {"openai_message": None, "parsed_result": None, "success": False, "error": str(e)}
 
     def _convert_to_openai_message(self, normal_text: str, calls: list[dict[str, Any]]) -> OpenAIAssistantMessage:
+        """
+        Convert parsing results to OpenAI format assistant message
+
+        Args:
+            normal_text: Normal text content
+            calls: List of tool calls
+
+        Returns:
+            OpenAI format assistant message
+        """
         if not calls:
+            # No tool calls, return plain text response
             return OpenAIAssistantMessage(role="assistant", content=normal_text, tool_calls=None)
 
+        # Convert tool calls to OpenAI format
         openai_tool_calls = []
         for i, call in enumerate(calls):
-            openai_tool_calls.append(
-                OpenAIToolCall(
-                    id=f"call_{i}_{call.get('name', 'unknown')}",
-                    type="function",
-                    function={"name": call.get("name", ""), "arguments": call.get("parameters", "{}")},
-                )
+            openai_tool_call = OpenAIToolCall(
+                id=f"call_{i}_{call.get('name', 'unknown')}",
+                type="function",
+                function={"name": call.get("name", ""), "arguments": call.get("parameters", "{}")},
             )
+            openai_tool_calls.append(openai_tool_call)
 
-        return OpenAIAssistantMessage(
-            role="assistant",
-            content=normal_text if normal_text.strip() else None,
-            tool_calls=openai_tool_calls,
+        result = OpenAIAssistantMessage(
+            role="assistant", content=normal_text if normal_text.strip() else None, tool_calls=openai_tool_calls
         )
+        return result
+
+    def _call_to_action_vllm(self, calls: list[Any], text_response: str) -> Action:
+        """
+        Convert vllm tool calls to Action object
+
+        This method replicates the original call_to_action_vllm logic,
+        ensuring compatibility with existing code.
+        """
+        # Default action if no action found
+        action = Action(name=RESPOND_ACTION_NAME, kwargs={"content": text_response})
+
+        if calls:
+            if len(calls) > 1:
+                logger.debug("Multiple tool calls identified, only taking first.")
+
+            tool_call = calls[0]
+
+            try:
+                params = json.loads(tool_call["parameters"])
+
+                if not isinstance(params, dict):
+                    logger.warning(f"{params} does not follow dict structure for action")
+                else:
+                    action = Action(name=tool_call["name"], kwargs=params)
+            except json.JSONDecodeError as e:
+                logger.warning(f"Failed to parse parameters as JSON: {e}")
+
+        return action
+
+    def get_openai_tools_format(self) -> list[dict[str, Any]]:
+        """
+        Get OpenAI format tool definitions
+
+        Returns:
+            List of OpenAI format tools
+        """
+        openai_tools = []
+        for tool in self.tools_info:
+            openai_tool = {
+                "type": "function",
+                "function": {
+                    "name": tool["function"]["name"],
+                    "description": tool["function"]["description"],
+                    "parameters": tool["function"]["parameters"],
+                },
+            }
+            openai_tools.append(openai_tool)
+
+        return openai_tools
 
 
+# Usage examples and factory functions
 def create_openai_adapter(
     tools_info: list[dict[str, Any]], parser_type: str = "qwen25"
 ) -> OpenAICompatibleToolCallAdapter:
-    """Factory function to create an OpenAI compatible tool-call adapter."""
+    """
+    Factory function to create OpenAI compatible tool call adapter
+
+    Args:
+        tools_info: List of tool information
+        parser_type: Parser type
+
+    Returns:
+        Configured adapter instance
+    """
     return OpenAICompatibleToolCallAdapter(tools_info, parser_type)

--- a/examples/tau-bench/openai_tool_adapter.py
+++ b/examples/tau-bench/openai_tool_adapter.py
@@ -1,0 +1,64 @@
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from tool_parser import parse_tools
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OpenAIToolCall:
+    id: str
+    type: str = "function"
+    function: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class OpenAIAssistantMessage:
+    role: str = "assistant"
+    content: str | None = None
+    tool_calls: list[OpenAIToolCall] | None = None
+
+
+class OpenAICompatibleToolCallAdapter:
+    def __init__(self, tools_info: list[dict[str, Any]], parser_type: str = "qwen25"):
+        self.tools_info = tools_info
+        self.parser_type = parser_type
+
+    def parse_response_to_openai_format(self, response: str) -> dict[str, Any]:
+        try:
+            parsed = parse_tools(response, self.tools_info, self.parser_type)
+            normal_text = parsed["normal_text"]
+            calls = parsed["calls"]
+            openai_message = self._convert_to_openai_message(normal_text, calls)
+            return {"openai_message": openai_message, "parsed_result": parsed, "success": True}
+        except Exception as e:
+            logger.warning(f"Parsing failed with error: {e}")
+            return {"openai_message": None, "parsed_result": None, "success": False, "error": str(e)}
+
+    def _convert_to_openai_message(self, normal_text: str, calls: list[dict[str, Any]]) -> OpenAIAssistantMessage:
+        if not calls:
+            return OpenAIAssistantMessage(role="assistant", content=normal_text, tool_calls=None)
+
+        openai_tool_calls = []
+        for i, call in enumerate(calls):
+            openai_tool_calls.append(
+                OpenAIToolCall(
+                    id=f"call_{i}_{call.get('name', 'unknown')}",
+                    type="function",
+                    function={"name": call.get("name", ""), "arguments": call.get("parameters", "{}")},
+                )
+            )
+
+        return OpenAIAssistantMessage(
+            role="assistant",
+            content=normal_text if normal_text.strip() else None,
+            tool_calls=openai_tool_calls,
+        )
+
+
+def create_openai_adapter(
+    tools_info: list[dict[str, Any]], parser_type: str = "qwen25"
+) -> OpenAICompatibleToolCallAdapter:
+    return OpenAICompatibleToolCallAdapter(tools_info, parser_type)

--- a/examples/tau-bench/run_qwen3_4B.sh
+++ b/examples/tau-bench/run_qwen3_4B.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+if grep -q $'\r' "$0" 2>/dev/null; then
+  exec bash <(sed 's/\r$//' "$0") "$@"
+fi
+
+pkill -9 vllm 2>/dev/null || true
+sleep 3
+ray stop --force 2>/dev/null || true
+pkill -9 ray 2>/dev/null || true
+pkill -9 -f 'python3 train.py' 2>/dev/null || true
+sleep 3
+
+set -ex
+
+export PYTHONUNBUFFERED=1
+export PYTHONBUFFERED=16
+
+unset PYTORCH_CUDA_ALLOC_CONF PYTORCH_ALLOC_CONF
+
+export TAU_BENCH_MOCK=1
+export TAU_BENCH_MAX_STEPS=10
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "$NVLINK_COUNT" -gt 0 ]; then
+  HAS_NVLINK=1
+else
+  HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+ACTOR_GPUS_PER_NODE="${ACTOR_GPUS_PER_NODE:-4}"
+ROLLOUT_NUM_GPUS="${ROLLOUT_NUM_GPUS:-4}"
+ROLLOUT_GPUS_PER_ENGINE="${ROLLOUT_GPUS_PER_ENGINE:-1}"
+TOTAL_GPUS="$((ACTOR_GPUS_PER_NODE + ROLLOUT_NUM_GPUS))"
+echo "TOTAL_GPUS (ray): ${TOTAL_GPUS}  (actor=${ACTOR_GPUS_PER_NODE}, rollout=${ROLLOUT_NUM_GPUS}, per_engine=${ROLLOUT_GPUS_PER_ENGINE})"
+
+VIME_ROOT="${VIME_ROOT:-/data/nfs_87/xky/vime_debug/vime_tau_bench}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+TAU_EXAMPLE="${SCRIPT_DIR}"
+cd "${VIME_ROOT}"
+
+export MODEL_ARGS_ROTARY_BASE=5000000
+source "${VIME_ROOT}/scripts/models/qwen3-4B.sh"
+
+HF_CKPT=/data/nfs_87/xky/models/Qwen3-4B-Instruct-2507
+REF_LOAD=/data/nfs_87/xky/models/Qwen3-4B-Instruct-2507_torch_dist
+SAVE_DIR=/data/nfs_87/xky/RL/vime_checkpoints/Qwen3-4B-Instruct_tau_bench
+
+LOG_ROOT=/data/nfs_87/xky/tb_logs
+TS=$(date +%Y%m%d_%H%M%S)
+export TENSORBOARD_DIR="${LOG_ROOT}/tb_qwen3_4b_tau_bench_${TS}"
+LOG_FILE="${LOG_ROOT}/train_qwen3_4b_tau_bench_${TS}.log"
+mkdir -p "${TENSORBOARD_DIR}" "${LOG_ROOT}"
+
+CKPT_ARGS=(
+   --hf-checkpoint "${HF_CKPT}"
+   --ref-load "${REF_LOAD}"
+)
+
+PROMPT_DATA=/data/nfs_87/xky/datasets/tau-bench/retail_train_tasks.jsonl
+ROLLOUT_ARGS=(
+   --prompt-data "${PROMPT_DATA}"
+   --input-key index
+   --rollout-shuffle
+   --num-rollout 50
+   --rollout-batch-size 16
+   --n-samples-per-prompt 4
+   --rollout-max-response-len 4096
+   --rollout-max-context-len 16384
+   --rollout-temperature 0.7
+   --global-batch-size 64
+   --balance-data
+)
+
+EVAL_ARGS=(
+   --eval-interval 5
+   --eval-prompt-data retail-dev /data/nfs_87/xky/datasets/tau-bench/retail_dev_tasks.jsonl
+   --n-samples-per-eval-prompt 1
+   --eval-max-response-len 4096
+   --eval-top-k 1
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 2
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 9216
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --use-kl-loss
+   --kl-loss-coef 0.001
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.01
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 5e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+)
+
+VLLM_ARGS=(
+   --rollout-num-gpus "${ROLLOUT_NUM_GPUS}"
+   --rollout-num-gpus-per-engine "${ROLLOUT_GPUS_PER_ENGINE}"
+   --rollout-backend vllm
+   --vllm-weight-sync-mode native
+   --vllm-gpu-memory-utilization 0.7
+   --vllm-max-model-len 16384
+)
+export VIME_VLLM_SERVER_HEALTH_TIMEOUT_SEC=900
+
+CUSTOM_ARGS=(
+   --custom-generate-function-path generate_with_tau.generate
+   --custom-rm-path generate_with_tau.batched_tau_bench_rm
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+   --train-memory-margin-bytes 2147483648
+   --use-tensorboard
+)
+
+VIME_PYTHONPATH="${TAU_EXAMPLE}:${VIME_ROOT}:/root/Megatron-LM/:${TAU_BENCH_SRC:-/data/nfs_87/xky/datasets/tau-bench-src/}:/usr/local/lib/python3.12/dist-packages/"
+
+echo "VIME_ROOT=${VIME_ROOT}"
+echo "TAU_EXAMPLE=${TAU_EXAMPLE}"
+echo "HF_CKPT=${HF_CKPT} REF_LOAD=${REF_LOAD} SAVE=${SAVE_DIR}"
+echo "PROMPT_DATA=${PROMPT_DATA}"
+
+export MASTER_ADDR=127.0.0.1
+ray start --head \
+  --node-ip-address "${MASTER_ADDR}" \
+  --num-gpus "${TOTAL_GPUS}" \
+  --disable-usage-stats \
+  --dashboard-host=0.0.0.0 \
+  --dashboard-port=8265
+
+unset http_proxy https_proxy
+
+RUNTIME_ENV_JSON='{"env_vars":{"PYTHONPATH":"'"${VIME_PYTHONPATH}"'","CUDA_DEVICE_MAX_CONNECTIONS":"1","NCCL_NVLS_ENABLE":"'"${HAS_NVLINK}"'","TENSORBOARD_DIR":"'"${TENSORBOARD_DIR}"'","VIME_VLLM_SERVER_HEALTH_TIMEOUT_SEC":"900","TAU_BENCH_MOCK":"1","TAU_BENCH_MAX_STEPS":"10"}}'
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --working-dir "${VIME_ROOT}" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 train.py \
+   --train-backend megatron \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node "${ACTOR_GPUS_PER_NODE}" \
+   "${MODEL_ARGS[@]}" \
+   "${CKPT_ARGS[@]}" \
+   "${ROLLOUT_ARGS[@]}" \
+   "${EVAL_ARGS[@]}" \
+   "${OPTIMIZER_ARGS[@]}" \
+   "${GRPO_ARGS[@]}" \
+   "${PERF_ARGS[@]}" \
+   "${VLLM_ARGS[@]}" \
+   "${CUSTOM_ARGS[@]}" \
+   "${MISC_ARGS[@]}" \
+   2>&1 | tee -a "${LOG_FILE}"

--- a/examples/tau-bench/run_qwen3_4B.sh
+++ b/examples/tau-bench/run_qwen3_4B.sh
@@ -35,19 +35,22 @@ ROLLOUT_GPUS_PER_ENGINE="${ROLLOUT_GPUS_PER_ENGINE:-1}"
 TOTAL_GPUS="$((ACTOR_GPUS_PER_NODE + ROLLOUT_NUM_GPUS))"
 echo "TOTAL_GPUS (ray): ${TOTAL_GPUS}  (actor=${ACTOR_GPUS_PER_NODE}, rollout=${ROLLOUT_NUM_GPUS}, per_engine=${ROLLOUT_GPUS_PER_ENGINE})"
 
-VIME_ROOT="${VIME_ROOT:-/data/nfs_87/xky/vime_debug/vime_tau_bench}"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+VIME_DIR="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
 TAU_EXAMPLE="${SCRIPT_DIR}"
-cd "${VIME_ROOT}"
+TAU_BENCH_SRC="${TAU_BENCH_SRC:-/root/tau-bench-src}"
+TAU_DATA_DIR="${TAU_DATA_DIR:-/root/tau-bench}"
+
+cd "${VIME_DIR}"
 
 export MODEL_ARGS_ROTARY_BASE=5000000
-source "${VIME_ROOT}/scripts/models/qwen3-4B.sh"
+source "${VIME_DIR}/scripts/models/qwen3-4B-Instruct-2507.sh"
 
-HF_CKPT=/data/nfs_87/xky/models/Qwen3-4B-Instruct-2507
-REF_LOAD=/data/nfs_87/xky/models/Qwen3-4B-Instruct-2507_torch_dist
-SAVE_DIR=/data/nfs_87/xky/RL/vime_checkpoints/Qwen3-4B-Instruct_tau_bench
+HF_CKPT="${HF_CKPT:-/root/Qwen3-4B-Instruct-2507}"
+REF_LOAD="${REF_LOAD:-/root/Qwen3-4B-Instruct-2507_torch_dist}"
+SAVE_DIR="${SAVE_DIR:-/root/Qwen3-4B-Instruct_tau_bench}"
 
-LOG_ROOT=/data/nfs_87/xky/tb_logs
+LOG_ROOT="${LOG_ROOT:-/root/logs}"
 TS=$(date +%Y%m%d_%H%M%S)
 export TENSORBOARD_DIR="${LOG_ROOT}/tb_qwen3_4b_tau_bench_${TS}"
 LOG_FILE="${LOG_ROOT}/train_qwen3_4b_tau_bench_${TS}.log"
@@ -56,9 +59,10 @@ mkdir -p "${TENSORBOARD_DIR}" "${LOG_ROOT}"
 CKPT_ARGS=(
    --hf-checkpoint "${HF_CKPT}"
    --ref-load "${REF_LOAD}"
+   --save "${SAVE_DIR}"
 )
 
-PROMPT_DATA=/data/nfs_87/xky/datasets/tau-bench/retail_train_tasks.jsonl
+PROMPT_DATA="${PROMPT_DATA:-${TAU_DATA_DIR}/retail_train_tasks.jsonl}"
 ROLLOUT_ARGS=(
    --prompt-data "${PROMPT_DATA}"
    --input-key index
@@ -75,7 +79,7 @@ ROLLOUT_ARGS=(
 
 EVAL_ARGS=(
    --eval-interval 5
-   --eval-prompt-data retail-dev /data/nfs_87/xky/datasets/tau-bench/retail_dev_tasks.jsonl
+   --eval-prompt-data retail-dev "${TAU_DATA_DIR}/retail_dev_tasks.jsonl"
    --n-samples-per-eval-prompt 1
    --eval-max-response-len 4096
    --eval-top-k 1
@@ -117,8 +121,6 @@ OPTIMIZER_ARGS=(
 VLLM_ARGS=(
    --rollout-num-gpus "${ROLLOUT_NUM_GPUS}"
    --rollout-num-gpus-per-engine "${ROLLOUT_GPUS_PER_ENGINE}"
-   --rollout-backend vllm
-   --vllm-weight-sync-mode native
    --vllm-gpu-memory-utilization 0.7
    --vllm-max-model-len 16384
 )
@@ -139,9 +141,9 @@ MISC_ARGS=(
    --use-tensorboard
 )
 
-VIME_PYTHONPATH="${TAU_EXAMPLE}:${VIME_ROOT}:/root/Megatron-LM/:${TAU_BENCH_SRC:-/data/nfs_87/xky/datasets/tau-bench-src/}:/usr/local/lib/python3.12/dist-packages/"
+VIME_PYTHONPATH="${TAU_EXAMPLE}:${VIME_DIR}:/root/Megatron-LM:${TAU_BENCH_SRC}"
 
-echo "VIME_ROOT=${VIME_ROOT}"
+echo "VIME_DIR=${VIME_DIR}"
 echo "TAU_EXAMPLE=${TAU_EXAMPLE}"
 echo "HF_CKPT=${HF_CKPT} REF_LOAD=${REF_LOAD} SAVE=${SAVE_DIR}"
 echo "PROMPT_DATA=${PROMPT_DATA}"
@@ -159,7 +161,7 @@ unset http_proxy https_proxy
 RUNTIME_ENV_JSON='{"env_vars":{"PYTHONPATH":"'"${VIME_PYTHONPATH}"'","CUDA_DEVICE_MAX_CONNECTIONS":"1","NCCL_NVLS_ENABLE":"'"${HAS_NVLINK}"'","TENSORBOARD_DIR":"'"${TENSORBOARD_DIR}"'","VIME_VLLM_SERVER_HEALTH_TIMEOUT_SEC":"900","TAU_BENCH_MOCK":"1","TAU_BENCH_MAX_STEPS":"10"}}'
 
 ray job submit --address="http://127.0.0.1:8265" \
-   --working-dir "${VIME_ROOT}" \
+   --working-dir "${VIME_DIR}" \
    --runtime-env-json="${RUNTIME_ENV_JSON}" \
    -- python3 train.py \
    --train-backend megatron \

--- a/examples/tau-bench/run_qwen3_4B.sh
+++ b/examples/tau-bench/run_qwen3_4B.sh
@@ -1,87 +1,58 @@
 #!/bin/bash
 
-if grep -q $'\r' "$0" 2>/dev/null; then
-  exec bash <(sed 's/\r$//' "$0") "$@"
-fi
-
-pkill -9 vllm 2>/dev/null || true
+# for rerun the task
+pkill -9 vllm
 sleep 3
-ray stop --force 2>/dev/null || true
-pkill -9 ray 2>/dev/null || true
-pkill -9 -f 'python3 train.py' 2>/dev/null || true
+ray stop --force
+pkill -9 ray
+pkill -9 python
 sleep 3
+pkill -9 ray
+pkill -9 python
 
 set -ex
 
+# will prevent ray from buffering stdout/stderr
 export PYTHONUNBUFFERED=1
-export PYTHONBUFFERED=16
-
-unset PYTORCH_CUDA_ALLOC_CONF PYTORCH_ALLOC_CONF
-
-export TAU_BENCH_MOCK=1
-export TAU_BENCH_MAX_STEPS=10
 
 NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
 if [ "$NVLINK_COUNT" -gt 0 ]; then
-  HAS_NVLINK=1
+    HAS_NVLINK=1
 else
-  HAS_NVLINK=0
+    HAS_NVLINK=0
 fi
 echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
 
-ACTOR_GPUS_PER_NODE="${ACTOR_GPUS_PER_NODE:-4}"
-ROLLOUT_NUM_GPUS="${ROLLOUT_NUM_GPUS:-4}"
-ROLLOUT_GPUS_PER_ENGINE="${ROLLOUT_GPUS_PER_ENGINE:-1}"
-TOTAL_GPUS="$((ACTOR_GPUS_PER_NODE + ROLLOUT_NUM_GPUS))"
-echo "TOTAL_GPUS (ray): ${TOTAL_GPUS}  (actor=${ACTOR_GPUS_PER_NODE}, rollout=${ROLLOUT_NUM_GPUS}, per_engine=${ROLLOUT_GPUS_PER_ENGINE})"
-
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
-VIME_DIR="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
-TAU_EXAMPLE="${SCRIPT_DIR}"
-TAU_BENCH_SRC="${TAU_BENCH_SRC:-/root/tau-bench-src}"
-TAU_DATA_DIR="${TAU_DATA_DIR:-/root/tau-bench}"
-
-cd "${VIME_DIR}"
-
-export MODEL_ARGS_ROTARY_BASE=5000000
-source "${VIME_DIR}/scripts/models/qwen3-4B-Instruct-2507.sh"
-
-HF_CKPT="${HF_CKPT:-/root/Qwen3-4B-Instruct-2507}"
-REF_LOAD="${REF_LOAD:-/root/Qwen3-4B-Instruct-2507_torch_dist}"
-SAVE_DIR="${SAVE_DIR:-/root/Qwen3-4B-Instruct_tau_bench}"
-
-LOG_ROOT="${LOG_ROOT:-/root/logs}"
-TS=$(date +%Y%m%d_%H%M%S)
-export TENSORBOARD_DIR="${LOG_ROOT}/tb_qwen3_4b_tau_bench_${TS}"
-LOG_FILE="${LOG_ROOT}/train_qwen3_4b_tau_bench_${TS}.log"
-mkdir -p "${TENSORBOARD_DIR}" "${LOG_ROOT}"
+source "${SCRIPT_DIR}/../../scripts/models/qwen3-4B-Instruct-2507.sh"
 
 CKPT_ARGS=(
-   --hf-checkpoint "${HF_CKPT}"
-   --ref-load "${REF_LOAD}"
-   --save "${SAVE_DIR}"
+   --hf-checkpoint /root/Qwen3-4B-Instruct-2507/
+   --ref-load /root/Qwen3-4B-Instruct-2507_torch_dist/
+   --load /root/Qwen3-4B-Instruct-2507_vime/
+   --save /root/Qwen3-4B-Instruct-2507_vime/
+   --save-interval 20
 )
 
-PROMPT_DATA="${PROMPT_DATA:-${TAU_DATA_DIR}/retail_train_tasks.jsonl}"
 ROLLOUT_ARGS=(
-   --prompt-data "${PROMPT_DATA}"
+   --prompt-data /root/tau-bench/retail_train_tasks.jsonl
    --input-key index
    --rollout-shuffle
-   --num-rollout 50
-   --rollout-batch-size 16
-   --n-samples-per-prompt 4
-   --rollout-max-response-len 4096
-   --rollout-max-context-len 16384
-   --rollout-temperature 0.7
-   --global-batch-size 64
+   --num-rollout 500
+   --rollout-batch-size 32
+   --n-samples-per-prompt 8
+   --rollout-max-response-len 1024
+   --rollout-temperature 1
+   --global-batch-size 256
+   --dynamic-sampling-filter-path vime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std
    --balance-data
 )
 
 EVAL_ARGS=(
    --eval-interval 5
-   --eval-prompt-data retail-dev "${TAU_DATA_DIR}/retail_dev_tasks.jsonl"
+   --eval-prompt-data retail-dev /root/tau-bench/retail_dev_tasks.jsonl
    --n-samples-per-eval-prompt 1
-   --eval-max-response-len 4096
+   --eval-max-response-len 1024
    --eval-top-k 1
 )
 
@@ -102,16 +73,16 @@ PERF_ARGS=(
 GRPO_ARGS=(
    --advantage-estimator grpo
    --use-kl-loss
-   --kl-loss-coef 0.001
+   --kl-loss-coef 0.00
    --kl-loss-type low_var_kl
-   --entropy-coef 0.01
+   --entropy-coef 0.00
    --eps-clip 0.2
    --eps-clip-high 0.28
 )
 
 OPTIMIZER_ARGS=(
    --optimizer adam
-   --lr 5e-6
+   --lr 1e-6
    --lr-decay-style constant
    --weight-decay 0.1
    --adam-beta1 0.9
@@ -119,62 +90,55 @@ OPTIMIZER_ARGS=(
 )
 
 VLLM_ARGS=(
-   --rollout-num-gpus "${ROLLOUT_NUM_GPUS}"
-   --rollout-num-gpus-per-engine "${ROLLOUT_GPUS_PER_ENGINE}"
+   --rollout-num-gpus-per-engine 1
    --vllm-gpu-memory-utilization 0.7
-   --vllm-max-model-len 16384
-)
-export VIME_VLLM_SERVER_HEALTH_TIMEOUT_SEC=900
-
-CUSTOM_ARGS=(
-   --custom-generate-function-path generate_with_tau.generate
-   --custom-rm-path generate_with_tau.batched_tau_bench_rm
+   # If gemini API reports concurrency limit error, set this parameter to reduce the concurrency
+   # --vllm-server-concurrency 32
 )
 
 MISC_ARGS=(
+   # default dropout in megatron is 0.1
    --attention-dropout 0.0
    --hidden-dropout 0.0
+   # should be good for model performance
    --accumulate-allreduce-grads-in-fp32
    --attention-softmax-in-fp32
+   # need to comment this when using model with MLA
    --attention-backend flash
-   --train-memory-margin-bytes 2147483648
-   --use-tensorboard
 )
 
-VIME_PYTHONPATH="${TAU_EXAMPLE}:${VIME_DIR}:/root/Megatron-LM:${TAU_BENCH_SRC}"
+CUSTOM_ARGS=(
+   --custom-generate-function-path generate_with_tau.generate
+)
+# launch the master node of ray in container
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
 
-echo "VIME_DIR=${VIME_DIR}"
-echo "TAU_EXAMPLE=${TAU_EXAMPLE}"
-echo "HF_CKPT=${HF_CKPT} REF_LOAD=${REF_LOAD} SAVE=${SAVE_DIR}"
-echo "PROMPT_DATA=${PROMPT_DATA}"
+# If you want more or less GPUs, change this parameter
+NUM_GPUS=2
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus ${NUM_GPUS} --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265 --temp-dir /root/shared/ray_temp
 
-export MASTER_ADDR=127.0.0.1
-ray start --head \
-  --node-ip-address "${MASTER_ADDR}" \
-  --num-gpus "${TOTAL_GPUS}" \
-  --disable-usage-stats \
-  --dashboard-host=0.0.0.0 \
-  --dashboard-port=8265
-
-unset http_proxy https_proxy
-
-RUNTIME_ENV_JSON='{"env_vars":{"PYTHONPATH":"'"${VIME_PYTHONPATH}"'","CUDA_DEVICE_MAX_CONNECTIONS":"1","NCCL_NVLS_ENABLE":"'"${HAS_NVLINK}"'","TENSORBOARD_DIR":"'"${TENSORBOARD_DIR}"'","VIME_VLLM_SERVER_HEALTH_TIMEOUT_SEC":"900","TAU_BENCH_MOCK":"1","TAU_BENCH_MAX_STEPS":"10"}}'
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"/root/Megatron-LM/:${SCRIPT_DIR}\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\"
+  }
+}"
 
 ray job submit --address="http://127.0.0.1:8265" \
-   --working-dir "${VIME_DIR}" \
    --runtime-env-json="${RUNTIME_ENV_JSON}" \
    -- python3 train.py \
-   --train-backend megatron \
    --actor-num-nodes 1 \
-   --actor-num-gpus-per-node "${ACTOR_GPUS_PER_NODE}" \
-   "${MODEL_ARGS[@]}" \
-   "${CKPT_ARGS[@]}" \
-   "${ROLLOUT_ARGS[@]}" \
-   "${EVAL_ARGS[@]}" \
-   "${OPTIMIZER_ARGS[@]}" \
-   "${GRPO_ARGS[@]}" \
-   "${PERF_ARGS[@]}" \
-   "${VLLM_ARGS[@]}" \
-   "${CUSTOM_ARGS[@]}" \
-   "${MISC_ARGS[@]}" \
-   2>&1 | tee -a "${LOG_FILE}"
+   --actor-num-gpus-per-node ${NUM_GPUS} \
+   --rollout-num-gpus ${NUM_GPUS} \
+   --colocate \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${DISTRIBUTED_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${VLLM_ARGS[@]} \
+   ${MISC_ARGS[@]} \
+   ${CUSTOM_ARGS[@]}

--- a/examples/tau-bench/tau1_mock.py
+++ b/examples/tau-bench/tau1_mock.py
@@ -1,0 +1,39 @@
+import argparse
+import json
+import os
+
+from tau_bench.envs import get_env
+from tau_bench.types import RunConfig
+
+ALL_DATA_MAPPINGS = {"retail": ["train", "test", "dev"], "airline": ["test"]}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Tau1 Mock Script")
+    parser.add_argument("--local_dir", required=True, help="Path to the local directory")
+    args = parser.parse_args()
+
+    local_dir = args.local_dir
+    if not os.path.isdir(local_dir):
+        os.makedirs(local_dir)
+    config = RunConfig(model_provider="mock", user_model_provider="mock", user_strategy="human", model="mock")
+    for env, split in ALL_DATA_MAPPINGS.items():
+        for s in split:
+            config.env = env
+            config.task_split = s
+            env_instance = get_env(
+                env_name=config.env,
+                user_strategy=config.user_strategy,
+                user_model=config.user_model,
+                task_split=config.task_split,
+            )
+            output_path = os.path.join(local_dir, f"{env}_{s}_tasks.jsonl")
+            with open(output_path, "w") as f:
+                for i, task in enumerate(env_instance.tasks):
+                    row = {"index": i, "metadata": task.model_dump()}
+                    f.write(json.dumps(row) + "\n")
+            print(f"Saved preprocessed task indices for {env} ({s}) to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tau-bench/tau1_mock.py
+++ b/examples/tau-bench/tau1_mock.py
@@ -31,7 +31,7 @@ def main():
             with open(output_path, "w") as f:
                 for i, task in enumerate(env_instance.tasks):
                     row = {"index": i, "metadata": task.model_dump()}
-                    f.write(json.dumps(row) + "\n")
+                    f.write(json.dumps(row) + "\n")  # <-- one JSON object per line
             print(f"Saved preprocessed task indices for {env} ({s}) to {output_path}")
 
 

--- a/examples/tau-bench/tool_parser.py
+++ b/examples/tau-bench/tool_parser.py
@@ -1,0 +1,93 @@
+import json
+import re
+from typing import Any
+
+
+def parse_tools(response: str, tools: list[dict[str, Any]], parser: str = "qwen25") -> dict[str, Any]:
+    if parser == "qwen25":
+        return _parse_qwen25_tools(response)
+    return _parse_qwen25_tools(response)
+
+
+def _try_parse_json_tool_call(text: str) -> dict[str, Any] | None:
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, dict) and "name" in parsed:
+            name = parsed.get("name", "")
+            parameters = parsed.get("arguments", parsed.get("parameters", {}))
+            if isinstance(parameters, str):
+                try:
+                    parameters = json.loads(parameters)
+                except json.JSONDecodeError:
+                    pass
+            return {"name": name, "parameters": parameters}
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return None
+
+
+def _parse_qwen25_tools(response: str) -> dict[str, Any]:
+    call_open = chr(60) + "tool_call" + chr(62)
+    call_close = chr(60) + "/tool_call" + chr(62)
+    call_open_alt = chr(60) + "call" + chr(62)
+    call_close_alt = chr(60) + "/call" + chr(62)
+    pattern = r"(?:" + call_open + "|" + call_open_alt + r")\s*(.*?)\s*(?:" + call_close + "|" + call_close_alt + ")"
+    tool_call_pattern = re.compile(pattern, re.DOTALL)
+    matches = tool_call_pattern.findall(response)
+
+    if matches:
+        parts = tool_call_pattern.split(response)
+        normal_text = parts[0].strip() if parts else ""
+        calls = []
+        for match in matches:
+            match = match.strip()
+            parsed_call = _try_parse_json_tool_call(match)
+            if parsed_call:
+                calls.append(parsed_call)
+            else:
+                try:
+                    json_match = re.search(r"\{.*\}", match, re.DOTALL)
+                    if json_match:
+                        parsed_call = _try_parse_json_tool_call(json_match.group())
+                        if parsed_call:
+                            calls.append(parsed_call)
+                        else:
+                            calls.append({"name": match, "parameters": {}})
+                    else:
+                        calls.append({"name": match, "parameters": {}})
+                except (json.JSONDecodeError, AttributeError):
+                    calls.append({"name": match, "parameters": {}})
+
+        return {
+            "normal_text": normal_text,
+            "calls": calls,
+        }
+
+    cleaned = re.sub(r"<\|im_end\|>", "", response).strip()
+    parsed_call = _try_parse_json_tool_call(cleaned)
+    if parsed_call:
+        return {
+            "normal_text": "",
+            "calls": [parsed_call],
+        }
+
+    json_pattern = re.compile(r'\{[^{}]*"name"\s*:\s*"[^"]+?"[^{}]*\}', re.DOTALL)
+    json_matches = json_pattern.findall(response)
+    if json_matches:
+        calls = []
+        for jm in json_matches:
+            parsed_call = _try_parse_json_tool_call(jm)
+            if parsed_call:
+                calls.append(parsed_call)
+        if calls:
+            normal_text = json_pattern.sub("", response).strip()
+            normal_text = re.sub(r"<\|im_end\|>", "", normal_text).strip()
+            return {
+                "normal_text": normal_text,
+                "calls": calls,
+            }
+
+    return {
+        "normal_text": response,
+        "calls": [],
+    }

--- a/examples/tau-bench/trainable_agents.py
+++ b/examples/tau-bench/trainable_agents.py
@@ -1,0 +1,488 @@
+import json
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from openai_tool_adapter import create_openai_adapter
+from tau_bench.agents.base import Agent
+from tau_bench.agents.tool_calling_agent import RESPOND_ACTION_NAME, ToolCallingAgent
+from tau_bench.types import Action, RunConfig
+from transformers import AutoTokenizer
+
+from vime.rollout.vllm_rollout import GenerateState, _build_inference_sampling_params
+from vime.utils.http_utils import post
+
+# Set up logger for this module
+logger = logging.getLogger(__name__)
+
+
+class Status(Enum):
+    COMPLETED = "completed"
+    TRUNCATED = "truncated"
+    ABORTED = "aborted"
+
+
+@dataclass
+class InteractionResult:
+    prompt: str
+    reward: float
+    messages: list[dict[str, Any]]
+    info: dict[str, Any]
+    response: str = ""
+    loss_mask: list[int] | None = None
+    tokens: int | None = None
+    status: Status = Status.COMPLETED
+
+
+def call_to_action_vllm(calls: list[Any], text_response: str) -> Action:
+    """
+    Convert vllm response message to Action, similar to original message_to_action
+    but adapted for vllm response format.
+    """
+    # Default action if no action was found.
+    action = Action(name=RESPOND_ACTION_NAME, kwargs={"content": text_response})
+    if calls:
+        if len(calls) > 1:
+            logger.debug("Multiple tool calls identified, only taking first.")
+        tool_call = calls[0]
+        params = json.loads(tool_call["parameters"])
+        if not isinstance(params, dict):
+            logger.warning(f"{params} does not follow dict structure for action")
+        else:
+            action = Action(name=tool_call["name"], kwargs=params)
+    return action
+
+
+TOOL_INSTRUCTION = (
+    " At each turn, you are allowed to call one or no function to assist "
+    "with task execution using <tools></tools> XML tags.\n"
+    "YOU MUST EXECUTE TOOLS TO MAKE ANY MODIFICATIONS OR CANCELLATIONS. "
+    "Each tool call leads to a message returned by the system.\n"
+    "NEVER confirm execution to the user without seeing confirmation "
+    "from the tool system.\n"
+)
+
+
+class TrainableAgentMixin:
+    """
+    Mixin class that provides trainable agent functionality for tau-bench environments.
+
+    This mixin extends the original tau-bench agent with async LLM interaction
+    capabilities for reinforcement learning training using vllm servers.
+    """
+
+    def _reformulate_tool_call(self, text: str) -> str:
+        """
+        Reformulate tool call instruction for tau-bench environment.
+
+        The default tool template assumes one or more function calls, but for
+        tau-bench, at most one tool call or skip tool calls are the valid options.
+
+        Args:
+            text: Original tool instruction text
+
+        Returns:
+            Reformulated tool instruction text
+        """
+        return text.replace("You may call one or more functions to assist with the user query.", TOOL_INSTRUCTION)
+
+    async def _call_llm(self, url: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """
+        Make an LLM call tracking.
+
+        Args:
+            url: vLLM server URL
+            payload: Request payload containing token_ids and sampling parameters
+
+        Returns:
+            LLM response from vllm server
+        """
+        return await post(url, payload)
+
+    def _parse_tool(self, response: str) -> dict[str, Any]:
+        """
+        Parse tool calls from LLM response string.
+
+        Args:
+            response: Raw response text from vllm
+
+        Returns:
+            Parsed tool call result in OpenAI format
+        """
+        return self.openai_adapter.parse_response_to_openai_format(response)
+
+    async def _execute_tool(self, env, action: Action):
+        """
+        Execute a tool/action in the environment.
+
+        Args:
+            env: Tau-bench environment instance
+            action: Action to execute
+
+        Returns:
+            Environment step result
+        """
+        return env.step(action)
+
+    def _initialize_environment(self, env, task_index: int | None) -> tuple[str, dict[str, Any]]:
+        """
+        Initialize the environment and get initial observation.
+
+        Args:
+            env: Tau-bench environment instance
+            task_index: Task index to reset to
+
+        Returns:
+            Tuple of (observation, info)
+        """
+        if task_index is not None:
+            env_reset_res = env.reset(task_index=task_index)
+        else:
+            env_reset_res = env.reset()
+        return env_reset_res.observation, env_reset_res.info.model_dump()
+
+    def _build_initial_messages(self, obs: str) -> list[dict[str, Any]]:
+        """
+        Build initial conversation messages.
+
+        Args:
+            obs: Initial observation from environment
+
+        Returns:
+            List of initial messages
+        """
+        return [{"role": "system", "content": self.wiki}, {"role": "user", "content": obs}]
+
+    def _prepare_prompt_tokens(self, state: GenerateState, messages: list[dict[str, Any]]) -> tuple[str, list[int]]:
+        """
+        Prepare prompt text and tokenize it.
+
+        Args:
+            state: GenerateState instance with tokenizer
+            messages: Conversation messages
+
+        Returns:
+            Tuple of (prompt_text, prompt_token_ids)
+        """
+        prompt_text = state.tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True, tools=self.tools_info
+        )
+        # Reformulate tool call instruction for tau-bench
+        prompt_text = self._reformulate_tool_call(prompt_text)
+        prompt_token_ids = state.tokenizer(prompt_text, add_special_tokens=False)["input_ids"]
+        return prompt_text, prompt_token_ids
+
+    async def asolve(
+        self,
+        env,
+        rollout_args: dict[str, Any],
+        sampling_params: dict[str, Any],
+        task_index: int | None = None,
+        max_num_steps: int = 30,
+    ) -> InteractionResult:
+        """
+        Execute async agent-environment interaction for training.
+
+        This method extends the original Agent to support async interaction with LLM
+        server for reinforcement learning training. It maintains conversation history,
+        tracks tokens, and records metadata for training purposes.
+
+        Args:
+            env: Tau-bench environment instance
+            rollout_args: Rollout configuration arguments
+            sampling_params: LLM sampling parameters
+            task_index: Specific task index to solve (optional)
+            max_num_steps: Maximum number of interaction steps
+
+        Returns:
+            InteractionResult containing the complete interaction trajectory
+        """
+        # Initialize environment and state
+        state = GenerateState(rollout_args)
+        # vLLM: /inference/v1/generate (takes token_ids, not text)
+        base_url = f"http://{rollout_args.vllm_router_ip}:" f"{rollout_args.vllm_router_port}"
+        url = f"{base_url}/inference/v1/generate"
+
+        # Get initial environment state
+        obs, info = self._initialize_environment(env, task_index)
+
+        # Build initial conversation
+        messages = self._build_initial_messages(obs)
+        prompt_text, prompt_token_ids = self._prepare_prompt_tokens(state, messages)
+
+        # Initialize tracking variables
+        loss_masks = []
+        response_token_ids = []
+        total_reward = 0.0
+
+        # Initialize result
+        res = InteractionResult(prompt=prompt_text, reward=0, messages=[], info={})
+
+        # Build vLLM-compatible sampling params
+        vllm_sampling_params = _build_inference_sampling_params(sampling_params)
+
+        # Multi-turn interaction loop
+        for _ in range(max_num_steps):
+            # Prepare payload for vllm
+            text_input = state.tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True, tools=self.tools_info
+            )
+            # Reformulate tool call instruction for tau-bench
+            text_input = self._reformulate_tool_call(text_input)
+            # vLLM takes token_ids, not text
+            token_ids = state.tokenizer(text_input, add_special_tokens=False)["input_ids"]
+            payload = {
+                "model": rollout_args.hf_checkpoint,
+                "token_ids": token_ids,
+                "sampling_params": vllm_sampling_params,
+            }
+
+            # Send request to vllm server
+            output = await self._call_llm(url, payload)
+
+            # Check for abort — vLLM uses choices[].finish_reason (flat string)
+            choice = output["choices"][0]
+            finish_reason = choice.get("finish_reason") or "stop"
+            if finish_reason == "abort":
+                res.status = Status.ABORTED
+                return self._build_final_result(
+                    res, total_reward, info, messages, loss_masks, prompt_token_ids, response_token_ids
+                )
+
+            # vLLM returns token_ids; decode to text
+            output_token_ids = choice.get("token_ids", [])
+            response = state.tokenizer.decode(output_token_ids, skip_special_tokens=False)
+            # Remove end of conversation token if present
+            if response.endswith("<|im_end|>"):
+                response = response[:-10]
+
+            # Parse tool calls using OpenAI adapter
+            logger.debug(f"Using OpenAI adapter to parse response: {response[:100]}...")
+            try:
+                openai_result = self._parse_tool(response)
+                logger.debug(f"OpenAI adapter result: success={openai_result['success']}")
+
+                if not openai_result["success"]:
+                    logger.warning(f"OpenAI adapter failed: {openai_result['error']}")
+                    logger.warning(
+                        f"rollout response: {response} can not be parsed into " f"tool calls {openai_result['error']}"
+                    )
+                    res.status = Status.ABORTED
+                    return self._build_final_result(
+                        res, total_reward, info, messages, loss_masks, prompt_token_ids, response_token_ids
+                    )
+
+                # Extract parsed results
+                parsed = openai_result["parsed_result"]
+                logger.debug(
+                    f"Successfully parsed - normal_text: '{parsed['normal_text']}', " f"calls: {parsed['calls']}"
+                )
+
+            except Exception as e:
+                logger.warning(f"Exception in OpenAI adapter: {e}")
+                logger.warning(f"rollout response: {response} can not be parsed into " f"tool calls {e}")
+                res.status = Status.ABORTED
+                return self._build_final_result(
+                    res, total_reward, info, messages, loss_masks, prompt_token_ids, response_token_ids
+                )
+
+            # Add assistant response to conversation
+            messages.append({"role": "assistant", "content": response})
+            assistant_token_ids, assistant_loss_mask = self._get_token_delta(state.tokenizer, messages)
+            response_token_ids.extend(assistant_token_ids)
+            loss_masks.extend(assistant_loss_mask)
+
+            # Execute action in environment
+            agent_content, calls = parsed["normal_text"], parsed["calls"]
+            logger.debug(f"Creating action from - content: '{agent_content}', " f"calls: {calls}")
+            action = call_to_action_vllm(calls, agent_content)
+            logger.debug(f"Created action: {action}")
+
+            try:
+                env_response = await self._execute_tool(env, action)
+            except Exception as e:
+                logger.warning("Environment step failed, this is usually related to " "the User simulation call.")
+                logger.warning(f"Error: {e}")
+                res.status = Status.ABORTED
+                return self._build_final_result(
+                    res, total_reward, info, messages, loss_masks, prompt_token_ids, response_token_ids
+                )
+
+            logger.debug(f"Environment response: reward={env_response.reward}, " f"done={env_response.done}")
+
+            # Update message history based on action type
+            if action.name != RESPOND_ACTION_NAME:
+                messages.append(
+                    {
+                        "role": "tool",
+                        "name": action.name,
+                        "content": env_response.observation,
+                    }
+                )
+            else:
+                # Direct response from user
+                messages.append({"role": "user", "content": env_response.observation})
+
+            # Update token tracking
+            env_token_ids, env_loss_mask = self._get_token_delta(state.tokenizer, messages)
+            response_token_ids.extend(env_token_ids)
+            loss_masks.extend(env_loss_mask)
+
+            # Update reward and info
+            total_reward = env_response.reward
+            info = {**info, **env_response.info.model_dump()}
+
+            # Check if done
+            if env_response.done:
+                res.status = Status.COMPLETED
+                break
+
+        # Handle truncation
+        if not env_response.done:
+            res.status = Status.TRUNCATED
+
+        return self._build_final_result(
+            res, total_reward, info, messages, loss_masks, prompt_token_ids, response_token_ids
+        )
+
+    def _get_token_delta(self, tokenizer: AutoTokenizer, messages: list[dict]) -> tuple[list[int], list[int]]:
+        """
+        Calculate token delta for multi-turn conversations.
+
+        Tokenization logic adapted from:
+        https://verl.readthedocs.io/en/v0.4.1/sglang_multiturn/multiturn.html
+        to calculate the right token count in a multi-turn environment using
+        delta between messages.
+
+        Args:
+            tokenizer: Tokenizer instance
+            messages: Conversation messages
+
+        Returns:
+            Tuple of (token_ids, loss_mask)
+        """
+        curr = tokenizer.apply_chat_template(messages, add_generation_prompt=False, tokenize=False)
+        token_ids = []
+        loss_mask = []
+
+        # Case 1: last message is an assistant response
+        if messages[-1]["role"] == "assistant":
+            prev = tokenizer.apply_chat_template(messages[:-1], add_generation_prompt=True, tokenize=False)
+            new_tokens = tokenizer.encode(curr[len(prev) :], add_special_tokens=False)
+            token_ids += new_tokens
+            loss_mask += [1] * len(new_tokens)  # Mask only the new assistant tokens
+        else:
+            # Case 2: last message is a tool response or environment observation
+            prev = tokenizer.apply_chat_template(messages[:-1], add_generation_prompt=False, tokenize=False)
+            new_tokens = tokenizer.encode(curr[len(prev) :], add_special_tokens=False)
+            token_ids += new_tokens
+            loss_mask += [0] * len(new_tokens)  # Don't mask environment/tool tokens
+
+        return token_ids, loss_mask
+
+    def _build_final_result(
+        self,
+        res: InteractionResult,
+        total_reward: float,
+        info: dict[str, Any],
+        messages: list[dict[str, Any]],
+        loss_masks: list[int],
+        prompt_token_ids: list[int],
+        response_token_ids: list[int],
+    ) -> InteractionResult:
+        """
+        Build the final interaction result with all collected data.
+
+        Args:
+            res: InteractionResult instance to populate
+            total_reward: Total reward accumulated during interaction
+            info: Environment info dictionary
+            messages: Complete conversation messages
+            loss_masks: Loss masks for training
+            prompt_token_ids: Prompt token IDs
+            response_token_ids: Response token IDs
+
+        Returns:
+            Populated InteractionResult
+        """
+        res.reward = total_reward
+        res.info = info
+        res.messages = messages
+        res.loss_mask = loss_masks
+        res.tokens = prompt_token_ids + response_token_ids
+        res.response = "".join([msg.get("content", "") for msg in messages if msg["role"] == "assistant"])
+        res.response_length = len(loss_masks)
+
+        logger.debug(
+            f"_build_final_result: response_length={res.response_length}, "
+            f"response_loss_mask_len={len(loss_masks)}, "
+            f"prompt_token_len={len(prompt_token_ids)}, "
+            f"response_token_len={len(response_token_ids)}, "
+            f"response='{res.response[:100]}...'"
+        )
+        return res
+
+
+class TrainableToolCallingAgent(ToolCallingAgent, TrainableAgentMixin):
+    """
+    A trainable version of ToolCallingAgent that uses vllm rollout for training.
+
+    This agent combines the original ToolCallingAgent functionality with the
+    TrainableAgentMixin to support async interaction with vllm servers for
+    reinforcement learning training.
+    """
+
+    def __init__(
+        self,
+        tools_info: list[dict[str, Any]],
+        wiki: str,
+        model: str,
+        provider: str,
+        temperature: float = 0.0,
+        rollout_args: dict[str, Any] | None = None,
+        sampling_params: dict[str, Any] | None = None,
+    ):
+        # Initialize the parent ToolCallingAgent
+        super().__init__(
+            tools_info=tools_info,
+            wiki=wiki,
+            model=model,
+            provider=provider,
+            temperature=temperature,
+        )
+
+        # Store rollout and sampling parameters as instance variables
+        self.rollout_args = rollout_args or {
+            "vllm_router_ip": "127.0.0.1",
+            "vllm_router_port": 3250,
+        }
+        self.sampling_params = sampling_params or {
+            "temperature": self.temperature,
+            "max_new_tokens": 512,
+            "top_p": 0.9,
+            "top_k": 50,
+        }
+        # Initialize OpenAI adapter
+        self.openai_adapter = create_openai_adapter(tools_info=self.tools_info, parser_type="qwen25")
+
+
+def agent_factory(
+    tools_info: list[dict[str, Any]],
+    wiki,
+    config: RunConfig,
+    rollout_args: dict[str, Any] | None = None,
+    sampling_params: dict[str, Any] | None = None,
+) -> Agent:
+    if config.agent_strategy == "tool-calling":
+        return TrainableToolCallingAgent(
+            tools_info=tools_info,
+            wiki=wiki,
+            model=config.model,
+            provider=config.model_provider,
+            temperature=config.temperature,
+            rollout_args=rollout_args,
+            sampling_params=sampling_params,
+        )
+    else:
+        raise NotImplementedError(f"Unsupported agent strategy: {config.agent_strategy}")

--- a/examples/tau-bench/vllm_tool_parser.py
+++ b/examples/tau-bench/vllm_tool_parser.py
@@ -1,3 +1,5 @@
+"""Local tool-call parser for vLLM rollout."""
+
 import json
 import re
 from typing import Any
@@ -37,7 +39,7 @@ def _parse_qwen25_tools(response: str) -> dict[str, Any]:
 
     if matches:
         parts = tool_call_pattern.split(response)
-        normal_text = parts[0].strip() if parts else ""
+        normal_text = " ".join(parts[i].strip() for i in range(0, len(parts), 2) if parts[i].strip())
         calls = []
         for match in matches:
             match = match.strip()

--- a/examples/tau-bench/vllm_tool_parser.py
+++ b/examples/tau-bench/vllm_tool_parser.py
@@ -1,95 +1,31 @@
-"""Local tool-call parser for vLLM rollout."""
-
-import json
-import re
 from typing import Any
 
-
-def parse_tools(response: str, tools: list[dict[str, Any]], parser: str = "qwen25") -> dict[str, Any]:
-    if parser == "qwen25":
-        return _parse_qwen25_tools(response)
-    return _parse_qwen25_tools(response)
+from vllm.tool_parsers.hermes_tool_parser import Hermes2ProToolParser
 
 
-def _try_parse_json_tool_call(text: str) -> dict[str, Any] | None:
-    try:
-        parsed = json.loads(text)
-        if isinstance(parsed, dict) and "name" in parsed:
-            name = parsed.get("name", "")
-            parameters = parsed.get("arguments", parsed.get("parameters", {}))
-            if isinstance(parameters, str):
-                try:
-                    parameters = json.loads(parameters)
-                except json.JSONDecodeError:
-                    pass
-            return {"name": name, "parameters": parameters}
-    except (json.JSONDecodeError, TypeError):
-        pass
-    return None
+class _StubTokenizer:
+    """Hermes2ProToolParser requires a tokenizer at init but does not use it in extract_tool_calls."""
+
+    pass
 
 
-def _parse_qwen25_tools(response: str) -> dict[str, Any]:
-    call_open = chr(60) + "tool_call" + chr(62)
-    call_close = chr(60) + "/tool_call" + chr(62)
-    call_open_alt = chr(60) + "call" + chr(62)
-    call_close_alt = chr(60) + "/call" + chr(62)
-    pattern = r"(?:" + call_open + "|" + call_open_alt + r")\s*(.*?)\s*(?:" + call_close + "|" + call_close_alt + ")"
-    tool_call_pattern = re.compile(pattern, re.DOTALL)
-    matches = tool_call_pattern.findall(response)
+def parse_tools(response: str, tools: list[dict[str, Any]], parser: str = "qwen25"):
+    """
+    This function mimics the function call parser API from
+    https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/entrypoints/http_server.py#L952
+    But running locally, using vLLM's Hermes2ProToolParser (handles the same
+    <tool_call>...</tool_call> format used by Qwen2.5).
+    """
+    tool_parser = Hermes2ProToolParser(_StubTokenizer())
+    result = tool_parser.extract_tool_calls(response, None)
 
-    if matches:
-        parts = tool_call_pattern.split(response)
-        normal_text = " ".join(parts[i].strip() for i in range(0, len(parts), 2) if parts[i].strip())
-        calls = []
-        for match in matches:
-            match = match.strip()
-            parsed_call = _try_parse_json_tool_call(match)
-            if parsed_call:
-                calls.append(parsed_call)
-            else:
-                try:
-                    json_match = re.search(r"\{.*\}", match, re.DOTALL)
-                    if json_match:
-                        parsed_call = _try_parse_json_tool_call(json_match.group())
-                        if parsed_call:
-                            calls.append(parsed_call)
-                        else:
-                            calls.append({"name": match, "parameters": {}})
-                    else:
-                        calls.append({"name": match, "parameters": {}})
-                except (json.JSONDecodeError, AttributeError):
-                    calls.append({"name": match, "parameters": {}})
-
-        return {
-            "normal_text": normal_text,
-            "calls": calls,
-        }
-
-    cleaned = re.sub(r"<\|im_end\|>", "", response).strip()
-    parsed_call = _try_parse_json_tool_call(cleaned)
-    if parsed_call:
-        return {
-            "normal_text": "",
-            "calls": [parsed_call],
-        }
-
-    json_pattern = re.compile(r'\{[^{}]*"name"\s*:\s*"[^"]+?"[^{}]*\}', re.DOTALL)
-    json_matches = json_pattern.findall(response)
-    if json_matches:
-        calls = []
-        for jm in json_matches:
-            parsed_call = _try_parse_json_tool_call(jm)
-            if parsed_call:
-                calls.append(parsed_call)
-        if calls:
-            normal_text = json_pattern.sub("", response).strip()
-            normal_text = re.sub(r"<\|im_end\|>", "", normal_text).strip()
-            return {
-                "normal_text": normal_text,
-                "calls": calls,
-            }
+    normal_text = result.content or ""
+    calls = []
+    if result.tool_calls:
+        for tc in result.tool_calls:
+            calls.append({"name": tc.function.name, "parameters": tc.function.arguments})
 
     return {
-        "normal_text": response,
-        "calls": [],
+        "normal_text": normal_text,
+        "calls": calls,
     }


### PR DESCRIPTION
## Summary

Mechanical alignment of the tau-bench example with the upstream slime codebase. All changes fall into three categories:

**1. Renames** — `slime`→`vime`, `sglang`→`vllm` across all files (paths, imports, docstrings, CLI flags)

**2. sglang→vllm API translation** (`trainable_agents.py`):
- sglang `/generate` (text input) → vLLM `/inference/v1/generate` (token_ids input)
- Response: `output["text"]` → `tokenizer.decode(choice["token_ids"])`
- Finish reason: `output["meta_info"]["finish_reason"]["type"]` → `choice["finish_reason"]` (flat string)
- Sampling params: `_build_inference_sampling_params()` for vLLM format mapping
- Router: `sglang_router_ip/port` → `vllm_router_ip/port`

**3. Tool parser translation** (`vllm_tool_parser.py`):
- sglang `FunctionCallParser.parse_non_stream()` → vLLM `Hermes2ProToolParser.extract_tool_calls()`
- Same `<tool_call>` XML format (Qwen2.5), same `parse_tools()` interface

**Structural restoration** (to match slime):
- **Add `trainable_agents.py`** — the PR inlined everything into a 578-line `generate_with_tau.py`; slime keeps the agent class in a separate file
- **Simplify `generate_with_tau.py`** — back to slime's ~150-line delegation pattern
- **Restore `openai_tool_adapter.py` methods** — `_call_to_action_vllm`, `get_openai_tools_format` (removed by PR)
- **Remove `__init__.py`** — slime doesn't have it
- **Restore slime's hyperparameters** in `run_qwen3_4B.sh` (num-rollout 500, batch-size 32, lr 1e-6, etc.)
- **Remove fabricated CLI flags** — `--rollout-backend vllm` and `--vllm-weight-sync-mode native` don't exist in vime

## Test plan

- [ ] Verify `trainable_agents.py` imports resolve (`vime.rollout.vllm_rollout.GenerateState`, `_build_inference_sampling_params`)
- [ ] Verify `vllm_tool_parser.py` parses `<tool_call>` XML correctly via `Hermes2ProToolParser`
- [ ] Smoke-test `run_qwen3_4B.sh` flag validity (no unknown arguments)
- [ ] End-to-end tau-bench training run

🤖 Generated with [Claude Code](https://claude.com/claude-code)