### PR TITLE
[release] bump to v0.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ class bdist_wheel(_bdist_wheel):
 setup(
     author="vime Team",
     name="vime",
-    version="0.2.4",
+    version="0.3.0",
     packages=find_packages(include=["vime*", "vime_plugins*"]),
     include_package_data=True,
     install_requires=_fetch_requirements("requirements.txt"),


### PR DESCRIPTION
## Summary
- Sync slime #1975: bump `setup.py` version from `0.2.4` to `0.3.0`
- Other changes in slime #1975 (data.py assert bounds, parallel_check simplification, CI matrix update) were already synced in prior PRs
- Conda/sglang-patch files (`conda-ci.yml`, `build_conda.sh`, `docker/patch/v0.5.12.post1/`) are slime-specific and skipped per translation rules

## Changes
- `setup.py`: `version="0.2.4"` → `version="0.3.0"`

## After merge
- Delete the stale upstream tag `v0.3.0` (points to slime commit `bf14dc21`, not on vime main)
- Create annotated tag `v0.3.0` on the merged commit
- Push the new tag