### PR TITLE
docs: acknowledge SkyRL/verl and list SkyRL/prime-rl as users in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Discussion channels:
 
 ## Positioning
 
-The vLLM community horizontally supports many LLM post-training frameworks, including (in alphabetical order) [NeMo RL](https://github.com/NVIDIA-NeMo/RL), [OpenRLHF](https://github.com/openrlhf/openrlhf), [verl](https://github.com/verl-project/verl), and so on. We built the Vime project to seamlessly bring slime's proven training paradigm into the vLLM ecosystem, offering a production-ready bridge that aligns both projects' rapid release cycles. We hope that users with different needs can find the right vLLM-ecosystem choice for their workflows. The vLLM community will continue to support the vLLM integration in these post-training frameworks.
+The vLLM community horizontally supports many LLM post-training frameworks, including (in alphabetical order) [NeMo RL](https://github.com/NVIDIA-NeMo/RL), [OpenRLHF](https://github.com/openrlhf/openrlhf), [prime-rl](https://github.com/PrimeIntellect-ai/prime-rl), [SkyRL](https://github.com/NovaSky-AI/SkyRL), [verl](https://github.com/verl-project/verl), and so on. We built the Vime project to seamlessly bring slime's proven training paradigm into the vLLM ecosystem, offering a production-ready bridge that aligns both projects' rapid release cycles. We hope that users with different needs can find the right vLLM-ecosystem choice for their workflows. The vLLM community will continue to support the vLLM integration in these post-training frameworks.
 
 ## Table of Contents
 
@@ -101,7 +101,7 @@ For frequently asked questions, please see the [Q&A](docs/en/get_started/qa.md)
 
 ## Acknowledgements
 
-Special thanks to the **slime** community for their great work. Vime is used by projects such as [SkyRL](https://github.com/NovaSky-AI/SkyRL) and [prime-rl](https://github.com/PrimeIntellect-ai/prime-rl). We also especially thank [SkyRL](https://github.com/NovaSky-AI/SkyRL) and [verl](https://github.com/verl-project/verl): we referenced their excellent work while building Vime. Vime is maintained by the vLLM community.
+Special thanks to the **slime** community for their great work. We also especially thank [SkyRL](https://github.com/NovaSky-AI/SkyRL) and [verl](https://github.com/verl-project/verl): we referenced their excellent work while building Vime. Vime is maintained by the vLLM community.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For frequently asked questions, please see the [Q&A](docs/en/get_started/qa.md)
 
 ## Acknowledgements
 
-Special thanks to the **slime** community for their great work. Vime is maintained by the vLLM community.
+Special thanks to the **slime** community for their great work. Vime is used by projects such as [SkyRL](https://github.com/NovaSky-AI/SkyRL) and [prime-rl](https://github.com/PrimeIntellect-ai/prime-rl). We also especially thank [SkyRL](https://github.com/NovaSky-AI/SkyRL) and [verl](https://github.com/verl-project/verl): we referenced their excellent work while building Vime. Vime is maintained by the vLLM community.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For frequently asked questions, please see the [Q&A](docs/en/get_started/qa.md)
 
 ## Acknowledgements
 
-Special thanks to the **slime** community for their great work. We also especially thank [SkyRL](https://github.com/NovaSky-AI/SkyRL) and [verl](https://github.com/verl-project/verl): we referenced their excellent work while building Vime. Vime is maintained by the vLLM community.
+Special thanks to the **slime** community for their great work. Thanks also go to [SkyRL](https://github.com/NovaSky-AI/SkyRL) and [verl](https://github.com/verl-project/verl), whose excellent work we referenced while building Vime. Vime is maintained by the vLLM community.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For frequently asked questions, please see the [Q&A](docs/en/get_started/qa.md)
 
 ## Acknowledgements
 
-Special thanks to the **slime** community for their great work. Thanks also go to [SkyRL](https://github.com/NovaSky-AI/SkyRL) and [verl](https://github.com/verl-project/verl), whose excellent work we referenced while building Vime. Vime is maintained by the vLLM community.
+Vime builds on ideas and infrastructure from the open-source RL ecosystem. We especially thank the [slime](https://github.com/THUDM/slime) community, whose great work Vime is directly built on. We also thank [SkyRL](https://github.com/NovaSky-AI/SkyRL) and [verl](https://github.com/verl-project/verl), whose excellent work we referenced. Vime is maintained by the vLLM community.
 
 ## Citation
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -22,7 +22,7 @@ Vime 继承了 slime 广泛的模型支持，包括：
 
 ## 定位
 
-vLLM 社区横向支持许多 LLM post-training 框架，包括（按字母顺序）[NeMo RL](https://github.com/NVIDIA-NeMo/RL)、[OpenRLHF](https://github.com/openrlhf/openrlhf)、[verl](https://github.com/verl-project/verl) 等。我们创建了 Vime 项目，旨在将 slime 经过验证的训练范式无缝引入 vLLM 生态系统，提供一个可用于生产的桥梁，对齐两个项目的快速迭代节奏。我们希望有不同需求的用户都能在 vLLM 生态中找到适合自己工作流的选择。vLLM 社区会一如既往地支持这些 post-training 框架中的 vLLM 集成。
+vLLM 社区横向支持许多 LLM post-training 框架，包括（按字母顺序）[NeMo RL](https://github.com/NVIDIA-NeMo/RL)、[OpenRLHF](https://github.com/openrlhf/openrlhf)、[prime-rl](https://github.com/PrimeIntellect-ai/prime-rl)、[SkyRL](https://github.com/NovaSky-AI/SkyRL)、[verl](https://github.com/verl-project/verl) 等。我们创建了 Vime 项目，旨在将 slime 经过验证的训练范式无缝引入 vLLM 生态系统，提供一个可用于生产的桥梁，对齐两个项目的快速迭代节奏。我们希望有不同需求的用户都能在 vLLM 生态中找到适合自己工作流的选择。vLLM 社区会一如既往地支持这些 post-training 框架中的 vLLM 集成。
 
 ## 目录
 
@@ -101,7 +101,7 @@ Vime 由 slime 衍生而来。以下上游资源与本仓库文档仍沿用 slim
 
 ## 致谢
 
-特别感谢 **slime** 社区的出色工作。[SkyRL](https://github.com/NovaSky-AI/SkyRL) 与 [prime-rl](https://github.com/PrimeIntellect-ai/prime-rl) 等项目正在使用 Vime。同时特别感谢 [SkyRL](https://github.com/NovaSky-AI/SkyRL) 与 [verl](https://github.com/verl-project/verl)：在构建 Vime 的过程中我们参考了它们的优秀工作。Vime 由 vLLM 社区维护。
+特别感谢 **slime** 社区的出色工作。同时特别感谢 [SkyRL](https://github.com/NovaSky-AI/SkyRL) 与 [verl](https://github.com/verl-project/verl)：在构建 Vime 的过程中我们参考了它们的优秀工作。Vime 由 vLLM 社区维护。
 
 ## 引用
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -101,7 +101,7 @@ Vime 由 slime 衍生而来。以下上游资源与本仓库文档仍沿用 slim
 
 ## 致谢
 
-特别感谢 **slime** 社区的出色工作。Vime 由 vLLM 社区维护。
+特别感谢 **slime** 社区的出色工作。[SkyRL](https://github.com/NovaSky-AI/SkyRL) 与 [prime-rl](https://github.com/PrimeIntellect-ai/prime-rl) 等项目正在使用 Vime。同时特别感谢 [SkyRL](https://github.com/NovaSky-AI/SkyRL) 与 [verl](https://github.com/verl-project/verl)：在构建 Vime 的过程中我们参考了它们的优秀工作。Vime 由 vLLM 社区维护。
 
 ## 引用
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -101,7 +101,7 @@ Vime 由 slime 衍生而来。以下上游资源与本仓库文档仍沿用 slim
 
 ## 致谢
 
-特别感谢 **slime** 社区的出色工作。也感谢 [SkyRL](https://github.com/NovaSky-AI/SkyRL) 与 [verl](https://github.com/verl-project/verl)，在构建 Vime 的过程中我们参考了它们的优秀工作。Vime 由 vLLM 社区维护。
+Vime 构建于开源 RL 生态的想法与基础设施之上。特别感谢 [slime](https://github.com/THUDM/slime) 社区——Vime 直接构建于其出色工作之上；也感谢 [SkyRL](https://github.com/NovaSky-AI/SkyRL) 与 [verl](https://github.com/verl-project/verl)，我们参考了它们的优秀工作。Vime 由 vLLM 社区维护。
 
 ## 引用
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -101,7 +101,7 @@ Vime 由 slime 衍生而来。以下上游资源与本仓库文档仍沿用 slim
 
 ## 致谢
 
-特别感谢 **slime** 社区的出色工作。同时特别感谢 [SkyRL](https://github.com/NovaSky-AI/SkyRL) 与 [verl](https://github.com/verl-project/verl)：在构建 Vime 的过程中我们参考了它们的优秀工作。Vime 由 vLLM 社区维护。
+特别感谢 **slime** 社区的出色工作。也感谢 [SkyRL](https://github.com/NovaSky-AI/SkyRL) 与 [verl](https://github.com/verl-project/verl)，在构建 Vime 的过程中我们参考了它们的优秀工作。Vime 由 vLLM 社区维护。
 
 ## 引用
 


### PR DESCRIPTION
Follow-up to #222.

## Changes (README.md + README_zh.md, kept in sync)

- **Positioning**: add [prime-rl](https://github.com/PrimeIntellect-ai/prime-rl) and [SkyRL](https://github.com/NovaSky-AI/SkyRL) to the alphabetical list of vLLM-ecosystem post-training frameworks.
- **Acknowledgements**: especially thank [SkyRL](https://github.com/NovaSky-AI/SkyRL) and [verl](https://github.com/verl-project/verl), whose work we referenced while building Vime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)