### PR TITLE
[Feature]  TransferQueue Integration for Rollout-to-Training

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ ray[default]
 ring_flash_attn
 safetensors
 tensorboard
+TransferQueue>=0.1.8
 transformers
 vllm-router>=0.1.14
 wandb

--- a/scripts/run-qwen3-4B-grpo-tq.sh
+++ b/scripts/run-qwen3-4B-grpo-tq.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+# for rerun the task
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python
+
+set -ex
+
+# will prevent ray from buffering stdout/stderr
+export PYTHONUNBUFFERED=1
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "$NVLINK_COUNT" -gt 0 ]; then
+    HAS_NVLINK=1
+else
+    HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+if command -v nvidia-smi >/dev/null 2>&1; then
+    DETECTED_GPUS=$(nvidia-smi -L 2>/dev/null | wc -l | tr -d ' ')
+else
+    DETECTED_GPUS=0
+fi
+NUM_GPUS=${NUM_GPUS:-${DETECTED_GPUS}}
+if [ -z "$NUM_GPUS" ] || [ "$NUM_GPUS" -le 0 ]; then
+    NUM_GPUS=8
+fi
+echo "NUM_GPUS: $NUM_GPUS"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+VIME_ROOT="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+source "${SCRIPT_DIR}/models/qwen3-4B.sh"
+
+CKPT_ARGS=(
+   --hf-checkpoint /root/Qwen3-4B
+   #--hf-checkpoint /root/Qwen3-4B-FP8
+   --ref-load /root/Qwen3-4B_torch_dist
+   --load /root/Qwen3-4B_vime/
+   --save /root/Qwen3-4B_vime/
+   --save-interval 20
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data /root/dapo-math-17k/dapo-math-17k.jsonl
+   --input-key prompt
+   --label-key label
+   --apply-chat-template
+   --rollout-shuffle
+   --rm-type deepscaler
+   --num-rollout 20
+   --rollout-batch-size 32
+   --n-samples-per-prompt 8
+   --rollout-max-response-len 2048
+   --rollout-temperature 1
+
+   --global-batch-size 256
+   --balance-data
+)
+
+EVAL_ARGS=(
+   --eval-interval 20
+   --eval-prompt-data aime /root/aime-2024/aime-2024.jsonl
+   --n-samples-per-eval-prompt 16
+   --eval-max-response-len 16384
+   --eval-top-p 1
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 2
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   # --micro-batch-size 1
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 9216
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --use-kl-loss
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+)
+
+WANDB_ARGS=(
+   # --use-wandb
+   # --wandb-project vime-dev
+   # --wandb-group qwen3-4B-test
+   # --wandb-key ${WANDB_KEY}
+)
+
+VLLM_ARGS=(
+   --rollout-num-gpus-per-engine 2
+   --vllm-gpu-memory-utilization 0.7
+)
+
+MISC_ARGS=(
+   # default dropout in megatron is 0.1
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   # should be good for model performance
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   # need to comment this when using model with MLA
+   --attention-backend flash
+   --train-memory-margin-bytes 2147483648
+)
+
+# launch the master node of ray in container
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus ${NUM_GPUS} --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+# Build the runtime environment JSON with proper variable substitution
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"${VIME_ROOT}:/root/Megatron-LM/\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\"
+  }
+}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 train.py \
+   --train-backend megatron \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node 4 \
+   --rollout-num-gpus 4 \
+   --enable-vime-transfer-queue true \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${VLLM_ARGS[@]} \
+   ${MISC_ARGS[@]}

--- a/train.py
+++ b/train.py
@@ -4,12 +4,14 @@ from vime.ray.placement_group import create_placement_groups, create_rollout_man
 from vime.utils.arguments import parse_args
 from vime.utils.logging_utils import configure_logger, finish_tracking, init_tracking, update_tracking_open_metrics
 from vime.utils.misc import should_run_periodic_action
+from vime.utils.transfer_queue import TransferQueueBridge
 
 
 def train(args):
     configure_logger()
     # allocate the GPUs
     pgs = create_placement_groups(args)
+    TransferQueueBridge.initialize(args)
     init_tracking(args)
 
     # create the rollout manager, with vLLM engines inside.
@@ -63,6 +65,11 @@ def train(args):
         if args.rollout_global_dataset:
             ray.get(rollout_manager.save.remote(rollout_id))
 
+    def clear_transfer_queue_partition(rollout_id):
+        # Driver owns TransferQueue partition lifecycle after all train consumers finish.
+        if TransferQueueBridge.enabled(args):
+            ray.get(rollout_manager.clear_transfer_queue_partition.remote(rollout_id))
+
     # train loop.
     for rollout_id in range(args.start_rollout_id, args.num_rollout):
         if args.eval_interval is not None and rollout_id == 0 and not args.skip_eval_before_train:
@@ -78,11 +85,21 @@ def train(args):
         if args.use_critic:
             value_refs = critic_model.async_train(rollout_id, rollout_data_ref)
             if actor_trains_this_step:
-                ray.get(actor_model.async_train(rollout_id, rollout_data_ref, external_data=value_refs))
+                if (
+                    TransferQueueBridge.critic_values_via_transfer_queue(args)
+                    and TransferQueueBridge.critic_values_via_transfer_queue(actor_model.args)
+                    and TransferQueueBridge.critic_values_via_transfer_queue(critic_model.args)
+                ):
+                    actor_refs = actor_model.async_train(rollout_id, rollout_data_ref)
+                    ray.get(value_refs + actor_refs)
+                else:
+                    ray.get(actor_model.async_train(rollout_id, rollout_data_ref, external_data=value_refs))
             else:
                 ray.get(value_refs)
         else:
             ray.get(actor_model.async_train(rollout_id, rollout_data_ref))
+
+        clear_transfer_queue_partition(rollout_id)
 
         if should_run_periodic_action(rollout_id, args.save_interval, num_rollout_per_epoch, args.num_rollout):
             save(rollout_id)

--- a/vime/backends/megatron_utils/actor.py
+++ b/vime/backends/megatron_utils/actor.py
@@ -3,6 +3,7 @@ import os
 import random
 from argparse import Namespace
 from contextlib import nullcontext
