### PR TITLE
[codex] fix vllm prefix caching defaults

### DIFF
--- a/tests/utils/test_vllm_engine.py
+++ b/tests/utils/test_vllm_engine.py
@@ -228,6 +228,25 @@ def test_build_vllm_cmd_adds_sleep_mode_only_for_offload_rollout(vllm_args):
 
 
 @pytest.mark.unit
+def test_build_vllm_cmd_enables_prefix_cache_by_default(vllm_args):
+    server_args = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
+
+    cmd, _ = mod.build_vllm_cmd_and_env(server_args)
+
+    assert "--enable-prefix-caching" in cmd
+
+
+@pytest.mark.unit
+def test_build_vllm_cmd_honors_explicit_prefix_cache_disable(vllm_args):
+    vllm_args.vllm_enable_prefix_caching = False
+    server_args = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
+
+    cmd, _ = mod.build_vllm_cmd_and_env(server_args)
+
+    assert "--enable-prefix-caching" not in cmd
+
+
+@pytest.mark.unit
 def test_build_vllm_cmd_does_not_infer_sleep_mode_from_colocate(vllm_args):
     vllm_args.colocate = True
     vllm_args.offload_rollout = False

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -400,6 +400,9 @@ def build_vllm_cmd_and_env(server_args: dict[str, Any]) -> tuple[list[str], dict
     if getattr(args, "use_rollout_routing_replay", False):
         cmd += ["--enable-return-routed-experts"]
 
+    if getattr(args, "vllm_enable_prefix_caching", True) is not False:
+        cmd += ["--enable-prefix-caching"]
+
     # gpu_memory_utilization: no vime-forced default. In colocate, training and rollout do not
     # occupy the GPU simultaneously (sleep/offload cycles), so vLLM's own default is fine. A user
     # value passed via --vllm-gpu-memory-utilization is auto-forwarded by _forward_vllm_cli_args.


### PR DESCRIPTION
## What changed

- Restore default-on prefix caching in the vLLM launcher when the user does not explicitly disable it.
- Add unit coverage for the default-on and explicit-off cases.

## Why

The vLLM subprocess was being launched without `--enable-prefix-caching` on the default path, which let the engine start with APC disabled and produced 0% hit rate in multi-turn rollout.

## Validation

- `PYTHONPATH=/home/aoshen/vime/projects/vime_modal_sandbox/vime-arguments-fix-clean pytest -q tests/utils/test_vllm_engine.py -q`
