### PR TITLE
fix: add coding_agent_rl dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,16 @@
 accelerate
+anthropic
 blobfile
 cloudpickle
 datasets
+e2b
 httpx[http2]
 mcp[cli]
 memray  # needed for debugging (but is lightweight), we can put it to dev mode when using pyproject.toml
 numba
 omegaconf
+openai
+openai-agents
 pillow
 pylatexenc
 pyyaml


### PR DESCRIPTION
## Summary

- Add `anthropic`, `e2b`, `openai`, `openai-agents` to `requirements.txt`
- These are coding_agent_rl dependencies synced in #148 (slime #1923 et al.) but the requirements were missed

## Test plan

- [ ] `pip install -r requirements.txt` succeeds with the new deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)