+from typing import Any
 
 import numpy as np
 import ray
@@ -22,6 +23,7 @@ from vime.utils.misc import Box
 from vime.utils.reloadable_process_group import destroy_process_groups, monkey_patch_torch_dist, reload_process_groups
 from vime.utils.routing_replay import RoutingReplay
 from vime.utils.timer import Timer, inverse_timer, timer, with_defer
+from vime.utils.transfer_queue import CRITIC_VALUE_FIELDS, TransferQueueBridge
 from vime.utils.types import RolloutBatch
 
 from ...utils.profile_utils import TrainProfiler
@@ -58,6 +60,7 @@ class MegatronTrainRayActor(TrainRayActor):
         super().init(args, role, with_ref, with_opd_teacher)
 
         init(args)
+        self.transfer_queue = TransferQueueBridge.connect(args)
 
         if is_megatron_main_rank():
             init_tracking(args, primary=False, role=role)
@@ -279,6 +282,88 @@ class MegatronTrainRayActor(TrainRayActor):
             ]
         return rollout_data
 
+    def _get_rollout_data_from_transfer_queue(self, rollout_id: int) -> tuple[RolloutBatch, Any]:
+        task_name = "critic_train" if self.role == "critic" else "actor_train"
+        rollout_data = None
+        batch_meta = None
+        data_fields = (
+            TransferQueueBridge.actor_train_data_fields(self.args)
+            if self.role == "actor"
+            else TransferQueueBridge.default_train_data_fields(self.args)
+        )
+        while rollout_data is None:
+            rollout_data, batch_meta = self.transfer_queue.get_data(
+                rollout_id,
+                task_name=task_name,
+                data_fields=data_fields,
+            )
+        return self._postprocess_transfer_queue_rollout_data(rollout_data), batch_meta
+
+    def _postprocess_transfer_queue_rollout_data(self, rollout_data: RolloutBatch) -> RolloutBatch:
+        rollout_data["tokens"] = [
+            torch.as_tensor(t, dtype=torch.long, device=torch.cuda.current_device()) for t in rollout_data["tokens"]
+        ]
+        rollout_data["loss_masks"] = [
+            torch.as_tensor(t, dtype=torch.int, device=torch.cuda.current_device()) for t in rollout_data["loss_masks"]
+        ]
+        if "multimodal_train_inputs" in rollout_data:
+            rollout_data["multimodal_train_inputs"] = [
+                (
+                    {
+                        key: (
+                            torch.from_numpy(v.copy()).to(device=torch.cuda.current_device())
+                            if isinstance(v, np.ndarray)
+                            else v.to(device=torch.cuda.current_device())
+                        )
+                        for key, v in mm_dict.items()
+                    }
+                    if mm_dict is not None
+                    else None
+                )
+                for mm_dict in rollout_data["multimodal_train_inputs"]
+            ]
+
+        if self.args.qkv_format == "bshd":
+            max_seq_len = max(rollout_data["total_lengths"])
+            pad_size = mpu.get_tensor_model_parallel_world_size() * self.args.data_pad_size_multiplier
+            max_seq_len = (max_seq_len + pad_size - 1) // pad_size * pad_size
+            rollout_data["max_seq_lens"] = [max_seq_len] * len(rollout_data["tokens"])
+
+        for key in ["rollout_log_probs", "teacher_log_probs"]:
+            if key not in rollout_data:
+                continue
+            rollout_data[key] = [
+                torch.as_tensor(
+                    slice_log_prob_with_cp(
+                        log_prob,
+                        total_length,
+                        response_length,
+                        self.args.qkv_format,
+                        rollout_data["max_seq_lens"][i] if self.args.qkv_format == "bshd" else None,
+                    ),
+                    device=torch.cuda.current_device(),
+                    dtype=torch.float32,
+                )
+                for i, (log_prob, total_length, response_length) in enumerate(
+                    zip(
+                        rollout_data[key],
+                        rollout_data["total_lengths"],
+                        rollout_data["response_lengths"],
+                        strict=False,
+                    )
+                )
+            ]
+        if "rollout_routed_experts" in rollout_data:
+            rollout_data["rollout_routed_experts"] = [
+                torch.as_tensor(r, dtype=torch.long) for r in rollout_data["rollout_routed_experts"]
+            ]
+        if "values" in rollout_data:
+            rollout_data["values"] = [
+                torch.as_tensor(value, dtype=torch.float32, device=torch.cuda.current_device())
+                for value in rollout_data["values"]
+            ]
+        return rollout_data
+
     def _switch_model(self, target_tag: str) -> None:
         if target_tag not in self.weights_backuper.backup_tags:
             raise ValueError(f"Cannot switch to unknown model tag: {target_tag}")
@@ -318,6 +403,12 @@ class MegatronTrainRayActor(TrainRayActor):
             batch = data_iterator[0].get_next(["rollout_routed_experts", "tokens"])
             rollout_routed_experts = batch["rollout_routed_experts"]
             tokens = batch["tokens"]
+            rollout_routed_experts = [
+                r.reshape(r.shape[0], self.args.num_layers, self.args.moe_router_topk)
+                if getattr(r, "ndim", 0) == 2
+                else r
+                for r in rollout_routed_experts
+            ]
             assert len(rollout_routed_experts) == len(tokens)
             for a, b in zip(rollout_routed_experts, tokens, strict=False):
                 assert a.shape[0] == b.shape[0] - 1, f"{a.shape}, {b.shape}"
@@ -388,10 +479,14 @@ class MegatronTrainRayActor(TrainRayActor):
             self.wake_up()
 
         with timer("data_preprocess"):
-            rollout_data = self._get_rollout_data(rollout_data_ref)
+            batch_meta = None
+            if TransferQueueBridge.enabled(self.args):
+                rollout_data, batch_meta = self._get_rollout_data_from_transfer_queue(rollout_id)
+            else:
+                rollout_data = self._get_rollout_data(rollout_data_ref)
 
         if self.role == "critic":
