### PR TITLE
[codex] fix vllm prefix caching defaults

### DIFF
--- a/examples/coding_agent_rl/generate.py
+++ b/examples/coding_agent_rl/generate.py
@@ -90,12 +90,19 @@ class _State(metaclass=SingletonMeta):
         self.reasoning_parser = getattr(args, "vllm_reasoning_parser", None) or None
         vllm_url = f"http://{args.vllm_router_ip}:{args.vllm_router_port}"
         public_host = os.environ.get("VIME_HEAD_HOST")
-        if not public_host:
+        # ADAPTER_URL_OVERRIDE lets a reverse tunnel (e.g. cloudflared) supply a
+        # ready-made public adapter URL when the head has no directly routable
+        # host:port -- e.g. Modal sandboxes on a private cluster. When set it
+        # fully replaces the VIME_HEAD_HOST + SHIM_PORT construction below.
+        adapter_url_override = os.environ.get("ADAPTER_URL_OVERRIDE")
+        if not public_host and not adapter_url_override:
             raise RuntimeError(
-                "VIME_HEAD_HOST is not set. Export it to the host IP that "
-                "sandboxes can reach for reverse-connection to the Anthropic adapter. "
-                "Without it the sandbox cannot dial back and the rollout will "
-                "silently abort."
+                "Neither VIME_HEAD_HOST nor ADAPTER_URL_OVERRIDE is set. Export "
+                "VIME_HEAD_HOST to the host IP that sandboxes can reach for "
+                "reverse-connection to the Anthropic adapter, or set "
+                "ADAPTER_URL_OVERRIDE to a full public adapter URL (e.g. a "
+                "cloudflared tunnel). Without one the sandbox cannot dial back "
+                "and the rollout will silently abort."
             )
         self.adapter = AnthropicAdapter(
             tokenizer=self.tokenizer,
@@ -115,7 +122,7 @@ class _State(metaclass=SingletonMeta):
             thread_name="anthropic-adapter",
             runner_kwargs={"handler_cancellation": True},
         )
