### PR TITLE
fix: restore dropped comments + formatting from rename PRs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ line_length = 119
 
 [tool.ruff]
 line-length = 320  # TODO
+
+[tool.ruff.lint]
 select = [
     "E",      # Pycodestyle Errors (Structural/Fundamental Errors like bad indentation)
     "F",      # Pyflakes (Core Errors: Unused imports, undefined names)

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -10,7 +10,7 @@ Pins two contracts that the rollout / training boundary depends on:
 
   2. ``update_from_meta_info`` finish_reason → Status enum mapping
      (length→TRUNCATED, abort→ABORTED, stop→COMPLETED). The match
-     statement at types.py:176-182 is the only place the engine's
+     statement at types.py:176-182 is the only place vLLM's
      finish_reason gets translated; a typo'd enum or removed case here
      would silently mis-tag every sample.
 """

--- a/vime/backends/megatron_utils/model.py
+++ b/vime/backends/megatron_utils/model.py
@@ -583,7 +583,8 @@ def train_one_step(
         # Update parameters.
         update_successful, grad_norm, num_zeros_in_grad = optimizer.step()
 
-        # Update learning rate.
+        # Update learning rate. Use the per-step global_batch_size when dynamic
+        # batching is on so the scheduler's samples-seen counter tracks reality.
         assert update_successful
         opt_param_scheduler.step(increment=step_global_batch_size)
 
@@ -843,7 +844,10 @@ def train(
 
 
 def save(
-    iteration: int, model: Sequence[DDP], optimizer: MegatronOptimizer, opt_param_scheduler: OptimizerParamScheduler
+    iteration: int,
+    model: Sequence[DDP],
+    optimizer: MegatronOptimizer,
+    opt_param_scheduler: OptimizerParamScheduler,
 ) -> None:
     """Persist a training checkpoint safely with forward hooks disabled.
 

--- a/vime/backends/vllm_utils/vllm_config.py
+++ b/vime/backends/vllm_utils/vllm_config.py
@@ -114,7 +114,7 @@ class ModelConfig:
 
 @dataclasses.dataclass
 class VllmConfig:
-    """Configuration for vLLM rollout engine deployment.
+    """Configuration for vLLM engine deployment.
 
     Loaded from ``--vllm-config`` YAML file.
 

--- a/vime/utils/logging_utils.py
+++ b/vime/utils/logging_utils.py
@@ -8,6 +8,7 @@ from .tensorboard_utils import _TensorboardAdapter
 _LOGGER_CONFIGURED = False
 
 
+# ref: SGLang
 def configure_logger(prefix: str = ""):
     global _LOGGER_CONFIGURED
     if _LOGGER_CONFIGURED:

--- a/vime/utils/types.py
+++ b/vime/utils/types.py
@@ -53,7 +53,7 @@ class Sample:
     # metadata used during training, e.g., what loss to use for this sample.
     train_metadata: dict | None = None
 
-    # Session ID for consistent_hash routing (used when --router-policy consistent_hash)
+    # Session ID for consistent hashing routing (used when router policy is consistent_hashing)
     session_id: str | None = None
 
     non_generation_time: float = 0.0  # time spent in non-generation steps
@@ -164,7 +164,7 @@ class Sample:
         And extract
         """
         if args.vllm_speculative_config:
-            # cannot directly use spec info from rollout engine because of partial rollout.
+            # cannot directly use spec info from vLLM because of partial rollout.
             self.spec_info.add(meta_info=meta_info)
 
         # Collect prefix cache statistics


### PR DESCRIPTION
## Summary

- Restore `# ref: SGLang` provenance comment in `logging_utils.py` (§5: upstream references preserved, not translated)
- Drop over-translated `rollout` from `VllmConfig` docstring (`"vLLM rollout engine"` → `"vLLM engine"`)
- Restore dynamic-batching comment on lr scheduler step in `model.py` + multi-line function signature formatting
- Restore `[tool.ruff.lint]` section header in `pyproject.toml`

Found by diffing `slime@44d29ee` (mechanically renamed) against vime main.

## Test plan

- [ ] No behavioral change — comments, docstrings, and config formatting only

🤖 Generated with [Claude Code](https://claude.com/claude-code)