-            result = self.train_critic(rollout_id, rollout_data)
+            result = self.train_critic(rollout_id, rollout_data, batch_meta=batch_meta)
         else:
             self.train_actor(rollout_id, rollout_data, external_data=external_data)
             result = None
@@ -402,7 +497,7 @@ class MegatronTrainRayActor(TrainRayActor):
 
         return result
 
-    def train_critic(self, rollout_id: int, rollout_data: RolloutBatch):
+    def train_critic(self, rollout_id: int, rollout_data: RolloutBatch, batch_meta=None):
         """Train critic and return CPU values (used as old-values for the next actor train)."""
         data_iterator = get_data_iterator(rollout_data)
         num_microbatches = rollout_data["num_microbatches"]
@@ -427,7 +522,21 @@ class MegatronTrainRayActor(TrainRayActor):
         if mpu.is_pipeline_last_stage() and "values" in rollout_data:
             from vime.backends.megatron_utils.data import tensors_to_cpu
 
-            return {"values": tensors_to_cpu(rollout_data["values"])}
+            values = tensors_to_cpu(rollout_data["values"])
+            if TransferQueueBridge.critic_values_via_transfer_queue(self.args):
+                if mpu.get_tensor_model_parallel_rank() == 0:
+                    if batch_meta is None:
+                        raise ValueError("TransferQueue critic values write-back requires batch_meta.")
+                    self.transfer_queue.put_data(
+                        rollout_id,
+                        {"values": values},
+                        data_fields=CRITIC_VALUE_FIELDS,
+                        batch_meta=batch_meta,
+                    )
+                return {}
+            return {"values": values}
+        if TransferQueueBridge.critic_values_via_transfer_queue(self.args):
+            return {}
         return {}
 
     def train_actor(self, rollout_id: int, rollout_data: RolloutBatch, external_data=None) -> None:

--- a/vime/backends/megatron_utils/actor.py
+++ b/vime/backends/megatron_utils/actor.py
@@ -300,6 +300,7 @@ class MegatronTrainRayActor(TrainRayActor):
         return self._postprocess_transfer_queue_rollout_data(rollout_data), batch_meta
 
     def _postprocess_transfer_queue_rollout_data(self, rollout_data: RolloutBatch) -> RolloutBatch:
+        Timer().seq_lens = rollout_data["total_lengths"]
         rollout_data["tokens"] = [
             torch.as_tensor(t, dtype=torch.long, device=torch.cuda.current_device()) for t in rollout_data["tokens"]
         ]

--- a/vime/ray/actor_group.py
+++ b/vime/ray/actor_group.py
@@ -5,6 +5,7 @@ from ray.util.placement_group import PlacementGroup
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from vime.ray.utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST
+from vime.utils.transfer_queue import TransferQueueBridge
 
 
 class RayTrainGroup:
@@ -57,6 +58,7 @@ class RayTrainGroup:
             "NVTE_FP8_BLOCK_SCALING_FP32_SCALES": os.environ.get("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", "1"),
             **{name: "1" for name in NOSET_VISIBLE_DEVICES_ENV_VARS_LIST},
             **self.args.train_env_vars,
+            **TransferQueueBridge.env_vars(self.args),
         }
 
         if self.args.offload_train and self.args.train_backend == "megatron":

--- a/vime/ray/placement_group.py
+++ b/vime/ray/placement_group.py
@@ -6,6 +6,8 @@ import ray
 from ray.util.placement_group import placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
+from vime.utils.transfer_queue import TransferQueueBridge
+
 from .actor_group import RayTrainGroup
 from .rollout import RolloutManager
 
@@ -145,6 +147,21 @@ def create_training_models(args, pgs, rollout_manager):
         )
         if args.megatron_config_path is None:
             critic_args.disable_param_buffers_cpu_backup = False
+
+        critic_values_via_tq = (
+            TransferQueueBridge.critic_values_via_transfer_queue(args)
+            and TransferQueueBridge.critic_values_via_transfer_queue(actor_args)
+            and TransferQueueBridge.critic_values_via_transfer_queue(critic_args)
+        )
+        if TransferQueueBridge.enabled(args) and not critic_values_via_tq:
+            logger.warning(
+                "TransferQueue critic values write-back is disabled because actor/critic TQ constraints do not both "
+                "hold. Base context_parallel_size=%s, actor context_parallel_size=%s, "
+                "critic context_parallel_size=%s; using Ray ObjectRef values.",
+                getattr(args, "context_parallel_size", 1),
+                getattr(actor_args, "context_parallel_size", 1),
+                getattr(critic_args, "context_parallel_size", 1),
+            )
 
         critic_model = allocate_train_group(
             args=critic_args,

--- a/vime/ray/rollout.py
+++ b/vime/ray/rollout.py
@@ -28,6 +28,7 @@ from vime.utils.logging_utils import configure_logger, init_tracking
 from vime.utils.metric_utils import compute_pass_rate, compute_rollout_step, compute_statistics, dict_add_prefix
 from vime.utils.misc import Box, group_by, load_function
 from vime.utils.types import Sample
+from vime.utils.transfer_queue import TransferQueueBridge
 
 from ..utils.metric_utils import has_repetition
 from .rollout_validation import validate_server_group_gpu_indices
@@ -383,6 +384,7 @@ class RolloutManager:
         init_tracking(args, primary=False)
         self.rollout_engine_lock = Lock.options(num_cpus=1, num_gpus=0).remote()
         self.rollout_id = -1
+        self.transfer_queue = TransferQueueBridge.connect(args)
 
         self._health_monitors = []
         if not self.args.debug_train_only and self.args.use_fault_tolerance:
@@ -436,6 +438,7 @@ class RolloutManager:
     def dispose(self):
         for monitor in self._health_monitors:
             monitor.stop()
+        self.transfer_queue.close()
         logging_utils.finish_tracking(self.args)
 
     @property
@@ -492,8 +495,15 @@ class RolloutManager:
             # if debug rollout only, we don't convert samples to train data and directly return
             return
         data = self._convert_samples_to_train_data(data)
+        if TransferQueueBridge.enabled(self.args):
+            self.transfer_queue.transfer_rollout_data(rollout_id, data)
+            return None
+
         return self._split_train_data_by_dp(data)
 
+    def clear_transfer_queue_partition(self, rollout_id):
+        self.transfer_queue.clear_partition(rollout_id)
+        
     def eval(self, rollout_id):
         if self.args.debug_train_only:
             # if debug train only, we don't generate evaluation data

--- a/vime/utils/arguments.py
+++ b/vime/utils/arguments.py
@@ -1325,6 +1325,52 @@ def get_vime_extra_args_provider(add_custom_arguments=None):
             )
             return parser
 
