### PR TITLE
fix(arguments): include DP in TP auto-compute default

### DIFF
--- a/tests/utils/test_vllm_arguments.py
+++ b/tests/utils/test_vllm_arguments.py
@@ -340,5 +340,52 @@ def test_parse_args_default_attribute_set_even_without_register(args_mod, monkey
     assert ns.vllm_tensor_parallel_size == 8
 
 
+@pytest.mark.unit
+def test_parse_args_tp_default_with_dp(args_mod, monkeypatch):
+    """TP auto-compute must divide by DP: TP = gpus / (PP * DP)."""
+    monkeypatch.setattr(args_mod, "add_vllm_arguments", lambda p: p)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["train.py", "--rollout-num-gpus-per-engine", "8", "--vllm-data-parallel-size", "4"],
+    )
+    ns = args_mod.vllm_parse_args()
+    assert ns.vllm_tensor_parallel_size == 2  # 8 / (1 * 4) = 2
+
+
+@pytest.mark.unit
+def test_parse_args_tp_default_with_pp_and_dp(args_mod, monkeypatch):
+    """TP = gpus / (PP * DP) when both PP and DP are set."""
+    monkeypatch.setattr(args_mod, "add_vllm_arguments", lambda p: p)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "train.py",
+            "--rollout-num-gpus-per-engine",
+            "8",
+            "--vllm-pipeline-parallel-size",
+            "2",
+            "--vllm-data-parallel-size",
+            "2",
+        ],
+    )
+    ns = args_mod.vllm_parse_args()
+    assert ns.vllm_tensor_parallel_size == 2  # 8 / (2 * 2) = 2
+
+
+@pytest.mark.unit
+def test_parse_args_tp_default_dp1_unchanged(args_mod, monkeypatch):
+    """DP=1 (default) must not change existing TP behavior."""
+    monkeypatch.setattr(args_mod, "add_vllm_arguments", lambda p: p)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["train.py", "--rollout-num-gpus-per-engine", "4", "--vllm-data-parallel-size", "1"],
+    )
+    ns = args_mod.vllm_parse_args()
+    assert ns.vllm_tensor_parallel_size == 4  # 4 / (1 * 1) = 4
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))

--- a/vime/backends/vllm_utils/arguments.py
+++ b/vime/backends/vllm_utils/arguments.py
@@ -274,13 +274,18 @@ def vllm_parse_args():
     parser = FlexibleArgumentParser(add_help=False)
     add_vllm_arguments(parser)
 
-    # Compute default vllm_tensor_parallel_size from CLI args
+    # Compute default vllm_tensor_parallel_size from CLI args.
+    # TP = gpus_per_engine / (PP * DP), matching _resolve_vllm_parallel_sizes
+    # in vllm_engine.py. Without the DP divisor the default is too large when
+    # --vllm-data-parallel-size > 1 (needed for expert parallelism).
     temp_parser = argparse.ArgumentParser(add_help=False)
     temp_parser.add_argument("--rollout-num-gpus-per-engine", type=int, default=1)
     temp_parser.add_argument("--vllm-pipeline-parallel-size", type=int, default=1)
+    temp_parser.add_argument("--vllm-data-parallel-size", type=int, default=1)
     temp_args, _ = temp_parser.parse_known_args()
     pp_size = temp_args.vllm_pipeline_parallel_size
-    vllm_tp_size = temp_args.rollout_num_gpus_per_engine // pp_size
+    dp_size = temp_args.vllm_data_parallel_size
+    vllm_tp_size = temp_args.rollout_num_gpus_per_engine // (pp_size * dp_size)
     parser.set_defaults(vllm_tensor_parallel_size=vllm_tp_size)
 
     args, _ = parser.parse_known_args()

--- a/vime/backends/vllm_utils/arguments.py
+++ b/vime/backends/vllm_utils/arguments.py
@@ -275,9 +275,6 @@ def vllm_parse_args():
     add_vllm_arguments(parser)
 
     # Compute default vllm_tensor_parallel_size from CLI args.
-    # TP = gpus_per_engine / (PP * DP), matching _resolve_vllm_parallel_sizes
-    # in vllm_engine.py. Without the DP divisor the default is too large when
-    # --vllm-data-parallel-size > 1 (needed for expert parallelism).
     temp_parser = argparse.ArgumentParser(add_help=False)
     temp_parser.add_argument("--rollout-num-gpus-per-engine", type=int, default=1)
     temp_parser.add_argument("--vllm-pipeline-parallel-size", type=int, default=1)


### PR DESCRIPTION
## Summary
- The `vllm_parse_args` default for `vllm_tensor_parallel_size` was computed as `rollout_num_gpus_per_engine // pp_size`, missing the `dp_size` divisor
- When `--vllm-data-parallel-size > 1` (required for expert parallelism via `--vllm-enable-expert-parallel`), the default TP was too large
- Align the formula with `_resolve_vllm_parallel_sizes` in `vllm_engine.py` which correctly uses `gpus // (pp * dp)`

## Example
With `--rollout-num-gpus-per-engine 8 --vllm-data-parallel-size 4 --vllm-pipeline-parallel-size 1`:
- **Before**: default TP = 8 // 1 = 8 (wrong)
- **After**: default TP = 8 // (1 * 4) = 2 (correct, matches engine launch)

The actual engine launch was unaffected because `_resolve_vllm_parallel_sizes` computed correctly at runtime. But the argparser default was inconsistent, which could confuse validation or logging code reading `args.vllm_tensor_parallel_size` before engine launch.

## Test plan
- [ ] Verify `--rollout-num-gpus-per-engine 8 --vllm-data-parallel-size 4` produces TP=2 in args
- [ ] Verify DP=1 (default) behavior unchanged: `--rollout-num-gpus-per-engine 4` still produces TP=4

🤖 Generated with [Claude Code](https://claude.com/claude-code)