### PR TITLE
docs: strip slime/sglang cross-reference comments (mirror-exactness cleanup)

### DIFF
--- a/docker/justfile
+++ b/docker/justfile
@@ -3,14 +3,14 @@
 # both the linux/amd64 and linux/arm64 digests and `docker pull` auto-selects
 # the platform. No arch suffix is ever published as a tag.
 #
-# CUDA 12.9 is the default, so it carries NO cu marker in the tag (like
-# slimerl/slime). Only the non-default cu13 variant is suffixed.
+# CUDA 12.9 is the default, so it carries NO cu marker in the tag. Only the
+# non-default cu13 variant is suffixed.
 #
 # The CUDA + source-built FA/TE images can't be cross-emulated, so each arch is
 # built on its own native host and pushed BY DIGEST (no tag lands in the hub),
 # then the two digests are fused into the final tag with `just manifest`.
 #
-# Tag scheme (mirrors slime's `nightly-dev-<date>` + `latest`):
+# Tag scheme:
 #   inferactinc/public:vime-<version>        immutable, multi-arch (cu12.9)
 #   inferactinc/public:vime-latest           rolling,   multi-arch (cu12.9)
 #   inferactinc/public:vime-cu13-<version>   immutable, multi-arch (cu13 variant)
@@ -63,7 +63,7 @@ manifest VARIANT AMD_DIGEST ARM_DIGEST:
     docker buildx imagetools create -t "{{IMAGE}}:vime${SUFFIX}-${VERSION}" -t "{{IMAGE}}:vime${SUFFIX}-latest" "{{IMAGE}}@{{AMD_DIGEST}}" "{{IMAGE}}@{{ARM_DIGEST}}"
 
 # ---- single-arch test/debug image for the run-ci-image validation job ----
-# slime-test analog; the e2e-test-image runner is x86, so this is amd64-only and
+# The e2e-test-image runner is x86, so this is amd64-only and
 # needs no manifest.
 build-test:
     #!/bin/bash

--- a/tests/test_qwen3_4B_streaming_partial_rollout.py
+++ b/tests/test_qwen3_4B_streaming_partial_rollout.py
@@ -10,10 +10,6 @@ cut, then the partial groups get recycled into the data buffer).
 Uses Qwen3-4B (vs the 0.5B in other short tests) so responses on dapo-math
 are long enough to actually trigger mid-stream aborts, and good enough to
 produce non-zero rewards.
-
-vime counterpart of slime's ``test_qwen3_4B_streaming_partial_rollout`` — the
-only structural change is the rollout engine: sglang args become vLLM args and
-the generate function points at ``vllm_streaming_rollout``.
 """
 
 import os

--- a/vime/agent/adapters/common.py
+++ b/vime/agent/adapters/common.py
@@ -174,7 +174,7 @@ def _sampling_params(session: Any, body: dict, *, max_token_keys: tuple[str, ...
 
 
 def _vllm_sampling_body(sp: dict) -> dict:
-    """Map the canonical (sglang-shaped) sampling dict to a vLLM ``/inference/v1/generate``
+    """Map the canonical sampling dict to a vLLM ``/inference/v1/generate``
     ``sampling_params`` body. vLLM uses ``max_tokens`` (not ``max_new_tokens``) and returns
     per-token logprobs when ``logprobs`` is set."""
     body: dict[str, Any] = {
@@ -270,9 +270,9 @@ async def call_vllm_generate(
         fr = choice.get("finish_reason")
         finish = fr if isinstance(fr, str) and fr else "stop"
     except (asyncio.CancelledError, aiohttp.ClientError, asyncio.TimeoutError):
-        # vLLM ``/inference/v1/generate`` has no per-request HTTP abort endpoint (unlike
-        # sglang ``/abort_request``). Cancelling the in-flight task tears down the aiohttp
-        # request, which drops the streaming connection so vLLM stops generating.
+        # vLLM ``/inference/v1/generate`` has no per-request HTTP abort endpoint.
+        # Cancelling the in-flight task tears down the aiohttp request, which drops
+        # the streaming connection so vLLM stops generating.
         if task is not None:
             task.cancel()
         raise

--- a/vime/rollout/vllm_streaming_rollout.py
+++ b/vime/rollout/vllm_streaming_rollout.py
@@ -17,15 +17,12 @@ The outer rollout loop (semaphore, dp_rank balancing, abort orchestration,
 partial-rollout buffer hand-off) is still owned by ``vllm_rollout``; this file
 only replaces the inner HTTP call.
 
-vime/vLLM counterpart of ``slime.rollout.sglang_streaming_rollout``. The
-behavioural difference from sglang matters here: sglang's streamed
-``meta_info.output_token_logprobs`` is **cumulative** (every chunk references
-the full list-so-far), whereas vLLM's ``/inference/v1/generate`` SSE chunks
-carry **delta** ``token_ids`` + ``logprobs`` per
-``GenerateResponseStreamChoice`` — so we *accumulate* the per-chunk deltas
-(``+=``) rather than overwriting from each chunk. Each delta choice has the
-same ``token_ids`` / ``logprobs.content`` shape as the non-streaming choice, so
-we parse it inline exactly like :func:`vime.rollout.vllm_rollout.generate`.
+vLLM's ``/inference/v1/generate`` SSE chunks carry **delta** ``token_ids`` +
+``logprobs`` per ``GenerateResponseStreamChoice`` — so we *accumulate* the
+per-chunk deltas (``+=``) rather than overwriting from each chunk. Each delta
+choice has the same ``token_ids`` / ``logprobs.content`` shape as the
+non-streaming choice, so we parse it inline exactly like
+:func:`vime.rollout.vllm_rollout.generate`.
 """
 
 import base64


### PR DESCRIPTION
## What

Remove translation-provenance and cross-engine-comparison clauses that reference the upstream slime/sglang code from in-tree comments and docstrings. These meta-comments don't exist in upstream slime, so dropping them restores byte-for-byte mirror-exactness (tracked under #107). **No behavior change** — comments/docstrings only.

All genuine technical content is preserved:
- the vLLM delta-accumulation explanation (why we `+=` per-chunk),
- the no-per-request-abort-endpoint behavior,
- the docker tag scheme,
- the streaming partial-rollout test rationale.

## Changes

| File | Removed |
|------|---------|
| `docker/justfile` | `(like slimerl/slime)`, `(mirrors slime's ...)`, `slime-test analog` framing |
| `tests/test_qwen3_4B_streaming_partial_rollout.py` | trailing `vime counterpart of slime's ...` docstring paragraph |
| `vime/rollout/vllm_streaming_rollout.py` | the sglang cumulative-vs-delta comparison (kept the vLLM delta explanation) |
| `vime/agent/adapters/common.py` | `(sglang-shaped)` and `(unlike sglang /abort_request)` clauses |

```
 docker/justfile                                  |  8 ++++----
 tests/test_qwen3_4B_streaming_partial_rollout.py |  4 ----
 vime/agent/adapters/common.py                    |  8 ++++----
 vime/rollout/vllm_streaming_rollout.py           | 15 ++++++---------
 4 files changed, 14 insertions(+), 21 deletions(-)
```