+        def add_transfer_queue_arguments(parser):
+            parser.add_argument(
+                "--enable-vime-transfer-queue",
+                action="store_true",
+                default=False,
+                help=(
+                    "Use TransferQueue as the rollout-to-training data plane. "
+                    "Rollout writes partition train_{rollout_id}; training actors read it by DP rank."
+                ),
+            )
+            parser.add_argument(
+                "--num-data-storage-units",
+                type=int,
+                default=1,
+                help="Number of TransferQueue SimpleStorageUnit actors.",
+            )
+            parser.add_argument(
+                "--max-staleness",
+                type=int,
+                default=0,
+                help="Maximum number of unconsumed TransferQueue train partitions allowed before rollout waits.",
+            )
+            parser.add_argument(
+                "--polling-mode",
+                action=argparse.BooleanOptionalAction,
+                default=True,
+                help="Whether the TransferQueue controller uses polling mode for metadata.",
+            )
+            parser.add_argument(
+                "--transfer-queue-staleness-poll-interval",
+                type=float,
+                default=1.0,
+                help="Seconds to wait between TransferQueue staleness checks.",
+            )
+            parser.add_argument(
+                "--transfer-queue-extra-data-fields",
+                type=str,
+                nargs="*",
+                default=[],
+                help=(
+                    "Extra rollout data fields to request from TransferQueue, useful for custom losses or "
+                    "custom convert_samples_to_train_data outputs."
+                ),
+            )
+            return parser
+        
         def add_custom_megatron_plugins_arguments(parser):
             """
             Add custom Megatron plugins arguments.
@@ -1401,6 +1447,7 @@ def get_vime_extra_args_provider(add_custom_arguments=None):
         parser = add_network_arguments(parser)
         parser = add_reward_model_arguments(parser)
         parser = add_rollout_buffer_arguments(parser)
+        parser = add_transfer_queue_arguments(parser)
         parser = add_mtp_training_arguments(parser)
         parser = add_ci_arguments(parser)
         parser = add_custom_megatron_plugins_arguments(parser)
@@ -1725,6 +1772,19 @@ def vime_validate_args(args):
             "will not instantiate vLLM servers and will only run the training process."
         )
         args.debug_train_only = True
+
+    if not hasattr(args, "tq_config"):
+        args.tq_config = None
+
+    if args.enable_vime_transfer_queue:
+        if args.debug_train_only:
+            raise ValueError(
+                "--enable-vime-transfer-queue is not supported with --debug-train-only/load_debug_rollout_data."
+            )
+        if args.max_staleness < 0:
+            raise ValueError("--max-staleness must be >= 0.")
+        if args.num_data_storage_units <= 0:
+            raise ValueError("--num-data-storage-units must be > 0.")
 
     args.use_critic = args.advantage_estimator == "ppo"
     # Critic always uses the same GPU count as actor.

--- a/vime/utils/train_metric_utils.py
+++ b/vime/utils/train_metric_utils.py
@@ -21,9 +21,10 @@ def log_perf_data_raw(
         return
 
     log_dict = {f"perf/{key}_time": val for key, val in log_dict_raw.items()}
+    seq_lens = getattr(timer_instance, "seq_lens", None)
 
-    if ("perf/actor_train_time" in log_dict) and (compute_total_fwd_flops is not None):
-        total_fwd_flops = compute_total_fwd_flops(seq_lens=timer_instance.seq_lens)
+    if ("perf/actor_train_time" in log_dict) and (compute_total_fwd_flops is not None) and seq_lens is not None:
+        total_fwd_flops = compute_total_fwd_flops(seq_lens=seq_lens)
 
         if "perf/log_probs_time" in log_dict:
             log_dict["perf/log_probs_tflops"] = total_fwd_flops / log_dict["perf/log_probs_time"]
@@ -33,7 +34,7 @@ def log_perf_data_raw(
 
         if log_dict["perf/actor_train_time"] > 0:
             log_dict["perf/actor_train_tflops"] = 3 * total_fwd_flops / log_dict["perf/actor_train_time"]
-            log_dict["perf/actor_train_tok_per_s"] = sum(timer_instance.seq_lens) / log_dict["perf/actor_train_time"]
+            log_dict["perf/actor_train_tok_per_s"] = sum(seq_lens) / log_dict["perf/actor_train_time"]
 
     if "perf/train_wait_time" in log_dict and "perf/train_time" in log_dict:
         total_time = log_dict["perf/train_wait_time"] + log_dict["perf/train_time"]

--- a/vime/utils/transfer_queue.py
+++ b/vime/utils/transfer_queue.py
@@ -187,6 +187,8 @@ class TransferQueueBridge:
     ):
         """Convert slime rollout data into the TensorDict format expected by TransferQueue."""
         TensorDict = _import_tensordict()
+        from tensordict.tensorclass import NonTensorData
+
         if not data:
             return TensorDict({}, batch_size=0 if batch_size is None else batch_size, device=device)
 
@@ -211,6 +213,11 @@ class TransferQueueBridge:
             tensors = [torch.tensor(seq, dtype=dtype, device=device) for seq in value]
             return torch.nested.as_nested_tensor(tensors, layout=torch.jagged)
 
+        def non_tensor_stack(value):
+            if not value:
+                return NonTensorData([], batch_size=0 if batch_size is None else batch_size)
+            return torch.stack([NonTensorData(item) for item in value], 0)
+
         result = {}
         for key, value in data.items():
             if not isinstance(value, list):
@@ -226,7 +233,7 @@ class TransferQueueBridge:
                 continue
 
             if key in {"metadata", "multimodal_train_inputs", "prompt"}:
-                result[key] = value
+                result[key] = non_tensor_stack(value)
                 continue
 
             if value and isinstance(value[0], torch.Tensor):
@@ -248,9 +255,15 @@ class TransferQueueBridge:
             if depth == 0:
                 result[key] = torch.empty(0, device=device)
             elif depth == 1:
-                result[key] = tensor_1d(value)
+                try:
+                    result[key] = tensor_1d(value)
+                except (TypeError, ValueError):
+                    result[key] = non_tensor_stack(value)
             elif depth == 2:
-                result[key] = tensor_2d(value)
+                try:
+                    result[key] = tensor_2d(value)
+                except (TypeError, ValueError):
+                    result[key] = non_tensor_stack(value)
             else:
                 raise ValueError(f"TransferQueue field '{key}' has unsupported nesting depth {depth}; max depth is 2.")
 
@@ -347,6 +360,7 @@ class TransferQueueBridge:
             "raw_reward",
             "truncated",
             "sample_indices",
+            "rollout_log_probs"
         ]
         if getattr(args, "use_rollout_logprobs", False):
             fields.append("rollout_log_probs")
@@ -437,7 +451,37 @@ class TransferQueueBridge:
         rollout_data, batch_meta = payload
         if rollout_data is None:
             return None, None
-        return self.tensordict_to_rollout_data(rollout_data), batch_meta
+        rollout_data = self.tensordict_to_rollout_data(rollout_data)
+        self._ensure_schedule_fields(rollout_data)
+        return rollout_data, batch_meta
+
+    def _ensure_schedule_fields(self, rollout_data: dict[str, Any]) -> None:
+        schedule_fields = {"global_batch_sizes", "num_microbatches", "micro_batch_indices"}
+        if schedule_fields.issubset(rollout_data):
+            return
+
+        from megatron.core import mpu
+
+        from vime.utils.dp_schedule import build_dp_schedule
+
+        total_lengths = rollout_data["total_lengths"]
+        local_batch_size = len(total_lengths)
+        train_parallel_config = {
+            "dp_size": 1,
+            "cp_size": mpu.get_context_parallel_world_size(),
+            "vpp_size": mpu.get_virtual_pipeline_model_parallel_world_size() or 1,
+            "microbatch_group_size_per_vp_stage": 1,
+        }
+        _, micro_batch_indices, num_microbatches, _ = build_dp_schedule(
+            self.args,
+            train_parallel_config,
+            total_lengths,
+            global_batch_size=local_batch_size,
+            rollout_indices=list(range(local_batch_size)),
+        )
+        rollout_data["global_batch_sizes"] = [getattr(self.args, "global_batch_size", None) or local_batch_size]
+        rollout_data["num_microbatches"] = num_microbatches
+        rollout_data["micro_batch_indices"] = micro_batch_indices[0]
 
     @staticmethod
     def _broadcast_payload(payload: list[Any], device: torch.device) -> None:
@@ -490,6 +534,8 @@ class TransferQueueBridge:
 
     @staticmethod
     def _unwrap_non_tensor_stack(value, non_tensor_data_cls):
+        if non_tensor_data_cls and isinstance(value, non_tensor_data_cls):
+            value = value.data
         output = []
         for item in list(value):
             raw = item.data if non_tensor_data_cls and isinstance(item, non_tensor_data_cls) else item

--- a/vime/utils/transfer_queue.py
+++ b/vime/utils/transfer_queue.py
@@ -1,0 +1,504 @@
+import logging
+import os
+import time
+from argparse import Namespace
+from typing import Any
+
+import numpy as np
+import torch
+import torch.distributed as dist
+from omegaconf import OmegaConf
+
+from slime.utils.async_utils import run
+
+logger = logging.getLogger(__name__)
+
+TRAIN_PARTITION_PREFIX = "train_"
+ACTOR_TRAIN_TASK = "actor_train"
+CRITIC_TRAIN_TASK = "critic_train"
+CRITIC_VALUE_FIELDS = ["values"]
+
+REQUIRED_TRAIN_DATA_FIELDS = [
+    "tokens",
+    "response_lengths",
+    "loss_masks",
+    "rewards",
+]
+
+
+def _import_transfer_queue():
+    try:
+        import transfer_queue as tq
+    except ImportError as exc:
+        raise ImportError(
+            "--enable-vime-transfer-queue requires the external `transfer_queue` package. "
+            "Install TransferQueue in the runtime environment before enabling this path."
+        ) from exc
+    return tq
+
+
+def _import_tensordict():
+    try:
+        from tensordict import TensorDict
+    except ImportError as exc:
+        raise ImportError(
+            "--enable-vime-transfer-queue requires `tensordict`, which is normally installed with TransferQueue."
+        ) from exc
+    return TensorDict
+
+
+class TransferQueueBridge:
+    """Facade for the optional TransferQueue rollout-to-training data path."""
+
+    def __init__(self, args: Namespace, client=None):
+        self.args = args
+        self.client = client
+
+    @classmethod
+    def enabled(cls, args: Namespace) -> bool:
+        return bool(getattr(args, "enable_vime_transfer_queue", False))
+
+    @classmethod
+    def initialize(cls, args: Namespace) -> None:
+        """Create the TransferQueue controller/storage and attach config to args."""
+        if not cls.enabled(args):
+            args.tq_config = None
+            return
+
+        os.environ.update(cls.env_vars(args))
+        tq = _import_transfer_queue()
+
+        total_storage_size = args.rollout_batch_size * args.n_samples_per_prompt * (args.max_staleness + 1)
+        sampler = cls._build_sampler(args, tq)
+        tq_config = OmegaConf.create(
+            {
+                "controller": {
+                    "sampler": sampler,
+                    "polling_mode": args.polling_mode,
+                },
+                "backend": {
+                    "SimpleStorage": {
+                        "total_storage_size": total_storage_size,
+                        "num_data_storage_units": args.num_data_storage_units,
+                    },
+                },
+            },
+            flags={"allow_objects": True},
+        )
+        args.tq_config = tq.init(conf=tq_config) or tq_config
+        logger.info(
+            "Initialized TransferQueue: total_storage_size=%s, num_data_storage_units=%s, max_staleness=%s",
+            total_storage_size,
+            args.num_data_storage_units,
+            args.max_staleness,
+        )
+        if getattr(args, "use_critic", False) and not cls.critic_values_via_transfer_queue(args):
+            logger.warning(
+                "TransferQueue critic values write-back is disabled because context_parallel_size=%s; "
+                "critic values will use the existing Ray ObjectRef path.",
+                getattr(args, "context_parallel_size", 1),
+            )
+
+    @classmethod
+    def env_vars(cls, args: Namespace) -> dict[str, str]:
+        if not cls.enabled(args):
+            return {}
+        return {
+            "TQ_PRE_ALLOC_SAMPLE_NUM": str(args.rollout_batch_size * args.n_samples_per_prompt),
+            "TQ_ZERO_COPY_SERIALIZATION": "true",
+        }
+
+    @classmethod
+    def connect(cls, args: Namespace) -> "TransferQueueBridge":
+        """Connect a Ray actor process to the already-created TransferQueue."""
+        if not cls.enabled(args):
+            return cls(args)
+        if getattr(args, "tq_config", None) is None:
+            raise ValueError(
+                "args.tq_config is missing. TransferQueueBridge.initialize(args) must run before actors start."
+            )
+        tq = _import_transfer_queue()
+        tq.init(args.tq_config)
+        return cls(args, tq.get_client())
+
+    def close(self) -> None:
+        if not self.enabled(self.args):
+            return
+        tq = _import_transfer_queue()
+        tq.close()
+
+    @classmethod
+    def _build_sampler(cls, args: Namespace, tq):
+        if getattr(args, "balance_data", False):
+            dp_size = cls.data_parallel_size(args)
+            logger.info("Using TransferQueue SeqlenBalancedSampler with dp_size=%s", dp_size)
+            return tq.SeqlenBalancedSampler(n_samples_per_prompt=args.n_samples_per_prompt, dp_size=dp_size)
+        return tq.GRPOGroupNSampler(n_samples_per_prompt=args.n_samples_per_prompt)
+
+    @classmethod
+    def data_parallel_size(cls, args: Namespace) -> int:
+        """Return the Megatron DP size used by TQ before Megatron is initialized."""
+        world_size = args.actor_num_nodes * args.actor_num_gpus_per_node
+        model_parallel_size = (
+            int(getattr(args, "tensor_model_parallel_size", 1))
+            * int(getattr(args, "pipeline_model_parallel_size", 1))
+            * int(getattr(args, "context_parallel_size", 1))
+        )
+        if model_parallel_size <= 0:
+            raise ValueError(f"Invalid model parallel size for TransferQueue: {model_parallel_size}")
+        if world_size % model_parallel_size != 0:
+            raise ValueError(
+                "Actor world size must be divisible by tensor*pipeline*context parallel size when using TransferQueue: "
+                f"world_size={world_size}, model_parallel_size={model_parallel_size}"
+            )
+        return world_size // model_parallel_size
+
+    @staticmethod
+    def add_total_lengths(train_data: dict[str, Any]) -> dict[str, Any]:
+        train_data = dict(train_data)
+        train_data["total_lengths"] = [len(tokens) for tokens in train_data["tokens"]]
+        return train_data
+
+    @classmethod
+    def normalize_train_data(cls, train_data: dict[str, Any]) -> dict[str, Any]:
+        """Make rollout train_data match the fields actor/critic request from TQ."""
+        missing = [field for field in REQUIRED_TRAIN_DATA_FIELDS if field not in train_data]
+        if missing:
+            raise ValueError(f"TransferQueue rollout data is missing required fields: {missing}")
+
+        train_data = cls.add_total_lengths(train_data)
+        batch_size = len(train_data["tokens"])
+
+        if "raw_reward" not in train_data:
+            train_data["raw_reward"] = list(train_data["rewards"])
+        if "truncated" not in train_data:
+            train_data["truncated"] = [0] * batch_size
+        if "sample_indices" not in train_data:
+            train_data["sample_indices"] = list(range(batch_size))
+
+        return train_data
+
+    @classmethod
+    def dict_to_tensordict(
+        cls,
+        data: dict[str, list],
+        batch_size: int | torch.Size | None = None,
+        device=None,
+    ):
+        """Convert slime rollout data into the TensorDict format expected by TransferQueue."""
+        TensorDict = _import_tensordict()
+        if not data:
+            return TensorDict({}, batch_size=0 if batch_size is None else batch_size, device=device)
+
+        def nesting_depth(value):
+            if isinstance(value, list) and value:
+                return 1 + nesting_depth(value[0])
+            return 0
+
+        def scalar_dtype(sample):
+            if isinstance(sample, bool):
+                return torch.bool
+            if isinstance(sample, float):
+                return torch.float32
+            return None
+
+        def tensor_1d(value):
+            dtype = scalar_dtype(value[0]) if value else None
+            return torch.tensor(value, dtype=dtype, device=device)
+
+        def tensor_2d(value):
+            dtype = scalar_dtype(value[0][0]) if value and value[0] else None
+            tensors = [torch.tensor(seq, dtype=dtype, device=device) for seq in value]
+            return torch.nested.as_nested_tensor(tensors, layout=torch.jagged)
+
+        result = {}
+        for key, value in data.items():
+            if not isinstance(value, list):
+                raise TypeError(f"TransferQueue field '{key}' must be a list, got {type(value)}")
+
+            if key == "rollout_routed_experts":
+                tensors = []
+                for item in value:
+                    arr = item.detach().cpu().numpy() if isinstance(item, torch.Tensor) else np.asarray(item)
+                    arr = np.ascontiguousarray(arr.reshape(arr.shape[0], -1))
+                    tensors.append(torch.from_numpy(arr).to(torch.int32))
+                result[key] = torch.nested.as_nested_tensor(tensors, layout=torch.jagged)
+                continue
+
+            if key in {"metadata", "multimodal_train_inputs", "prompt"}:
+                result[key] = value
+                continue
+
+            if value and isinstance(value[0], torch.Tensor):
+                tensors = []
+                for item in value:
+                    tensor = item.detach()
+                    if tensor.device.type != "cpu":
+                        tensor = tensor.cpu()
+                    if device is not None:
+                        tensor = tensor.to(device)
+                    tensors.append(tensor)
+                if tensors[0].ndim == 0:
+                    result[key] = torch.stack(tensors)
+                else:
+                    result[key] = torch.nested.as_nested_tensor(tensors, layout=torch.jagged)
+                continue
+
+            depth = nesting_depth(value)
+            if depth == 0:
+                result[key] = torch.empty(0, device=device)
+            elif depth == 1:
+                result[key] = tensor_1d(value)
+            elif depth == 2:
+                result[key] = tensor_2d(value)
+            else:
+                raise ValueError(f"TransferQueue field '{key}' has unsupported nesting depth {depth}; max depth is 2.")
+
+        return TensorDict(result, batch_size=batch_size, device=device)
+
+    def transfer_rollout_data(self, rollout_id: int, train_data: dict[str, Any]) -> None:
+        """Write one rollout partition to TransferQueue."""
+        client = self._require_client()
+        self.wait_for_staleness()
+        train_data = self.normalize_train_data(train_data)
+        rollout_batch = self.dict_to_tensordict(train_data, batch_size=len(train_data["tokens"]))
+        metadata = run(client.async_put(data=rollout_batch, partition_id=self.partition_id(rollout_id)))
+        self._set_total_length_custom_meta(metadata, train_data["total_lengths"])
+        logger.info(
+            "Transferred rollout_id=%s to TransferQueue partition=%s with %s samples; fields=%s",
+            rollout_id,
+            self.partition_id(rollout_id),
+            len(train_data["tokens"]),
+            sorted(train_data.keys()),
+        )
+
+    def put_data(
+        self,
+        rollout_id: int,
+        data: dict[str, Any],
+        *,
+        data_fields: list[str],
+        batch_meta=None,
+    ) -> None:
+        """Write derived fields back to an existing TransferQueue batch."""
+        if not self.enabled(self.args) or self.client is None:
+            return
+
+        missing = [field for field in data_fields if field not in data]
+        if missing:
+            raise ValueError(f"TransferQueue write-back data is missing fields: {missing}")
+
+        payload = {field: data[field] for field in data_fields}
+        batch_size = len(next(iter(payload.values()))) if payload else 0
+        rollout_batch = self.dict_to_tensordict(payload, batch_size=batch_size)
+        if batch_meta is None:
+            raise ValueError("TransferQueue write-back requires batch_meta from the matching get_meta/get_data call.")
+
+        run(self.client.async_put(data=rollout_batch, metadata=batch_meta))
+        logger.info(
+            "Wrote TransferQueue fields: partition=%s fields=%s samples=%s",
+            self.partition_id(rollout_id),
+            data_fields,
+            batch_size,
+        )
+
+    def _set_total_length_custom_meta(self, metadata, total_lengths: list[int]) -> None:
+        if metadata is None or getattr(metadata, "size", 0) == 0 or not hasattr(metadata, "update_custom_meta"):
+            return
+        metadata.update_custom_meta([{"total_lengths": int(length)} for length in total_lengths])
+        run(self._require_client().async_set_custom_meta(metadata))
+
+    def wait_for_staleness(self) -> None:
+        """Apply simple partition-count backpressure before writing a new rollout."""
+        client = self._require_client()
+        max_staleness = int(getattr(self.args, "max_staleness", 0))
+        poll_interval = float(getattr(self.args, "transfer_queue_staleness_poll_interval", 1.0))
+        while True:
+            partitions = run(client.async_get_partition_list())
+            train_partitions = [p for p in partitions if str(p).startswith(TRAIN_PARTITION_PREFIX)]
+            if len(train_partitions) <= max_staleness:
+                return
+            logger.info(
+                "TransferQueue staleness backpressure: %s train partitions > max_staleness=%s; waiting %.2fs",
+                len(train_partitions),
+                max_staleness,
+                poll_interval,
+            )
+            time.sleep(poll_interval)
+
+    def clear_partition(self, rollout_id: int) -> None:
+        if not self.enabled(self.args) or self.client is None:
+            return
+        run(self.client.async_clear_partition(partition_id=self.partition_id(rollout_id)))
+        logger.info("Cleared TransferQueue partition %s", self.partition_id(rollout_id))
+
+    @staticmethod
+    def partition_id(rollout_id: int) -> str:
+        return f"{TRAIN_PARTITION_PREFIX}{rollout_id}"
+
+    @classmethod
+    def default_train_data_fields(cls, args: Namespace) -> list[str]:
+        fields = [
+            "tokens",
+            "total_lengths",
+            "response_lengths",
+            "loss_masks",
+            "rewards",
+            "raw_reward",
+            "truncated",
+            "sample_indices",
+        ]
+        if getattr(args, "use_rollout_logprobs", False):
+            fields.append("rollout_log_probs")
+        if getattr(args, "use_rollout_routing_replay", False):
+            fields.append("rollout_routed_experts")
+        if getattr(args, "multimodal_keys", None) is not None:
+            fields.append("multimodal_train_inputs")
+        if getattr(args, "use_opd", False) and getattr(args, "opd_type", None) == "sglang":
+            fields.append("teacher_log_probs")
+        for field in getattr(args, "transfer_queue_extra_data_fields", []) or []:
+            if field not in fields:
+                fields.append(field)
+        return fields
+
+    @classmethod
+    def critic_values_via_transfer_queue(cls, args: Namespace) -> bool:
+        return (
+            cls.enabled(args)
+            and getattr(args, "use_critic", False)
+            and int(getattr(args, "context_parallel_size", 1)) == 1
+        )
+
+    @classmethod
+    def actor_train_data_fields(cls, args: Namespace) -> list[str]:
+        fields = cls.default_train_data_fields(args)
+        if cls.critic_values_via_transfer_queue(args):
+            for field in CRITIC_VALUE_FIELDS:
+                if field not in fields:
+                    fields.append(field)
+        return fields
+
+    def get_data(
+        self,
+        rollout_id: int,
+        *,
+        task_name: str,
+        data_fields: list[str] | None = None,
+    ):
+        """Fetch this DP rank's rollout data from TransferQueue and broadcast it to model-parallel ranks."""
+        from megatron.core import mpu
+
+        client = self._require_client()
+        data_fields = data_fields or self.default_train_data_fields(self.args)
+        total_batch_size = self.args.rollout_batch_size * self.args.n_samples_per_prompt
+        dp_size = mpu.get_data_parallel_world_size(with_context_parallel=False)
+        if total_batch_size % dp_size != 0:
+            raise ValueError(
+                "TransferQueue requires rollout_batch_size*n_samples_per_prompt to be divisible by DP size: "
+                f"total_batch_size={total_batch_size}, dp_size={dp_size}"
+            )
+        batch_size = total_batch_size // dp_size
+        sampling_config = {
+            "dp_rank": mpu.get_data_parallel_rank(with_context_parallel=False),
+            "task_name": task_name,
+            "batch_index": 0,
+            "partition_id": self.partition_id(rollout_id),
+        }
+
+        should_fetch = (
+            mpu.get_tensor_model_parallel_rank() == 0
+            and mpu.get_pipeline_model_parallel_rank() == 0
+            and mpu.get_context_parallel_rank() == 0
+        )
+        payload = [None, None]
+        if should_fetch:
+            batch_meta = client.get_meta(
+                data_fields=data_fields,
+                batch_size=batch_size,
+                partition_id=self.partition_id(rollout_id),
+                sampling_config=sampling_config,
+                task_name=task_name,
+            )
+            if batch_meta.size != 0:
+                payload = [client.get_data(batch_meta), batch_meta]
+                logger.info(
+                    "Fetched TransferQueue data: partition=%s task=%s dp_rank=%s batch_size=%s fields=%s",
+                    self.partition_id(rollout_id),
+                    task_name,
+                    sampling_config["dp_rank"],
+                    batch_meta.size,
+                    data_fields,
+                )
+
+        device = torch.device(f"cuda:{torch.cuda.current_device()}") if torch.cuda.is_available() else torch.device(
+            "cpu"
+        )
+        self._broadcast_payload(payload, device)
+        rollout_data, batch_meta = payload
+        if rollout_data is None:
+            return None, None
+        return self.tensordict_to_rollout_data(rollout_data), batch_meta
+
+    @staticmethod
+    def _broadcast_payload(payload: list[Any], device: torch.device) -> None:
+        from megatron.core import mpu
+
+        def bcast(group):
+            src = dist.get_global_rank(group, 0)
+            dist.broadcast_object_list(payload, src=src, group=group, device=device)
+
+        if mpu.get_context_parallel_world_size() > 1:
+            bcast(mpu.get_context_parallel_group())
+        bcast(mpu.get_tensor_model_parallel_group())
+        if mpu.get_pipeline_model_parallel_world_size() > 1:
+            bcast(mpu.get_pipeline_model_parallel_group())
+
+    @classmethod
+    def tensordict_to_rollout_data(cls, data) -> dict[str, Any]:
+        """Turn TransferQueue TensorDict payload back into slime's list-based RolloutBatch."""
+        try:
+            from tensordict import TensorDict
+            from tensordict.tensorclass import NonTensorData
+        except ImportError:
+            TensorDict = ()
+            NonTensorData = ()
+
+        if not isinstance(data, TensorDict):
+            return data
+
+        rollout_data = {}
+        for key, value in data.items():
+            if key in {"metadata", "multimodal_train_inputs", "prompt"}:
+                rollout_data[key] = cls._unwrap_non_tensor_stack(value, NonTensorData)
+            elif (
+                "lengths" in key
+                or key
+                in {
+                    "rewards",
+                    "raw_reward",
+                    "truncated",
+                    "sample_indices",
+                    "round_number",
+                }
+            ):
+                rollout_data[key] = value.tolist() if isinstance(value, torch.Tensor) else list(value)
+            elif isinstance(value, torch.Tensor):
+                rollout_data[key] = [item for item in value]
+            else:
+                rollout_data[key] = cls._unwrap_non_tensor_stack(value, NonTensorData)
+        return rollout_data
+
+    @staticmethod
+    def _unwrap_non_tensor_stack(value, non_tensor_data_cls):
+        output = []
+        for item in list(value):
+            raw = item.data if non_tensor_data_cls and isinstance(item, non_tensor_data_cls) else item
+            if hasattr(raw, "items"):
+                raw = dict(raw.items())
+            output.append(raw)
+        return output
+
+    def _require_client(self):
+        if self.client is None:
+            raise ValueError("TransferQueue client is not connected.")
+        return self.client

