### PR TITLE
sync: port slime #1963/#1985/#1986 test & skill gaps (#107 follow-up)

### DIFF
--- a/.claude/skills/add-tests-and-ci/SKILL.md
+++ b/.claude/skills/add-tests-and-ci/SKILL.md
@@ -26,7 +26,19 @@ Use this skill when:
 
 ### Step 2: Keep CI Compatibility
 
-When creating CI-discoverable tests, ensure top-level constants and conventions match repository patterns (including `NUM_GPUS = <N>` where expected).
+- CI executes registered test files with `python tests/<file>.py`, not only pytest discovery. New CPU pytest files should include:
+
+```python
+import pytest
+
+NUM_GPUS = 0
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))
+```
+
+- `run-ci-changed` extracts a top-level `NUM_GPUS = <N>` constant from added/modified `tests/test_*.py` and `tests/plugin_contracts/test_*.py`; if missing, it defaults to 8 GPUs. Set `NUM_GPUS = 0` for CPU-only tests.
+- For GPU/e2e tests, follow the nearby file pattern (`prepare()`, `execute()`, `NUM_GPUS`, and any model/dataset constants).
 
 ### Step 3: Run Local Validation
 
@@ -45,7 +57,7 @@ For CI workflow changes:
 python .github/workflows/generate_github_workflows.py
 ```
 
-3. Commit both template and generated workflow files
+3. Include both the template and generated workflow file in the change set (`.j2` and `.yml`). If the user asked for a commit, commit both.
 
 ### Step 5: Provide Verifiable PR Notes
 
@@ -59,6 +71,8 @@ Include:
 ## Common Mistakes
 
 - Editing generated workflow file only
+- Forgetting `NUM_GPUS = 0` on a CPU-only changed test, causing `run-ci-changed` to default to 8 GPUs
+- Adding a CPU pytest file that passes under `pytest tests/foo.py` but fails under CI's `python tests/foo.py`
 - Adding tests without following existing constants/conventions
 - Making tests too large or non-deterministic
 - Skipping local validation and relying only on remote CI

--- a/tests/test_cp_utils.py
+++ b/tests/test_cp_utils.py
@@ -29,6 +29,9 @@ from vime.backends.megatron_utils.cp_utils import (  # noqa: E402
 )
 
 
+NUM_GPUS = 0
+
+
 def _make_inputs(per_sample_lengths: list[int]):
     """Build (total_lengths, response_lengths, loss_masks) for samples of the given lengths.
 

--- a/tests/test_dp_schedule.py
+++ b/tests/test_dp_schedule.py
@@ -11,6 +11,9 @@ import pytest
 from vime.utils.dp_schedule import build_dp_schedule
 
 
+NUM_GPUS = 0
+
+
 def make_args(
     *,
     micro_batch_size=1,

--- a/tests/test_loss_cp_invariance.py
+++ b/tests/test_loss_cp_invariance.py
@@ -73,6 +73,9 @@ from _cp_dist_helpers import (
 )
 
 
+NUM_GPUS = 0
+
+
 def _grad_norm_worker(
     rank: int,
     world_size: int,

--- a/tests/test_megatron_argument_validation.py
+++ b/tests/test_megatron_argument_validation.py
@@ -6,6 +6,9 @@ from pathlib import Path
 import pytest
 
 
+NUM_GPUS = 0
+
+
 def load_arguments_module(monkeypatch):
     megatron_mod = types.ModuleType("megatron")
     training_mod = types.ModuleType("megatron.training")

--- a/tests/test_metric_report.py
+++ b/tests/test_metric_report.py
@@ -34,6 +34,9 @@ from vime.backends.megatron_utils.cp_utils import (  # noqa: E402
 
 
 @pytest.fixture
+NUM_GPUS = 0
+
+
 def mock_dp_with_cp_group(monkeypatch):
     """A sentinel "process group" object plus a no-op ``dist.all_reduce``.
 

--- a/tests/test_metric_report_dist.py
+++ b/tests/test_metric_report_dist.py
@@ -43,6 +43,9 @@ from _cp_dist_helpers import (
 )
 
 
+NUM_GPUS = 0
+
+
 def _train_step_distributed_worker(
     rank: int,
     world_size: int,

--- a/tests/test_moonlight_16B_A3B.py
+++ b/tests/test_moonlight_16B_A3B.py
@@ -30,12 +30,12 @@ def execute():
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type math "
-        "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 4096 "
         "--rollout-temperature 1 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
     )
 
     eval_args = (
@@ -83,7 +83,7 @@ def execute():
         "--rollout-num-gpus-per-engine 2 "
         "--vllm-gpu-memory-utilization 0.8 "
         "--vllm-max-num-seqs 512 "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-max-cudagraph-capture-size 16 "
     )
 
     ci_args = "--ci-test "

--- a/tests/test_moonlight_16B_A3B_r3.py
+++ b/tests/test_moonlight_16B_A3B_r3.py
@@ -30,12 +30,12 @@ def execute():
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type math "
-        "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 4096 "
         "--rollout-temperature 1 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
     )
 
     eval_args = (
@@ -84,7 +84,7 @@ def execute():
         "--rollout-num-gpus-per-engine 2 "
         "--vllm-gpu-memory-utilization 0.8 "
         "--vllm-max-num-seqs 512 "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-max-cudagraph-capture-size 16 "
     )
 
     ci_args = "--ci-test "

--- a/tests/test_quick_start_glm4_9B.py
+++ b/tests/test_quick_start_glm4_9B.py
@@ -2,7 +2,6 @@ import os
 import vime.utils.external_utils.command_utils as U
 
 ENABLE_EVAL = U.get_bool_env_var("VIME_TEST_ENABLE_EVAL", "1")
-TIGHT_DEVICE_MEMORY = U.get_bool_env_var("VIME_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "GLM-Z1-9B-0414"
 MODEL_TYPE = "glm4-9B"
@@ -28,12 +27,12 @@ def execute():
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type deepscaler "
-        "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 8192 "
         "--rollout-temperature 1 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
         "--balance-data "
     )
 
@@ -56,7 +55,7 @@ def execute():
         "--recompute-method uniform "
         "--recompute-num-layers 1 "
         "--use-dynamic-batch-size "
-        f"--max-tokens-per-gpu {2048 if TIGHT_DEVICE_MEMORY else 4608} "
+        "--max-tokens-per-gpu 4608 "
     )
 
     grpo_args = (
@@ -80,7 +79,7 @@ def execute():
         "--adam-beta2 0.98 "
     )
 
-    vllm_args = "--rollout-num-gpus-per-engine 2 " "--vllm-max-cudagraph-capture-size 32 "
+    vllm_args = "--rollout-num-gpus-per-engine 2 " "--vllm-max-cudagraph-capture-size 16 "
 
     ci_args = "--ci-test "
 

--- a/tests/test_qwen2.5_0.5B_async_short.py
+++ b/tests/test_qwen2.5_0.5B_async_short.py
@@ -1,7 +1,6 @@
 import os
 import vime.utils.external_utils.command_utils as U
 
-TIGHT_DEVICE_MEMORY = U.get_bool_env_var("VIME_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
@@ -25,11 +24,11 @@ def execute():
         "--rollout-shuffle "
         "--rm-type deepscaler "
         "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 8192 "
         "--rollout-temperature 0.8 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
         "--balance-data "
     )
 
@@ -65,8 +64,8 @@ def execute():
 
     vllm_args = (
         "--rollout-num-gpus-per-engine 1 "
-        f"--vllm-gpu-memory-utilization {0.55 if TIGHT_DEVICE_MEMORY else 0.65} "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-gpu-memory-utilization 0.65 "
+        "--vllm-max-cudagraph-capture-size 16 "
     )
 
     ci_args = "--ci-test "

--- a/tests/test_qwen2.5_0.5B_debug_rollout_then_train.py
+++ b/tests/test_qwen2.5_0.5B_debug_rollout_then_train.py
@@ -13,7 +13,6 @@ import tempfile
 
 import vime.utils.external_utils.command_utils as U
 
-TIGHT_DEVICE_MEMORY = U.get_bool_env_var("VIME_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
@@ -40,11 +39,11 @@ def _common_args(debug_data_dir: str):
         "--rollout-shuffle "
         "--rm-type math "
         f"--num-rollout {NUM_ROLLOUT} "
-        "--rollout-batch-size 8 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 256 "
         "--rollout-temperature 0.8 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
     )
 
     perf_args = (
@@ -89,8 +88,8 @@ def execute_rollout_only(debug_data_dir: str):
 
     vllm_args = (
         "--rollout-num-gpus-per-engine 1 "
-        f"--vllm-gpu-memory-utilization {0.6 if TIGHT_DEVICE_MEMORY else 0.7} "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-gpu-memory-utilization 0.7 "
+        "--vllm-max-cudagraph-capture-size 16 "
     )
 
     phase1_args = (

--- a/tests/test_qwen2.5_0.5B_fanout_short.py
+++ b/tests/test_qwen2.5_0.5B_fanout_short.py
@@ -44,7 +44,6 @@ import tempfile
 
 import vime.utils.external_utils.command_utils as U
 
-TIGHT_DEVICE_MEMORY = U.get_bool_env_var("VIME_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
@@ -94,8 +93,8 @@ def execute():
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type deepscaler "
-        "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 1 "
         "--rollout-max-response-len 8192 "
         "--rollout-temperature 0.8 "
@@ -146,8 +145,8 @@ def execute():
 
     vllm_args = (
         "--rollout-num-gpus-per-engine 1 "
-        f"--vllm-gpu-memory-utilization {0.6 if TIGHT_DEVICE_MEMORY else 0.7} "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-gpu-memory-utilization 0.7 "
+        "--vllm-max-cudagraph-capture-size 8 "
     )
 
     ci_args = "--ci-test "

--- a/tests/test_qwen2.5_0.5B_fully_async_short.py
+++ b/tests/test_qwen2.5_0.5B_fully_async_short.py
@@ -12,7 +12,6 @@ existing 0.5B short tests.
 import os
 import vime.utils.external_utils.command_utils as U
 
-TIGHT_DEVICE_MEMORY = U.get_bool_env_var("VIME_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
@@ -38,12 +37,12 @@ def execute():
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type deepscaler "
-        "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 8192 "
         "--rollout-temperature 0.8 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
         "--balance-data "
     )
 
@@ -79,8 +78,8 @@ def execute():
 
     vllm_args = (
         "--rollout-num-gpus-per-engine 1 "
-        f"--vllm-gpu-memory-utilization {0.55 if TIGHT_DEVICE_MEMORY else 0.65} "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-gpu-memory-utilization 0.65 "
+        "--vllm-max-cudagraph-capture-size 16 "
     )
 
     ci_args = "--ci-test "

--- a/tests/test_qwen2.5_0.5B_opd_vllm.py
+++ b/tests/test_qwen2.5_0.5B_opd_vllm.py
@@ -5,7 +5,6 @@ import urllib.request
 
 import vime.utils.external_utils.command_utils as U
 
-TIGHT_DEVICE_MEMORY = U.get_bool_env_var("VIME_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
@@ -101,11 +100,11 @@ def execute():
             "--rollout-shuffle "
             "--rm-type math "
             "--num-rollout 2 "
-            "--rollout-batch-size 8 "
+            "--rollout-batch-size 4 "
             "--n-samples-per-prompt 4 "
             "--rollout-max-response-len 1024 "
             "--rollout-temperature 0.8 "
-            "--global-batch-size 32 "
+            "--global-batch-size 16 "
         )
 
         eval_args = (
@@ -157,9 +156,9 @@ def execute():
 
         vllm_args = (
             "--rollout-num-gpus-per-engine 1 "
-            f"--vllm-gpu-memory-utilization {0.6 if TIGHT_DEVICE_MEMORY else 0.7} "
+            "--vllm-gpu-memory-utilization 0.7 "
             "--vllm-max-num-seqs 32 "
-            "--vllm-max-cudagraph-capture-size 32 "
+            "--vllm-max-cudagraph-capture-size 16 "
         )
 
         ci_args = "--ci-test "

--- a/tests/test_qwen2.5_0.5B_ppo_critic_only_short.py
+++ b/tests/test_qwen2.5_0.5B_ppo_critic_only_short.py
@@ -3,7 +3,6 @@ import tempfile
 
 import vime.utils.external_utils.command_utils as U
 
-TIGHT_DEVICE_MEMORY = U.get_bool_env_var("VIME_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
@@ -42,12 +41,12 @@ megatron:
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type deepscaler "
-        "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 1024 "
         "--rollout-temperature 0.8 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
         "--balance-data "
     )
 
@@ -85,7 +84,7 @@ megatron:
     vllm_args = (
         "--rollout-num-gpus-per-engine 1 "
         "--rollout-num-gpus 2 "
-        f"--vllm-gpu-memory-utilization {0.55 if TIGHT_DEVICE_MEMORY else 0.65} "
+        "--vllm-gpu-memory-utilization 0.65 "
         "--vllm-max-cudagraph-capture-size 64"
     )
 

--- a/tests/test_qwen2.5_0.5B_short.py
+++ b/tests/test_qwen2.5_0.5B_short.py
@@ -1,7 +1,6 @@
 import os
 import vime.utils.external_utils.command_utils as U
 
-TIGHT_DEVICE_MEMORY = U.get_bool_env_var("VIME_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
@@ -25,11 +24,11 @@ def execute():
         "--rollout-shuffle "
         "--rm-type deepscaler "
         "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 8192 "
         "--rollout-temperature 0.8 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
         "--balance-data "
     )
 
@@ -65,8 +64,8 @@ def execute():
 
     vllm_args = (
         "--rollout-num-gpus-per-engine 1 "
-        f"--vllm-gpu-memory-utilization {0.6 if TIGHT_DEVICE_MEMORY else 0.7} "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-gpu-memory-utilization 0.7 "
+        "--vllm-max-cudagraph-capture-size 16 "
     )
 
     ci_args = "--ci-test "

--- a/tests/test_qwen2.5_0.5B_vllm_config.py
+++ b/tests/test_qwen2.5_0.5B_vllm_config.py
@@ -3,7 +3,6 @@ import tempfile
 
 import vime.utils.external_utils.command_utils as U
 
-TIGHT_DEVICE_MEMORY = U.get_bool_env_var("VIME_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
@@ -50,14 +49,14 @@ def execute():
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type math "
-        "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 1024 "
         "--rollout-temperature 0.8 "
         "--over-sampling-batch-size 16 "
         "--dynamic-sampling-filter-path vime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
     )
 
     eval_args = (
@@ -100,9 +99,9 @@ def execute():
 
     vllm_args = (
         "--rollout-num-gpus-per-engine 1 "
-        f"--vllm-gpu-memory-utilization {0.6 if TIGHT_DEVICE_MEMORY else 0.7} "
+        "--vllm-gpu-memory-utilization 0.7 "
         "--vllm-max-num-seqs 32 "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-max-cudagraph-capture-size 16 "
         f"--vllm-config {config_path} "
     )
 

--- a/tests/test_qwen2.5_0.5B_vllm_config_distributed.py
+++ b/tests/test_qwen2.5_0.5B_vllm_config_distributed.py
@@ -3,7 +3,6 @@ import tempfile
 
 import vime.utils.external_utils.command_utils as U
 
-TIGHT_DEVICE_MEMORY = U.get_bool_env_var("VIME_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
@@ -51,14 +50,14 @@ def execute():
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type math "
-        "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 1024 "
         "--rollout-temperature 0.8 "
         "--over-sampling-batch-size 16 "
         "--dynamic-sampling-filter-path vime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
     )
 
     eval_args = (
@@ -101,9 +100,9 @@ def execute():
 
     vllm_args = (
         "--rollout-num-gpus-per-engine 1 "
-        f"--vllm-gpu-memory-utilization {0.6 if TIGHT_DEVICE_MEMORY else 0.7} "
+        "--vllm-gpu-memory-utilization 0.7 "
         "--vllm-max-num-seqs 32 "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-max-cudagraph-capture-size 16 "
         f"--vllm-config {config_path} "
     )
 

--- a/tests/test_qwen3.5_0.8B_gsm8k_async_short.py
+++ b/tests/test_qwen3.5_0.8B_gsm8k_async_short.py
@@ -3,7 +3,6 @@ import os
 import vime.utils.external_utils.command_utils as U
 
 
-TIGHT_DEVICE_MEMORY = U.get_bool_env_var("VIME_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "Qwen3.5-0.8B"
 MODEL_TYPE = "qwen3.5-0.8B"
@@ -34,13 +33,13 @@ def execute():
         "--rollout-shuffle "
         "--rm-type math "
         "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 1024 "
         "--rollout-temperature 0.8 "
         "--over-sampling-batch-size 16 "
         "--dynamic-sampling-filter-path vime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
     )
 
     eval_args = (
@@ -83,7 +82,7 @@ def execute():
 
     vllm_args = (
         "--rollout-num-gpus-per-engine 1 "
-        f"--vllm-gpu-memory-utilization {0.55 if TIGHT_DEVICE_MEMORY else 0.65} "
+        "--vllm-gpu-memory-utilization 0.65 "
         "--vllm-max-cudagraph-capture-size 64"
     )
 

--- a/tests/test_qwen3.5_0.8B_gsm8k_short.py
+++ b/tests/test_qwen3.5_0.8B_gsm8k_short.py
@@ -3,7 +3,6 @@ import os
 import vime.utils.external_utils.command_utils as U
 
 
-TIGHT_DEVICE_MEMORY = U.get_bool_env_var("VIME_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "Qwen3.5-0.8B"
 MODEL_TYPE = "qwen3.5-0.8B"
@@ -34,13 +33,13 @@ def execute():
         "--rollout-shuffle "
         "--rm-type math "
         "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 1024 "
         "--rollout-temperature 0.8 "
         "--over-sampling-batch-size 16 "
         "--dynamic-sampling-filter-path vime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
     )
 
     eval_args = (
@@ -83,7 +82,7 @@ def execute():
 
     vllm_args = (
         "--rollout-num-gpus-per-engine 1 "
-        f"--vllm-gpu-memory-utilization {0.6 if TIGHT_DEVICE_MEMORY else 0.7} "
+        "--vllm-gpu-memory-utilization 0.7 "
         "--vllm-max-cudagraph-capture-size 64"
     )
 

--- a/tests/test_qwen3.6_35B_A3B_pd_mooncake.py
+++ b/tests/test_qwen3.6_35B_A3B_pd_mooncake.py
@@ -43,11 +43,11 @@ def execute():
         "--rollout-shuffle "
         "--rm-type deepscaler "
         "--num-rollout 2 "
-        "--rollout-batch-size 8 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 16384 "
         "--rollout-temperature 1.0 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
     )
 
     eval_args = (

--- a/tests/test_qwen3_0.6B_parallel_check.py
+++ b/tests/test_qwen3_0.6B_parallel_check.py
@@ -36,7 +36,7 @@ def execute():
         "--n-samples-per-prompt 8 "
         "--rollout-max-response-len 8192 "
         "--rollout-temperature 0.8 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
     )
 
     ppo_args = (
@@ -61,7 +61,7 @@ def execute():
         "--rollout-num-gpus-per-engine 2 "
         "--rollout-num-gpus 8 "
         "--vllm-gpu-memory-utilization 0.8 "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-max-cudagraph-capture-size 16 "
     )
 
     ci_args = "--ci-test "

--- a/tests/test_qwen3_30B_A3B.py
+++ b/tests/test_qwen3_30B_A3B.py
@@ -36,12 +36,12 @@ def execute():
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type deepscaler "
-        "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 8192 "
         "--rollout-temperature 1 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
         "--balance-data "
     )
 
@@ -95,7 +95,7 @@ def execute():
         "--rollout-num-gpus-per-engine 8 "
         "--vllm-gpu-memory-utilization 0.8 "
         "--vllm-max-num-seqs 512 "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-max-cudagraph-capture-size 16 "
     )
 
     if USE_DEEPEP:

--- a/tests/test_qwen3_30B_A3B_r3.py
+++ b/tests/test_qwen3_30B_A3B_r3.py
@@ -36,12 +36,12 @@ def execute():
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type deepscaler "
-        "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 8192 "
         "--rollout-temperature 1 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
         "--balance-data "
     )
 
@@ -95,7 +95,7 @@ def execute():
         "--rollout-num-gpus-per-engine 8 "
         "--vllm-gpu-memory-utilization 0.8 "
         "--vllm-max-num-seqs 512 "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-max-cudagraph-capture-size 16 "
     )
 
     if USE_DEEPEP:

--- a/tests/test_qwen3_4B_ckpt.py
+++ b/tests/test_qwen3_4B_ckpt.py
@@ -49,12 +49,12 @@ def execute(mode: str = ""):
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type deepscaler "
-        "--num-rollout 3 "
+        "--num-rollout 2 "
         "--rollout-batch-size 4 "
         "--n-samples-per-prompt 8 "
         "--rollout-max-response-len 1024 "
         "--rollout-temperature 0.8 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
         "--balance-data "
     )
 
@@ -100,7 +100,7 @@ def execute(mode: str = ""):
     )
 
     vllm_args = (
-        "--rollout-num-gpus-per-engine 2 --vllm-gpu-memory-utilization 0.8 --vllm-max-cudagraph-capture-size 32 "
+        "--rollout-num-gpus-per-engine 2 --vllm-gpu-memory-utilization 0.8 --vllm-max-cudagraph-capture-size 16 "
     )
 
     ci_args = "--ci-test "

--- a/tests/test_qwen3_4B_ppo.py
+++ b/tests/test_qwen3_4B_ppo.py
@@ -47,12 +47,12 @@ megatron:
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type deepscaler "
-        "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 8192 "
         "--rollout-temperature 0.8 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
         "--balance-data "
     )
 
@@ -102,7 +102,7 @@ megatron:
         "--rollout-num-gpus 8 "
         "--vllm-gpu-memory-utilization 0.8 "
         "--vllm-max-num-seqs 512 "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-max-cudagraph-capture-size 16 "
     )
 
     ci_args = "--ci-test "

--- a/tests/test_qwen3_4B_ppo_disaggregate.py
+++ b/tests/test_qwen3_4B_ppo_disaggregate.py
@@ -47,12 +47,12 @@ megatron:
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type deepscaler "
-        "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 8192 "
         "--rollout-temperature 0.8 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
         "--balance-data "
     )
 
@@ -102,7 +102,7 @@ megatron:
         "--rollout-num-gpus 4 "
         "--vllm-gpu-memory-utilization 0.8 "
         "--vllm-max-num-seqs 512 "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-max-cudagraph-capture-size 16 "
     )
 
     ci_args = "--ci-test "

--- a/tests/test_qwen3_4B_ppo_train_critic_only.py
+++ b/tests/test_qwen3_4B_ppo_train_critic_only.py
@@ -47,12 +47,12 @@ megatron:
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type deepscaler "
-        "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 8 "
         "--rollout-max-response-len 8192 "
         "--rollout-temperature 0.8 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
         "--balance-data "
     )
 

--- a/tests/test_qwen3_4B_streaming_partial_rollout.py
+++ b/tests/test_qwen3_4B_streaming_partial_rollout.py
@@ -96,7 +96,7 @@ def execute():
         "--rollout-num-gpus 8 "
         "--vllm-gpu-memory-utilization 0.8 "
         "--vllm-max-num-seqs 512 "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-max-cudagraph-capture-size 16 "
     )
 
     ci_args = "--ci-test "

--- a/tests/test_rm_deepscaler.py
+++ b/tests/test_rm_deepscaler.py
@@ -16,6 +16,9 @@ from vime.rollout.rm_hub.deepscaler import get_deepscaler_rule_based_reward
 
 
 @pytest.mark.unit
+NUM_GPUS = 0
+
+
 def test_response_split_on_think_marker_grades_tail():
     """The default chat format puts the answer after ``</think>``. Only
     the tail is graded — pre-think reasoning is ignored, even if it

--- a/tests/test_rm_f1.py
+++ b/tests/test_rm_f1.py
@@ -35,6 +35,9 @@ from vime.rollout.rm_hub.f1 import f1_score, normalize_answer
         ("the", ""),  # all-article input collapses to empty
     ],
 )
+NUM_GPUS = 0
+
+
 def test_normalize_answer(raw, expected):
     assert normalize_answer(raw) == expected
 

--- a/tests/test_rm_gpqa.py
+++ b/tests/test_rm_gpqa.py
@@ -49,6 +49,9 @@ from vime.rollout.rm_hub.gpqa import DEFAULT_VALID_LETTERS, _extract_letter_from
         ("we ruled out A, then B, settled on C", "C"),
     ],
 )
+NUM_GPUS = 0
+
+
 def test_extract_letter_named_patterns_and_fallback(response, expected):
     assert _extract_letter_from_response(response, DEFAULT_VALID_LETTERS) == expected
 

--- a/tests/test_rm_math.py
+++ b/tests/test_rm_math.py
@@ -37,6 +37,9 @@ from vime.rollout.rm_hub.math_utils import (
 
 
 @pytest.mark.unit
+NUM_GPUS = 0
+
+
 def test_last_boxed_returns_last_when_multiple():
     """When two boxed expressions exist, ``rfind`` picks the last one."""
     s = r"first attempt \boxed{wrong}, final \boxed{42}"

--- a/tests/test_rm_math_dapo.py
+++ b/tests/test_rm_math_dapo.py
@@ -35,6 +35,9 @@ from vime.rollout.rm_hub.math_dapo_utils import (
 
 
 @pytest.mark.unit
+NUM_GPUS = 0
+
+
 def test_last_boxed_picks_rightmost():
     assert last_boxed_only_string(r"\boxed{first}, then \boxed{42}") == r"\boxed{42}"
 

--- a/tests/test_rollout_validation.py
+++ b/tests/test_rollout_validation.py
@@ -4,6 +4,9 @@ from vime.ray.rollout_validation import validate_server_group_gpu_indices
 
 
 @pytest.mark.unit
+NUM_GPUS = 0
+
+
 def test_validate_server_group_gpu_indices_accepts_valid_config():
     validate_server_group_gpu_indices(
         worker_type="regular",

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -29,6 +29,9 @@ from vime.utils.types import Sample
 # ---------------------------------------------------------------------------
 
 
+NUM_GPUS = 0
+
+
 def _make_sample(**overrides) -> Sample:
     """Build a Sample with one non-default value per field-category so the
     round-trip test exercises every code path in to_dict/from_dict, not

--- a/tests/test_vllm_config_mixed_offload.py
+++ b/tests/test_vllm_config_mixed_offload.py
@@ -18,7 +18,6 @@ import tempfile
 
 import vime.utils.external_utils.command_utils as U
 
-TIGHT_DEVICE_MEMORY = U.get_bool_env_var("VIME_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
@@ -63,12 +62,12 @@ def execute():
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type math "
-        "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 512 "
         "--rollout-temperature 0.8 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
     )
 
     eval_args = (
@@ -110,9 +109,9 @@ def execute():
 
     vllm_args = (
         "--rollout-num-gpus-per-engine 1 "
-        f"--vllm-gpu-memory-utilization {0.6 if TIGHT_DEVICE_MEMORY else 0.7} "
+        "--vllm-gpu-memory-utilization 0.7 "
         "--vllm-max-num-seqs 32 "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-max-cudagraph-capture-size 16 "
         f"--vllm-config {config_path} "
     )
 

--- a/tests/test_vllm_config_mixed_offload_ft.py
+++ b/tests/test_vllm_config_mixed_offload_ft.py
@@ -15,7 +15,6 @@ import tempfile
 
 import vime.utils.external_utils.command_utils as U
 
-TIGHT_DEVICE_MEMORY = U.get_bool_env_var("VIME_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
@@ -61,11 +60,11 @@ def execute():
         "--rollout-shuffle "
         "--rm-type math "
         "--num-rollout 3 "
-        "--rollout-batch-size 8 "
+        "--rollout-batch-size 4 "
         "--n-samples-per-prompt 4 "
         "--rollout-max-response-len 512 "
         "--rollout-temperature 0.8 "
-        "--global-batch-size 32 "
+        "--global-batch-size 16 "
     )
 
     eval_args = (
@@ -107,9 +106,9 @@ def execute():
 
     vllm_args = (
         "--rollout-num-gpus-per-engine 1 "
-        f"--vllm-gpu-memory-utilization {0.6 if TIGHT_DEVICE_MEMORY else 0.7} "
+        "--vllm-gpu-memory-utilization 0.7 "
         "--vllm-max-num-seqs 32 "
-        "--vllm-max-cudagraph-capture-size 32 "
+        "--vllm-max-cudagraph-capture-size 16 "
         f"--vllm-config {config_path} "
     )
 


### PR DESCRIPTION
## Summary

- **slime #1963** — `.claude/skills/add-tests-and-ci/SKILL.md` was dropped by rename PR #42; restores `NUM_GPUS` / pytest `__main__` guard documentation + 2 Common Mistakes entries (main trajectory.py code was already synced in #148)
- **slime #1985** — shrinks e2e test batch sizes across 26 test files (`rollout-batch-size 8→4`, `global-batch-size 32→16`, `num-rollout 3→2`, `cudagraph-capture-size 32→16`) and removes `TIGHT_DEVICE_MEMORY` env-var workaround
- **slime #1986** (test portion) — adds `NUM_GPUS = 0` to 13 CPU-only pytest files so `run-ci-changed` classifies them as zero-GPU

CI workflow template changes from #1985 are deferred (vime CI matrix has independent structure).

Ref: #107

## Test plan

- [ ] Verify `run-ci-changed` picks up `NUM_GPUS = 0` for CPU-only test files
- [ ] Spot-check batch-size values match slime@44d29ee post-#1985
- [ ] SKILL.md content matches slime #1963

🤖 Generated with [Claude Code](https://claude.com/claude-code)