### PR TITLE
[Doc] Fix Read the Docs build config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,5 @@ build:
       - pip install -r docs/requirements.txt
     build:
       html:
-        - cd docs
         - mkdir -p "$READTHEDOCS_OUTPUT/html"
-        - VIME_DOC_LANG=en sphinx-build -b html -D language=en --conf-dir ./ ./en "$READTHEDOCS_OUTPUT/html"
+        - VIME_DOC_LANG=en sphinx-build -b html -D language=en -c docs docs/en "$READTHEDOCS_OUTPUT/html"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,7 +104,7 @@ html_favicon = "_static/image/logo.ico"
 html_title = project
 html_copy_source = True
 html_last_updated_fmt = ""
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL")
 
 html_theme_options = {
     "repository_url": "https://github.com/vllm-project/vime",


### PR DESCRIPTION
Fix RTD Sphinx build config for vime docs.

- remove  from 
- point Sphinx to  from repo root
- default  to 

This should unblock RTD builds for the merged docs configuration.