### PR TITLE
fix: refine positioning wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Discussion channels:
 
 ## Positioning
 
-The vLLM community horizontally supports many LLM post-training frameworks, including (in alphabetical order) [NeMo RL](https://github.com/NVIDIA-NeMo/RL), [OpenRLHF](https://github.com/openrlhf/openrlhf), [verl](https://github.com/verl-project/verl), and so on. We built the Vime project to seamlessly bring slime's proven training paradigm into the vLLM ecosystem, offering a production-ready bridge that aligns both projects' rapid release cycles. Vime is not meant to be a competitor to these frameworks; instead, we hope it can coexist and provide more options for users. The vLLM community will continue to support the vLLM integration in these post-training frameworks.
+The vLLM community horizontally supports many LLM post-training frameworks, including (in alphabetical order) [NeMo RL](https://github.com/NVIDIA-NeMo/RL), [OpenRLHF](https://github.com/openrlhf/openrlhf), [verl](https://github.com/verl-project/verl), and so on. We built the Vime project to seamlessly bring slime's proven training paradigm into the vLLM ecosystem, offering a production-ready bridge that aligns both projects' rapid release cycles. We hope that users with different needs can find the right vLLM-ecosystem choice for their workflows. The vLLM community will continue to support the vLLM integration in these post-training frameworks.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ Discussion channels:
 
 ## Positioning
 
-The vLLM community horizontally supports many LLM post-training frameworks, including [NeMo RL](https://github.com/NVIDIA-NeMo/RL), [OpenRLHF](https://github.com/openrlhf/openrlhf), [verl](https://github.com/verl-project/verl), and so on. We built the Vime project because some post-training users like slime, but the slime maintainers don't have the bandwidth to maintain the vLLM integration. Vime is not meant to be a competitor to these frameworks; instead, we hope it can coexist and provide more options for users. The vLLM community will continue to support the vLLM integration in these post-training frameworks.
-
-We don't expect heavy new post-training related features to be directly added to Vime. Bugfixes and performance optimizations are welcome.
+The vLLM community horizontally supports many LLM post-training frameworks, including [NeMo RL](https://github.com/NVIDIA-NeMo/RL), [OpenRLHF](https://github.com/openrlhf/openrlhf), [verl](https://github.com/verl-project/verl), and so on. We built the Vime project to seamlessly bring slime's proven training paradigm into the vLLM ecosystem, offering a production-ready bridge that aligns both projects' rapid release cycles. Vime is not meant to be a competitor to these frameworks; instead, we hope it can coexist and provide more options for users. The vLLM community will continue to support the vLLM integration in these post-training frameworks.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Discussion channels:
 
 ## Positioning
 
-The vLLM community horizontally supports many LLM post-training frameworks, including [NeMo RL](https://github.com/NVIDIA-NeMo/RL), [OpenRLHF](https://github.com/openrlhf/openrlhf), [verl](https://github.com/verl-project/verl), and so on. We built the Vime project to seamlessly bring slime's proven training paradigm into the vLLM ecosystem, offering a production-ready bridge that aligns both projects' rapid release cycles. Vime is not meant to be a competitor to these frameworks; instead, we hope it can coexist and provide more options for users. The vLLM community will continue to support the vLLM integration in these post-training frameworks.
+The vLLM community horizontally supports many LLM post-training frameworks, including (in alphabetical order) [NeMo RL](https://github.com/NVIDIA-NeMo/RL), [OpenRLHF](https://github.com/openrlhf/openrlhf), [verl](https://github.com/verl-project/verl), and so on. We built the Vime project to seamlessly bring slime's proven training paradigm into the vLLM ecosystem, offering a production-ready bridge that aligns both projects' rapid release cycles. Vime is not meant to be a competitor to these frameworks; instead, we hope it can coexist and provide more options for users. The vLLM community will continue to support the vLLM integration in these post-training frameworks.
 
 ## Table of Contents
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -20,7 +20,7 @@ Vime 继承了 slime 广泛的模型支持，包括：
 
 ## 定位
 
-vLLM 社区横向支持许多 LLM post-training 框架，包括 [NeMo RL](https://github.com/NVIDIA-NeMo/RL)、[OpenRLHF](https://github.com/openrlhf/openrlhf)、[verl](https://github.com/verl-project/verl) 等。我们创建了 Vime 项目，旨在将 slime 经过验证的训练范式无缝引入 vLLM 生态系统，提供一个可用于生产的桥梁，对齐两个项目的快速迭代节奏。Vime 并不是这些框架的竞争者；相反，我们希望它能与它们共存，为用户提供更多选择。vLLM 社区也会持续支持这些 post-training 框架中的 vLLM 集成。
+vLLM 社区横向支持许多 LLM post-training 框架，包括（按字母顺序）[NeMo RL](https://github.com/NVIDIA-NeMo/RL)、[OpenRLHF](https://github.com/openrlhf/openrlhf)、[verl](https://github.com/verl-project/verl) 等。我们创建了 Vime 项目，旨在将 slime 经过验证的训练范式无缝引入 vLLM 生态系统，提供一个可用于生产的桥梁，对齐两个项目的快速迭代节奏。Vime 并不是这些框架的竞争者；相反，我们希望它能与它们共存，为用户提供更多选择。vLLM 社区也会持续支持这些 post-training 框架中的 vLLM 集成。
 
 ## 目录
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -20,9 +20,7 @@ Vime 继承了 slime 广泛的模型支持，包括：
 
 ## 定位
 
-vLLM 社区横向支持许多 LLM post-training 框架，包括 [NeMo RL](https://github.com/NVIDIA-NeMo/RL)、[OpenRLHF](https://github.com/openrlhf/openrlhf)、[verl](https://github.com/verl-project/verl) 等。我们创建了 Vime 项目，是因为一些 post-training 用户喜欢 slime，但 slime 维护者没有足够精力维护 vLLM 集成。Vime 并不是这些框架的竞争者；相反，我们希望它能与它们共存，为用户提供更多选择。vLLM 社区也会持续支持这些 post-training 框架中的 vLLM 集成。
-
-我们不期望大量新的 post-training 相关功能直接加入 Vime。欢迎 bugfix 和性能优化。
+vLLM 社区横向支持许多 LLM post-training 框架，包括 [NeMo RL](https://github.com/NVIDIA-NeMo/RL)、[OpenRLHF](https://github.com/openrlhf/openrlhf)、[verl](https://github.com/verl-project/verl) 等。我们创建了 Vime 项目，旨在将 slime 经过验证的训练范式无缝引入 vLLM 生态系统，提供一个可用于生产的桥梁，对齐两个项目的快速迭代节奏。Vime 并不是这些框架的竞争者；相反，我们希望它能与它们共存，为用户提供更多选择。vLLM 社区也会持续支持这些 post-training 框架中的 vLLM 集成。
 
 ## 目录
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -20,7 +20,7 @@ Vime 继承了 slime 广泛的模型支持，包括：
 
 ## 定位
 
-vLLM 社区横向支持许多 LLM post-training 框架，包括（按字母顺序）[NeMo RL](https://github.com/NVIDIA-NeMo/RL)、[OpenRLHF](https://github.com/openrlhf/openrlhf)、[verl](https://github.com/verl-project/verl) 等。我们创建了 Vime 项目，旨在将 slime 经过验证的训练范式无缝引入 vLLM 生态系统，提供一个可用于生产的桥梁，对齐两个项目的快速迭代节奏。我们希望有不同需求的用户都能在 vLLM 生态中找到适合自己工作流的选择。vLLM 社区持续支持这些 post-training 框架中的 vLLM 集成。
+vLLM 社区横向支持许多 LLM post-training 框架，包括（按字母顺序）[NeMo RL](https://github.com/NVIDIA-NeMo/RL)、[OpenRLHF](https://github.com/openrlhf/openrlhf)、[verl](https://github.com/verl-project/verl) 等。我们创建了 Vime 项目，旨在将 slime 经过验证的训练范式无缝引入 vLLM 生态系统，提供一个可用于生产的桥梁，对齐两个项目的快速迭代节奏。我们希望有不同需求的用户都能在 vLLM 生态中找到适合自己工作流的选择。vLLM 社区会一如既往地支持这些 post-training 框架中的 vLLM 集成。
 
 ## 目录
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -20,7 +20,7 @@ Vime 继承了 slime 广泛的模型支持，包括：
 
 ## 定位
 
-vLLM 社区横向支持许多 LLM post-training 框架，包括（按字母顺序）[NeMo RL](https://github.com/NVIDIA-NeMo/RL)、[OpenRLHF](https://github.com/openrlhf/openrlhf)、[verl](https://github.com/verl-project/verl) 等。我们创建了 Vime 项目，旨在将 slime 经过验证的训练范式无缝引入 vLLM 生态系统，提供一个可用于生产的桥梁，对齐两个项目的快速迭代节奏。我们希望有不同需求的用户都能在 vLLM 生态中找到适合自己工作流的选择。vLLM 社区也会持续支持这些 post-training 框架中的 vLLM 集成。
+vLLM 社区横向支持许多 LLM post-training 框架，包括（按字母顺序）[NeMo RL](https://github.com/NVIDIA-NeMo/RL)、[OpenRLHF](https://github.com/openrlhf/openrlhf)、[verl](https://github.com/verl-project/verl) 等。我们创建了 Vime 项目，旨在将 slime 经过验证的训练范式无缝引入 vLLM 生态系统，提供一个可用于生产的桥梁，对齐两个项目的快速迭代节奏。我们希望有不同需求的用户都能在 vLLM 生态中找到适合自己工作流的选择。vLLM 社区持续支持这些 post-training 框架中的 vLLM 集成。
 
 ## 目录
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -20,7 +20,7 @@ Vime 继承了 slime 广泛的模型支持，包括：
 
 ## 定位
 
-vLLM 社区横向支持许多 LLM post-training 框架，包括（按字母顺序）[NeMo RL](https://github.com/NVIDIA-NeMo/RL)、[OpenRLHF](https://github.com/openrlhf/openrlhf)、[verl](https://github.com/verl-project/verl) 等。我们创建了 Vime 项目，旨在将 slime 经过验证的训练范式无缝引入 vLLM 生态系统，提供一个可用于生产的桥梁，对齐两个项目的快速迭代节奏。Vime 并不是这些框架的竞争者；相反，我们希望它能与它们共存，为用户提供更多选择。vLLM 社区也会持续支持这些 post-training 框架中的 vLLM 集成。
+vLLM 社区横向支持许多 LLM post-training 框架，包括（按字母顺序）[NeMo RL](https://github.com/NVIDIA-NeMo/RL)、[OpenRLHF](https://github.com/openrlhf/openrlhf)、[verl](https://github.com/verl-project/verl) 等。我们创建了 Vime 项目，旨在将 slime 经过验证的训练范式无缝引入 vLLM 生态系统，提供一个可用于生产的桥梁，对齐两个项目的快速迭代节奏。我们希望有不同需求的用户都能在 vLLM 生态中找到适合自己工作流的选择。vLLM 社区也会持续支持这些 post-training 框架中的 vLLM 集成。
 
 ## 目录
 


### PR DESCRIPTION
## Summary
- Replace "no bandwidth" motivation with "seamlessly bring slime's proven training paradigm into the vLLM ecosystem"
- Remove commitment sentence ("We don't expect heavy new post-training related features...")
- Applied to both README.md and README_zh.md

Companion to the blog post wording fix on vllm-project.github.io.

## Test plan
- [ ] Verify rendered markdown on both READMEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)