--- a/vime/utils/transfer_queue.py
+++ b/vime/utils/transfer_queue.py
@@ -9,7 +9,7 @@ import torch
 import torch.distributed as dist
 from omegaconf import OmegaConf
 
-from slime.utils.async_utils import run
+from vime.utils.async_utils import run
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## ✨ Summary

Introduce an **optional VIME TransferQueue data path** for transferring rollout data to training.  
When enabled via `--enable-vime-transfer-queue`, rollout batches are written directly into the TransferQueue. Megatron actor/critic workers then fetch their DP-local training data straight from TQ, bypassing the previous Ray ObjectRef rollout payload path.

---

## 🔧 What’s Changed

- **TransferQueueBridge** – A new central component that handles:
  - TQ initialization and client connections
  - Field conversion
  - Partition cleanup
  - Unified data fetch/write APIs

- **Rollout Workers** now publish normalized rollout batches directly into the TQ.

- **Megatron Actor Workers** now fetch rollout data from the TQ instead of relying on Ray ObjectRefs.

- **Local Training Schedule Preservation** – After fetching from TQ, the following fields are kept intact:
  - `global_batch_sizes`
  - `num_microbatches`
  - `micro_batch_indices`

- **Backpressure & Cleanup** – TQ staleness backpressure is enforced, and explicit partition cleanup runs once consumers have finished.

- **Extended Field Support** – Both tensor and non‑tensor rollout fields are supported, including multimodal inputs, metadata, prompts, routing replay data, and extra configured fields.