-        self.adapter_url = f"http://{public_host}:{self.app_handle.port}"
+        self.adapter_url = adapter_url_override or f"http://{public_host}:{self.app_handle.port}"
         logger.info(
             "[coding_agent_rl] tokenizer=%s adapter=%s max_context_len=%s tool_parser=%s reasoning_parser=%s",
             args.hf_checkpoint,

--- a/examples/coding_agent_rl/sandbox.py
+++ b/examples/coding_agent_rl/sandbox.py
@@ -20,7 +20,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from vime.agent.sandbox import E2BSandbox, Sandbox
+from vime.agent.sandbox import E2BSandbox, ModalSandbox, Sandbox
 
 
 logger = logging.getLogger(__name__)
@@ -55,12 +55,28 @@ CC_PROMPT = os.environ.get(
 _BOOT_SEM: asyncio.Semaphore | None = None
 
 
+def make_sandbox(image: str) -> Sandbox:
+    """Construct the configured sandbox backend for ``image``.
+
+    Backend is chosen by ``VIME_AGENT_SANDBOX_BACKEND`` (read per call so run.sh
+    / tests can set it): ``e2b`` (default, unchanged behavior) or ``modal``.
+    Both backends satisfy the same :class:`Sandbox` Protocol, so the work-sandbox
+    and eval-sandbox call sites below stay backend-agnostic.
+    """
+    backend = os.environ.get("VIME_AGENT_SANDBOX_BACKEND", "e2b").strip().lower()
+    if backend == "modal":
+        return ModalSandbox(image)
+    if backend in ("", "e2b"):
+        return E2BSandbox(image)
+    raise ValueError(f"unknown VIME_AGENT_SANDBOX_BACKEND={backend!r} (expected 'e2b' or 'modal')")
+
+
 # ---------------------------------------------------------------------------
 # Sandbox bootstrap (Node + Claude Code + agent user)
 # ---------------------------------------------------------------------------
 @asynccontextmanager
-async def boot_agent_sandbox(image: str) -> AsyncIterator[E2BSandbox]:
-    """Boot a fresh E2B sandbox and install the Claude Code toolchain.
+async def boot_agent_sandbox(image: str) -> AsyncIterator[Sandbox]:
+    """Boot a fresh sandbox (E2B or Modal) and install the Claude Code toolchain.
 
     This is the provisioning wrapper for the work sandbox: create the sandbox
     from the dataset image, install Node 22 + Claude Code CLI from host
@@ -74,7 +90,7 @@ async def boot_agent_sandbox(image: str) -> AsyncIterator[E2BSandbox]:
     sb = None
     last_err: Exception | None = None
     for attempt in range(SWE_BOOT_RETRIES):
-        cand = E2BSandbox(image)
+        cand = make_sandbox(image)
         try:
             async with _BOOT_SEM:
                 await cand.__aenter__()
@@ -312,7 +328,7 @@ async def evaluate(
         logger.warning("[e2b.evaluate] no swepro/eval_cmd; reward=0")
         return 0.0, False, True
 
-    async with E2BSandbox(image) as ev:
+    async with make_sandbox(image) as ev:
         await ensure_agent_user(ev, workdir)
         if swepro:
             await _setup_swepro_assets(ev, swepro)

--- a/tests/test_agent_modal_sandbox.py
+++ b/tests/test_agent_modal_sandbox.py
@@ -1,0 +1,637 @@
+"""Unit tests for the Modal sandbox backend (vime.agent.sandbox.ModalSandbox)
+and the coding_agent_rl make_sandbox() factory.
+
+No network and no real ``modal`` dependency: a fully faked ``modal`` module is
+injected into ``sys.modules`` so ``import modal`` inside ModalSandbox picks it
+up. The fakes record every SDK call (App.lookup / Image.from_registry /
+Secret.from_dict / Sandbox.create / exec / stdin / wait / terminate) so we can
+assert the exact wiring: image-from-registry, runuser user emulation, env
+whitelist forwarding, stdin file streaming, chown-after-write, output capping,
+timeout contract, and always-terminate cleanup.
+
+Run: python -m pytest tests/test_modal_sandbox.py -v   (no pytest-asyncio needed)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Make the dev workspace importable (vime/ and examples/ live one level up).
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+# ---------------------------------------------------------------------------
+# async test plumbing (no pytest-asyncio)
+# ---------------------------------------------------------------------------
+def aiotest(afn):
+    @functools.wraps(afn)
+    def wrapper(*args, **kwargs):
+        return asyncio.run(afn(*args, **kwargs))
+
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Fake modal SDK
+# ---------------------------------------------------------------------------
+class _Aio:
+    """Wrap an async fn so ``obj.aio(*a, **k)`` returns its coroutine, matching
+    Modal's synchronicity surface (e.g. ``await sb.exec.aio(...)``)."""
+
+    def __init__(self, afn):
+        self._afn = afn
+
+    def aio(self, *a, **k):
+        return self._afn(*a, **k)
+
+
+class FakeStream:
+    def __init__(self, getter):
+        self._getter = getter
+
+    @property
+    def read(self):
+        getter = self._getter
+
+        async def _read():
+            return getter()
+
+        return _Aio(_read)
+
+
+class FakeStdin:
+    def __init__(self, sb):
+        self._sb = sb
+
+    def write(self, data):
+        self._sb.stdin_writes.append(data)
+
+    def write_eof(self):
+        self._sb.stdin_eof = True
+
+    @property
+    def drain(self):
+        async def _drain():
+            return None
+
+        return _Aio(_drain)
+
+
+class FakeProc:
+    def __init__(self, sb):
+        self._sb = sb
+        self.stdin = FakeStdin(sb)
+        self.stdout = FakeStream(lambda: sb.next_stdout)
+        self.stderr = FakeStream(lambda: sb.next_stderr)
+
+    @property
+    def wait(self):
+        sb = self._sb
+
+        async def _wait():
+            if sb.raise_timeout:
+                raise sys.modules["modal"].exception.SandboxTimeoutError("simulated timeout")
+            return sb.next_rc
+
+        return _Aio(_wait)
+
+
+class FakeSandbox:
+    def __init__(self, **create_kwargs):
+        self.create_kwargs = create_kwargs
+        self.object_id = "sb-fake-0001"
+        self.exec_calls = []  # list of (argv_tuple, kwargs_dict)
+        self.stdin_writes = []
+        self.stdin_eof = False
+        self.next_stdout = "OUT"
+        self.next_stderr = "ERR"
+        self.next_rc = 0
+        self.raise_timeout = False
+        self.terminated = False
+
+    @property
+    def exec(self):
+        sb = self
+
+        async def _exec(*argv, **kwargs):
+            sb.exec_calls.append((argv, kwargs))
+            return FakeProc(sb)
+
+        return _Aio(_exec)
+
+    @property
+    def terminate(self):
+        sb = self
+
+        async def _terminate():
+            sb.terminated = True
+
+        return _Aio(_terminate)
+
+
+def _make_fake_modal():
+    mod = types.ModuleType("modal")
+
+    exc = types.ModuleType("modal.exception")
+
+    class SandboxTimeoutError(Exception):
+        pass
+
+    class NotFoundError(Exception):
+        pass
+
+    exc.SandboxTimeoutError = SandboxTimeoutError
+    exc.NotFoundError = NotFoundError
+    mod.exception = exc
+
+    # App.lookup.aio(name, *, create_if_missing=...)
+    class _App:
+        def __init__(self, name, create_if_missing):
+            self.name = name
+            self.create_if_missing = create_if_missing
+
+    class AppNS:
+        lookups = []
+
+    async def _app_lookup(name, *, create_if_missing=False, **_):
+        a = _App(name, create_if_missing)
+        AppNS.lookups.append(a)
+        return a
+
+    AppNS.lookup = _Aio(_app_lookup)
+    mod.App = AppNS
+
+    # Image.from_registry(tag, secret=None)  -- synchronous
+    class _Image:
+        def __init__(self, tag, secret):
+            self.tag = tag
+            self.secret = secret
+
+    class ImageNS:
+        calls = []
+
+    def _from_registry(tag, secret=None, **_):
+        img = _Image(tag, secret)
+        ImageNS.calls.append((tag, secret))
+        return img
+
+    ImageNS.from_registry = staticmethod(_from_registry)
+    mod.Image = ImageNS
+
+    # Secret.from_dict(d)  -- synchronous
+    class _Secret:
+        def __init__(self, d):
+            self.d = d
+
+    class SecretNS:
+        created = []
+
+    def _from_dict(d):
+        SecretNS.created.append(d)
+        return _Secret(d)
+
+    SecretNS.from_dict = staticmethod(_from_dict)
+    mod.Secret = SecretNS
+
+    # Sandbox.create.aio(**kwargs)
+    class SandboxNS:
+        created = []
+
+    async def _create(**kwargs):
+        sb = FakeSandbox(**kwargs)
+        SandboxNS.created.append(sb)
+        return sb
+
+    SandboxNS.create = _Aio(_create)
+    mod.Sandbox = SandboxNS
+
+    return mod
+
+
+@pytest.fixture(autouse=True)
+def fake_modal(monkeypatch):
+    """Install a fresh fake ``modal`` and isolate all backend env knobs."""
+    for var in (
+        "VIME_AGENT_SANDBOX_BACKEND",
+        "VIME_AGENT_SANDBOX_MODAL_APP",
+        "SWE_SANDBOX_MODAL_APP",
+        "VIME_AGENT_SANDBOX_MODAL_CPU",
+        "SWE_SANDBOX_MODAL_CPU",
+        "VIME_AGENT_SANDBOX_MODAL_MEMORY_MB",
+        "SWE_SANDBOX_MODAL_MEMORY_MB",
+        "VIME_AGENT_SANDBOX_MODAL_BLOCK_NETWORK",
+        "SWE_SANDBOX_MODAL_BLOCK_NETWORK",
+        "VIME_AGENT_SANDBOX_MODAL_MAX_OUTPUT_BYTES",
+        "SWE_SANDBOX_MODAL_MAX_OUTPUT_BYTES",
+        "VIME_AGENT_SANDBOX_LIFETIME_SEC",
+        "SWE_SANDBOX_LIFETIME_SEC",
+        "DOCKER_USERNAME",
+        "DOCKER_PASSWORD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    mod = _make_fake_modal()
+    monkeypatch.setitem(sys.modules, "modal", mod)
+    monkeypatch.setitem(sys.modules, "modal.exception", mod.exception)
+    return mod
+
+
+def _import_sandbox_module():
+    import vime.agent.sandbox as s
+
+    return s
+
+
+async def _entered(image="ghcr.io/x/img:latest", **kwargs):
+    s = _import_sandbox_module()
+    ms = s.ModalSandbox(image, **kwargs)
+    await ms.__aenter__()
+    return ms
+
+
+# ---------------------------------------------------------------------------
+# Protocol + construction
+# ---------------------------------------------------------------------------
+def test_protocol_conformance():
+    s = _import_sandbox_module()
+    ms = s.ModalSandbox("img:latest")
+    assert isinstance(ms, s.Sandbox)  # runtime_checkable Protocol
+    assert ms.sandbox_id == ""
+
+
+def test_init_defaults():
+    s = _import_sandbox_module()
+    ms = s.ModalSandbox("img:latest")
+    assert ms.timeout == 3600
+    assert ms.app_name == "vime-coding-agent-sandbox"
+    assert ms.cpu == 2.0
+    assert ms.memory_mb == 8192
+    assert ms.block_network is False
+    assert ms.max_output_bytes == 0
+
+
+def test_init_env_overrides(monkeypatch):
+    monkeypatch.setenv("VIME_AGENT_SANDBOX_MODAL_APP", "my-app")
+    monkeypatch.setenv("VIME_AGENT_SANDBOX_MODAL_CPU", "4")
+    monkeypatch.setenv("VIME_AGENT_SANDBOX_MODAL_MEMORY_MB", "16384")
+    monkeypatch.setenv("VIME_AGENT_SANDBOX_MODAL_BLOCK_NETWORK", "true")
+    monkeypatch.setenv("VIME_AGENT_SANDBOX_MODAL_MAX_OUTPUT_BYTES", "1024")
+    monkeypatch.setenv("VIME_AGENT_SANDBOX_LIFETIME_SEC", "900")
+    s = _import_sandbox_module()
+    ms = s.ModalSandbox("img:latest")
+    assert ms.app_name == "my-app"
+    assert ms.cpu == 4.0
+    assert ms.memory_mb == 16384
+    assert ms.block_network is True
+    assert ms.max_output_bytes == 1024
+    assert ms.timeout == 900
+
+
+def test_init_kwarg_overrides_win_over_env(monkeypatch):
+    monkeypatch.setenv("VIME_AGENT_SANDBOX_MODAL_CPU", "4")
+    s = _import_sandbox_module()
+    ms = s.ModalSandbox("img:latest", cpu=8.0, memory_mb=2048, timeout=120, block_network=True, app_name="kw")
+    assert ms.cpu == 8.0
+    assert ms.memory_mb == 2048
+    assert ms.timeout == 120
+    assert ms.block_network is True
+    assert ms.app_name == "kw"
+
+
+def test_swe_fallback_env(monkeypatch):
+    monkeypatch.setenv("SWE_SANDBOX_MODAL_CPU", "3")
+    monkeypatch.setenv("SWE_SANDBOX_LIFETIME_SEC", "1234")
+    s = _import_sandbox_module()
+    ms = s.ModalSandbox("img:latest")
+    assert ms.cpu == 3.0
+    assert ms.timeout == 1234
+
+
+# ---------------------------------------------------------------------------
+# __aenter__ / image / app / create
+# ---------------------------------------------------------------------------
+@aiotest
+async def test_aenter_creates_and_sets_id(fake_modal):
+    ms = await _entered(image="ghcr.io/epoch-research/swe-bench.eval.x86_64.foo:latest", cpu=2.0, memory_mb=8192)
+    # App.lookup(create_if_missing=True)
+    assert len(fake_modal.App.lookups) == 1
+    assert fake_modal.App.lookups[0].create_if_missing is True
+    # Image.from_registry(tag)
+    assert fake_modal.Image.calls[-1][0] == "ghcr.io/epoch-research/swe-bench.eval.x86_64.foo:latest"
+    # Sandbox.create kwargs
+    sb = fake_modal.Sandbox.created[-1]
+    assert sb.create_kwargs["cpu"] == 2.0
+    assert sb.create_kwargs["memory"] == 8192
+    assert sb.create_kwargs["timeout"] == 3600
+    assert sb.create_kwargs["block_network"] is False
+    assert sb.create_kwargs["image"] is not None
+    assert sb.create_kwargs["app"] is not None
+    # sandbox_id reflects object_id
+    assert ms.sandbox_id == "sb-fake-0001"
+
+
+@aiotest
+async def test_aenter_public_image_no_secret(fake_modal):
+    await _entered()
+    assert fake_modal.Secret.created == []  # no DOCKER_* -> no registry secret
+    assert fake_modal.Image.calls[-1][1] is None  # secret arg None
+
+
+@aiotest
+async def test_aenter_private_registry_secret(fake_modal, monkeypatch):
+    monkeypatch.setenv("DOCKER_USERNAME", "alice")
+    monkeypatch.setenv("DOCKER_PASSWORD", "s3cr3t")
+    await _entered()
+    assert fake_modal.Secret.created, "expected a registry secret to be built"
+    d = fake_modal.Secret.created[-1]
+    assert d == {"REGISTRY_USERNAME": "alice", "REGISTRY_PASSWORD": "s3cr3t"}
+    assert fake_modal.Image.calls[-1][1] is not None  # secret passed to from_registry
+
+
+# ---------------------------------------------------------------------------
+# exec: user emulation + env + return + check + cap + timeout
+# ---------------------------------------------------------------------------
+@aiotest
+async def test_exec_root_argv_and_return(fake_modal):
+    ms = await _entered()
+    ms._sb.next_stdout, ms._sb.next_stderr, ms._sb.next_rc = "hello", "warn", 0
+    rc, out, err = await ms.exec("echo hi")
+    assert (rc, out, err) == (0, "hello", "warn")
+    argv, kwargs = ms._sb.exec_calls[-1]
+    assert argv == ("bash", "-lc", "echo hi")
+    assert kwargs["env"] is None
+    assert kwargs["timeout"] == 120
+
+
+@aiotest
+async def test_exec_root_with_env_passed(fake_modal):
+    ms = await _entered()
+    env = {"ANTHROPIC_BASE_URL": "http://x", "ANTHROPIC_AUTH_TOKEN": "tok"}
+    await ms.exec("claude --version", env=env, timeout=30)
+    argv, kwargs = ms._sb.exec_calls[-1]
+    assert argv == ("bash", "-lc", "claude --version")
+    assert kwargs["env"] == env
+    assert kwargs["timeout"] == 30
+
+
+@aiotest
+async def test_exec_nonroot_wraps_with_runuser(fake_modal):
+    ms = await _entered()
+    await ms.exec("git diff", user="agent")
+    argv, kwargs = ms._sb.exec_calls[-1]
+    assert argv == ("runuser", "-u", "agent", "--", "bash", "-lc", "git diff")
+    assert kwargs["env"] is None
+
+
+@aiotest
+async def test_exec_nonroot_with_env_whitelists_keys(fake_modal):
+    ms = await _entered()
+    env = {"A": "1", "B": "2"}
+    await ms.exec("run", user="agent", env=env)
+    argv, kwargs = ms._sb.exec_calls[-1]
+    assert argv[0:3] == ("runuser", "-u", "agent")
+    assert argv[3] == "--whitelist-environment=A,B"
+    assert argv[4:] == ("--", "bash", "-lc", "run")
+    assert kwargs["env"] == env
+
+
+@aiotest
+async def test_exec_check_raises_on_nonzero(fake_modal):
+    ms = await _entered()
+    ms._sb.next_rc, ms._sb.next_stderr = 2, "boom"
+    with pytest.raises(RuntimeError) as ei:
+        await ms.exec("false", check=True)
+    assert "exit=2" in str(ei.value)
+
+
+@aiotest
+async def test_exec_check_ok_on_zero(fake_modal):
+    ms = await _entered()
+    ms._sb.next_rc = 0
+    rc, _, _ = await ms.exec("true", check=True)
+    assert rc == 0
+
+
+@aiotest
+async def test_exec_no_check_returns_nonzero(fake_modal):
+    ms = await _entered()
+    ms._sb.next_rc = 7
+    rc, _, _ = await ms.exec("maybe-fails", check=False)
+    assert rc == 7
+
+
+@aiotest
+async def test_exec_output_capping(fake_modal):
+    ms = await _entered(max_output_bytes=10)
+    ms._sb.next_stdout = "x" * 50
+    _, out, _ = await ms.exec("spew")
+    assert out.startswith("x" * 10)
+    assert "truncated" in out
+
+
+@aiotest
+async def test_exec_no_cap_by_default(fake_modal):
+    ms = await _entered()  # max_output_bytes == 0 -> unlimited (mirror E2B)
+    ms._sb.next_stdout = "y" * 5000
+    _, out, _ = await ms.exec("spew")
+    assert out == "y" * 5000
+
+
+@aiotest
+async def test_exec_timeout_noncheck_returns_sentinel(fake_modal):
+    ms = await _entered()
+    ms._sb.raise_timeout = True
+    rc, out, err = await ms.exec("sleep 999", timeout=1, check=False)
+    assert rc == -1
+    assert out == ""
+    assert "timeout" in err
+
+
+@aiotest
+async def test_exec_timeout_check_raises(fake_modal):
+    ms = await _entered()
+    ms._sb.raise_timeout = True
+    with pytest.raises(RuntimeError) as ei:
+        await ms.exec("sleep 999", timeout=1, check=True)
+    assert "timed out" in str(ei.value)
+
+
+# Modal 1.4.2 does NOT raise on a per-exec timeout; wait() returns rc == -1
+# (verified on real Modal). These cover that real path, not just the raise path.
+@aiotest
+async def test_exec_rc_minus1_noncheck_returns_timeout(fake_modal):
+    ms = await _entered()
+    ms._sb.next_rc = -1
+    ms._sb.next_stdout = ""
+    ms._sb.next_stderr = ""  # real Modal timeout yields empty streams + rc=-1
+    rc, out, err = await ms.exec("sleep 999", timeout=1, check=False)
+    assert rc == -1
+    assert "timeout" in err or "killed" in err
+
+
+@aiotest
+async def test_exec_rc_minus1_check_raises_as_timeout(fake_modal):
+    ms = await _entered()
+    ms._sb.next_rc = -1
+    with pytest.raises(RuntimeError) as ei:
+        await ms.exec("sleep 999", timeout=1, check=True)
+    msg = str(ei.value)
+    assert "timed out" in msg or "killed" in msg
+
+
+# ---------------------------------------------------------------------------
+# write_file: str / bytes / host Path, mkdir+cat, eof, chown
+# ---------------------------------------------------------------------------
+@aiotest
+async def test_write_file_str_root_no_chown(fake_modal):
+    ms = await _entered()
+    await ms.write_file("/workspace/PROBLEM_STATEMENT.md", "hello world")
+    # exactly one exec (the create); no chown because user == root
+    assert len(ms._sb.exec_calls) == 1
+    argv, kwargs = ms._sb.exec_calls[0]
+    assert argv[0:2] == ("bash", "-lc")
+    assert "mkdir -p" in argv[2] and "cat >" in argv[2]
+    assert "/workspace/PROBLEM_STATEMENT.md" in argv[2]
+    assert kwargs["text"] is False  # binary stdin
+    assert b"".join(ms._sb.stdin_writes) == b"hello world"
+    assert ms._sb.stdin_eof is True
+
+
+@aiotest
+async def test_write_file_bytes(fake_modal):
+    ms = await _entered()
+    await ms.write_file("/tmp/blob.bin", b"\x00\x01\x02\xff")
+    assert b"".join(ms._sb.stdin_writes) == b"\x00\x01\x02\xff"
+    assert ms._sb.stdin_eof is True
+
+
+@aiotest
+async def test_write_file_host_path_streams_chunks(fake_modal, tmp_path):
+    # 5 MiB host file -> multiple 2 MiB stdin chunks streamed verbatim.
+    payload = bytes(range(256)) * (5 * 1024 * 1024 // 256)
+    host = tmp_path / "node22.tar"
+    host.write_bytes(payload)
+    ms = await _entered()
+    await ms.write_file("/tmp/node22.tar", host)
+    assert len(ms._sb.stdin_writes) >= 2  # streamed in chunks, not one shot
+    assert b"".join(ms._sb.stdin_writes) == payload
+    assert ms._sb.stdin_eof is True
+
+
+@aiotest
+async def test_write_file_chowns_for_nonroot_user(fake_modal):
+    ms = await _entered()
+    await ms.write_file("/home/agent/.cagent_run.sh", "#!/bin/bash\n", user="agent")
+    # create exec + chown exec
+    assert len(ms._sb.exec_calls) == 2
+    chown_argv, _ = ms._sb.exec_calls[1]
+    assert chown_argv == ("bash", "-lc", "chown agent:agent /home/agent/.cagent_run.sh")
+
+
+@aiotest
+async def test_write_file_nonzero_raises_oserror(fake_modal):
+    ms = await _entered()
+    ms._sb.next_rc = 1  # the cat command "fails"
+    with pytest.raises(OSError):
+        await ms.write_file("/root/denied", "x")
+
+
+# ---------------------------------------------------------------------------
+# read_file
+# ---------------------------------------------------------------------------
+@aiotest
+async def test_read_file_success(fake_modal):
+    ms = await _entered()
+    ms._sb.next_rc, ms._sb.next_stdout = 0, '{"tests": []}'
+    out = await ms.read_file("/workspace/swepro_eval/result.json", user="agent")
+    assert out == '{"tests": []}'
+    argv, _ = ms._sb.exec_calls[-1]
+    # read runs as the requested user via runuser, cat-ing the path
+    assert argv[0:3] == ("runuser", "-u", "agent")
+    assert "cat --" in argv[-1]
+
+
+@aiotest
+async def test_read_file_failure_returns_empty(fake_modal):
+    ms = await _entered()
+    ms._sb.next_rc = 1  # cat fails (missing file)
+    out = await ms.read_file("/nope")
+    assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# __aexit__ cleanup (always terminate)
+# ---------------------------------------------------------------------------
+@aiotest
+async def test_aexit_terminates(fake_modal):
+    ms = await _entered()
+    sb = ms._sb
+    await ms.__aexit__(None, None, None)
+    assert sb.terminated is True
+    assert ms._sb is None
+
+
+@aiotest
+async def test_aexit_safe_without_sandbox(fake_modal):
+    s = _import_sandbox_module()
+    ms = s.ModalSandbox("img:latest")  # never entered
+    await ms.__aexit__(None, None, None)  # must not raise
+
+
+@aiotest
+async def test_async_context_manager_roundtrip(fake_modal):
+    s = _import_sandbox_module()
+    async with s.ModalSandbox("img:latest") as ms:
+        assert ms.sandbox_id == "sb-fake-0001"
+        sb = ms._sb
+    assert sb.terminated is True
+
+
+# ---------------------------------------------------------------------------
+# make_sandbox() factory
+# ---------------------------------------------------------------------------
+def _import_factory():
+    import examples.coding_agent_rl.sandbox as cas
+
+    return cas
+
+
+def test_factory_default_is_e2b():
+    cas = _import_factory()
+    s = _import_sandbox_module()
+    assert isinstance(cas.make_sandbox("img:latest"), s.E2BSandbox)
+
+
+def test_factory_explicit_e2b(monkeypatch):
+    monkeypatch.setenv("VIME_AGENT_SANDBOX_BACKEND", "e2b")
+    cas = _import_factory()
+    s = _import_sandbox_module()
+    assert isinstance(cas.make_sandbox("img:latest"), s.E2BSandbox)
+
+
+def test_factory_modal(monkeypatch):
+    monkeypatch.setenv("VIME_AGENT_SANDBOX_BACKEND", "modal")
+    cas = _import_factory()
+    s = _import_sandbox_module()
+    assert isinstance(cas.make_sandbox("img:latest"), s.ModalSandbox)
+
+
+def test_factory_modal_case_insensitive(monkeypatch):
+    monkeypatch.setenv("VIME_AGENT_SANDBOX_BACKEND", "  MODAL ")
+    cas = _import_factory()
+    s = _import_sandbox_module()
+    assert isinstance(cas.make_sandbox("img:latest"), s.ModalSandbox)
+
+
+def test_factory_unknown_raises(monkeypatch):
+    monkeypatch.setenv("VIME_AGENT_SANDBOX_BACKEND", "podman")
+    cas = _import_factory()
+    with pytest.raises(ValueError):
+        cas.make_sandbox("img:latest")

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -150,6 +150,25 @@ def test_build_vllm_cmd_adds_sleep_mode_only_for_offload_rollout(vllm_args):
 
 
 @pytest.mark.unit
+def test_build_vllm_cmd_enables_prefix_cache_by_default(vllm_args):
+    server_args = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
+
+    cmd, _ = mod.build_vllm_cmd_and_env(server_args)
+
+    assert "--enable-prefix-caching" in cmd
+
+
+@pytest.mark.unit
+def test_build_vllm_cmd_honors_explicit_prefix_cache_disable(vllm_args):
+    vllm_args.vllm_enable_prefix_caching = False
+    server_args = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
+
+    cmd, _ = mod.build_vllm_cmd_and_env(server_args)
+
+    assert "--enable-prefix-caching" not in cmd
+
+
+@pytest.mark.unit
 def test_build_vllm_cmd_does_not_infer_sleep_mode_from_colocate(vllm_args):
     vllm_args.colocate = True
     vllm_args.offload_rollout = False

--- a/vime/agent/sandbox.py
+++ b/vime/agent/sandbox.py
@@ -13,6 +13,7 @@ import io
 import json
 import logging
 import os
+import shlex
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
@@ -279,3 +280,236 @@ class E2BSandbox:
             )
         except Exception:
             return ""
+
+
+# ---------------------------------------------------------------------------
+# Modal backend
+# ---------------------------------------------------------------------------
+# A second concrete Sandbox provider (alongside E2BSandbox) backed by
+# ``modal.Sandbox``. Selected at runtime by the coding-agent example's
+# ``make_sandbox()`` factory via ``VIME_AGENT_SANDBOX_BACKEND=modal``; the E2B
+# path is untouched when this backend is not selected.
+#
+# Reverse-network note: coding_agent_rl runs Claude Code *inside* the sandbox,
+# which dials back to the in-process Anthropic adapter on the training head
+# (``ANTHROPIC_BASE_URL=adapter_url``). Modal sandboxes have outbound internet
+# when ``block_network=False`` (the default here), so they can reach the head as
+# long as the adapter URL is publicly routable. On a private cluster, expose the
+# adapter's ``SHIM_PORT`` through a tunnel (e.g. cloudflared) and point
+# ``SLIME_HEAD_HOST`` / ``ADAPTER_URL_OVERRIDE`` at it. (Verified end-to-end:
+# a Modal sandbox successfully dialed back through a cloudflared tunnel.)
+#
+# Gap map vs E2B:
+#   * Modal exec has no ``user=`` -> emulate with ``runuser -u <user>``.
+#   * ``write_file`` streams str/bytes/host-Path over command stdin, then chowns.
+#   * Image comes from a registry tag (``Image.from_registry``), optionally with
+#     ``REGISTRY_USERNAME``/``REGISTRY_PASSWORD`` from DOCKER_* env for private
+#     registries.
+#   * Cleanup always reaches ``terminate`` (a leaked Modal sandbox counts against
+#     the account's concurrent-sandbox cap until its wall-clock timeout).
+
+_modal_app_env = ("VIME_AGENT_SANDBOX_MODAL_APP", "SWE_SANDBOX_MODAL_APP")
+_modal_cpu_env = ("VIME_AGENT_SANDBOX_MODAL_CPU", "SWE_SANDBOX_MODAL_CPU")
+_modal_memory_mb_env = ("VIME_AGENT_SANDBOX_MODAL_MEMORY_MB", "SWE_SANDBOX_MODAL_MEMORY_MB")
+_modal_block_network_env = ("VIME_AGENT_SANDBOX_MODAL_BLOCK_NETWORK", "SWE_SANDBOX_MODAL_BLOCK_NETWORK")
+_modal_max_output_bytes_env = ("VIME_AGENT_SANDBOX_MODAL_MAX_OUTPUT_BYTES", "SWE_SANDBOX_MODAL_MAX_OUTPUT_BYTES")
+
+_MODAL_WRITE_CHUNK = 2 * 1024 * 1024  # 2 MiB stdin chunks for host-Path uploads
+
+
+def _truthy(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+class ModalSandbox:
+    """Async context manager around ``modal.Sandbox``.
+
+    Mirrors :class:`E2BSandbox`'s public surface so the coding-agent example can
+    swap backends without touching its bootstrap / runner / evaluator code: same
+    ``__aenter__`` / ``__aexit__``, ``exec``, ``write_file``, ``read_file``, and
+    ``sandbox_id``. ``modal`` is imported lazily so importing this module never
+    requires the dependency unless the Modal backend is actually used.
+    """
+
+    # Shared lifetime env with E2BSandbox so run.sh sets one knob for both.
+    lifetime_sec_env = ("VIME_AGENT_SANDBOX_LIFETIME_SEC", "SWE_SANDBOX_LIFETIME_SEC")
+    default_lifetime_sec = 3600
+    default_app_name = "vime-coding-agent-sandbox"
+    default_cpu = 2.0
+    default_memory_mb = 8192
+
+    def __init__(
+        self,
+        image: str,
+        *,
+        timeout: int | None = None,
+        app_name: str | None = None,
+        cpu: float | None = None,
+        memory_mb: int | None = None,
+        block_network: bool | None = None,
+        max_output_bytes: int | None = None,
+    ) -> None:
+        self.image = image
+        self.timeout = int(timeout) if timeout is not None else self._lifetime_sec_from_env()
+        self.app_name = app_name or _getenv(*_modal_app_env, default=self.default_app_name)
+        self.cpu = float(cpu) if cpu is not None else float(_getenv(*_modal_cpu_env, default=str(self.default_cpu)))
+        self.memory_mb = (
+            int(memory_mb)
+            if memory_mb is not None
+            else int(_getenv(*_modal_memory_mb_env, default=str(self.default_memory_mb)))
+        )
+        if block_network is not None:
+            self.block_network = bool(block_network)
+        else:
+            self.block_network = _truthy(_getenv(*_modal_block_network_env, default="0"))
+        self.max_output_bytes = (
+            int(max_output_bytes)
+            if max_output_bytes is not None
+            else int(_getenv(*_modal_max_output_bytes_env, default="0"))
+        )
+        self._sb = None
+        self._app = None
+        self.sandbox_id = ""
+
+    @classmethod
+    def _lifetime_sec_from_env(cls) -> int:
+        return int(_getenv(*cls.lifetime_sec_env, default=str(cls.default_lifetime_sec)))
+
+    @staticmethod
+    def _registry_secret(modal):
+        """Build a private-registry Secret from DOCKER_* env, or None for public."""
+        user = os.environ.get("DOCKER_USERNAME")
+        pw = os.environ.get("DOCKER_PASSWORD")
+        if user and pw:
+            return modal.Secret.from_dict({"REGISTRY_USERNAME": user, "REGISTRY_PASSWORD": pw})
+        return None
+
+    async def __aenter__(self) -> ModalSandbox:
+        import modal
+
+        self._app = await modal.App.lookup.aio(self.app_name, create_if_missing=True)
+        secret = self._registry_secret(modal)
+        image = (
+            modal.Image.from_registry(self.image, secret=secret)
+            if secret is not None
+            else modal.Image.from_registry(self.image)
+        )
+        self._sb = await modal.Sandbox.create.aio(
+            image=image,
+            app=self._app,
+            cpu=self.cpu,
+            memory=self.memory_mb,
+            timeout=self.timeout,
+            block_network=self.block_network,
+        )
+        self.sandbox_id = self._sb.object_id
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        # Always reach terminate: a leaked sandbox counts against Modal's
+        # concurrent-sandbox cap until its wall-clock timeout fires.
+        if self._sb is not None:
+            try:
+                await self._sb.terminate.aio()
+            except Exception as e:
+                logger.warning("[agent.sandbox] modal terminate %s failed: %s", (self.sandbox_id or "")[:12], e)
+            finally:
+                self._sb = None
+
+    @staticmethod
+    def _build_argv(cmd: str, user: str, env: dict[str, str] | None) -> list[str]:
+        """argv for running ``cmd`` as ``user``. Modal has no user= on exec, so
+        non-root uses ``runuser``; env keys are whitelisted through so the target
+        user's shell still sees them (matches the E2B ``envs=`` semantics)."""
+        if user == "root":
+            return ["bash", "-lc", cmd]
+        argv = ["runuser", "-u", user]
+        if env:
+            argv.append("--whitelist-environment=" + ",".join(env.keys()))
+        argv += ["--", "bash", "-lc", cmd]
+        return argv
+
+    def _cap(self, text: str | None) -> str:
+        text = text or ""
+        if self.max_output_bytes and len(text) > self.max_output_bytes:
+            return text[: self.max_output_bytes] + f"\n<truncated; output exceeded {self.max_output_bytes} bytes>\n"
+        return text
+
+    async def exec(
+        self,
+        cmd: str,
+        *,
+        user: str = "root",
+        env: dict[str, str] | None = None,
+        timeout: int = 120,
+        check: bool = False,
+    ) -> ExecResult:
+        import modal
+
+        argv = self._build_argv(cmd, user, env)
+        proc = await self._sb.exec.aio(*argv, timeout=timeout, env=env or None)
+        try:
+            # Gather reads with wait so a chatty stream can't backpressure-stall
+            # the other before the process is reaped (matches Modal's own idiom).
+            out, err, rc = await asyncio.gather(proc.stdout.read.aio(), proc.stderr.read.aio(), proc.wait.aio())
+        except modal.exception.SandboxTimeoutError:
+            # Defensive: most Modal paths signal a per-exec timeout via rc == -1
+            # (handled below, no exception), but keep this for any that raise.
+            if check:
+                raise RuntimeError(f"modal exec timed out after {timeout}s: {cmd[:120]}") from None
+            return -1, "", f"<modal exec timeout after {timeout}s>"
+        rc = int(rc) if rc is not None else 0
+        out, err = self._cap(out), self._cap(err)
+        # Modal returns rc == -1 (no exception) when a per-exec timeout fires or
+        # the process is killed. Surface it as a clear timeout rather than a
+        # generic non-zero exit.
+        if rc == -1:
+            if check:
+                raise RuntimeError(f"modal exec timed out / was killed after {timeout}s: {cmd[:120]}")
+            return -1, out, err or f"<modal exec timeout/killed after {timeout}s>"
+        if check and rc != 0:
+            raise RuntimeError(f"modal exec failed (exit={rc}): {cmd[:120]}\n{err[:400]}")
+        return rc, out, err
+
+    async def write_file(self, sandbox_path: str, content: FileContent, *, user: str = "root") -> None:
+        directory = os.path.dirname(sandbox_path) or "."
+        create_cmd = f"mkdir -p {shlex.quote(directory)} && cat > {shlex.quote(sandbox_path)}"
+        # text=False -> binary stdin so host Paths / bytes stream verbatim.
+        proc = await self._sb.exec.aio("bash", "-lc", create_cmd, timeout=600, text=False)
+        try:
+            if isinstance(content, Path):
+                with open(content, "rb") as fp:
+                    while True:
+                        chunk = fp.read(_MODAL_WRITE_CHUNK)
+                        if not chunk:
+                            break
+                        proc.stdin.write(chunk)
+                        await proc.stdin.drain.aio()
+            else:
+                data = content.encode() if isinstance(content, str) else content
+                proc.stdin.write(data)
+                await proc.stdin.drain.aio()
+            proc.stdin.write_eof()
+            await proc.stdin.drain.aio()
+            # Drain stderr alongside wait so the write can't stall on a full
+            # stderr pipe, and so the failure message is preserved.
+            err_raw, rc = await asyncio.gather(proc.stderr.read.aio(), proc.wait.aio())
+        except Exception as e:
+            raise OSError(f"modal write_file({sandbox_path}) failed: {e!r}") from e
+        if rc != 0:
+            err_msg = (
+                err_raw.decode("utf-8", "replace") if isinstance(err_raw, (bytes, bytearray)) else str(err_raw or "")
+            )
+            raise OSError(f"modal write_file({sandbox_path}) exit={rc}: {err_msg[:300]}")
+        if user != "root":
+            crc, _, cerr = await self.exec(
+                f"chown {shlex.quote(user)}:{shlex.quote(user)} {shlex.quote(sandbox_path)}",
+                user="root",
+                check=False,
+            )
+            if crc != 0:
+                logger.warning("[agent.sandbox] modal chown %s -> %s failed: %s", sandbox_path, user, cerr[:200])
+
+    async def read_file(self, sandbox_path: str, *, user: str = "root") -> str:
+        rc, out, _ = await self.exec(f"cat -- {shlex.quote(sandbox_path)}", user=user, timeout=120, check=False)
+        return out if rc == 0 else ""

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -398,6 +398,9 @@ def build_vllm_cmd_and_env(server_args: dict[str, Any]) -> tuple[list[str], dict
     if getattr(args, "use_rollout_routing_replay", False):
         cmd += ["--enable-return-routed-experts"]
 
+    if getattr(args, "vllm_enable_prefix_caching", True) is not False:
+        cmd += ["--enable-prefix-caching"]
+
     # gpu_memory_utilization: no vime-forced default. In colocate, training and rollout do not
     # occupy the GPU simultaneously (sleep/offload cycles), so vLLM's own default is fine. A user
     # value passed via --vllm-gpu-memory-utilization is auto-forwarded by _forward_vllm_cli_args.


### PR DESCRIPTION
## What changed

- Restore default-on prefix caching in the vLLM launcher when the user does not explicitly disable it.
- Add unit coverage for the default-on and explicit-off cases.

## Why

The vLLM subprocess was being launched without `--enable-prefix-caching` on the default path, which let the engine start with APC disabled and produced 0% hit rate in multi-turn rollout.

## Validation

- `PYTHONPATH=/home/aoshen/vime/projects/vime_modal_sandbox/vime-arguments-fix pytest -q tests/unit/backends/vllm_utils/test_vllm_engine.py -q`
