### PR TITLE
refactor(vllm_engine): in-process launch + dataclass field introspection

### DIFF
--- a/tests/utils/test_vllm_arguments.py
+++ b/tests/utils/test_vllm_arguments.py
@@ -26,104 +26,6 @@ def args_mod():
     return mod
 
 
-@pytest.mark.unit
-def test_wrapper_prefixes_long_flag_real_parser(args_mod):
-    parser = argparse.ArgumentParser(add_help=False)
-    wrap = args_mod._make_add_argument_wrapper(parser.add_argument)
-    wrap("--gpu-memory-utilization", type=float, default=0.92)
-    parsed, _ = parser.parse_known_args(["--vllm-gpu-memory-utilization", "0.5"])
-    assert parsed.vllm_gpu_memory_utilization == 0.5
-
-
-@pytest.mark.unit
-def test_wrapper_prefixes_dest_real_parser(args_mod):
-    parser = argparse.ArgumentParser(add_help=False)
-    wrap = args_mod._make_add_argument_wrapper(parser.add_argument)
-    wrap("--foo", dest="foo", type=int, default=0)
-    parsed, _ = parser.parse_known_args(["--vllm-foo", "7"])
-    assert parsed.vllm_foo == 7
-
-
-@pytest.mark.unit
-def test_wrapper_no_double_prefix(args_mod):
-    parser = argparse.ArgumentParser(add_help=False)
-    wrap = args_mod._make_add_argument_wrapper(parser.add_argument)
-    wrap("--foo", dest="vllm_foo", type=int, default=0)
-    dests = {a.dest for a in parser._actions if a.option_strings}
-    assert "vllm_foo" in dests
-    assert "vllm_vllm_foo" not in dests
-
-
-@pytest.mark.unit
-def test_wrapper_skips_dest_listed_in_SKIPPED_DESTS(args_mod):
-    parser = argparse.ArgumentParser(add_help=False)
-    wrap = args_mod._make_add_argument_wrapper(parser.add_argument)
-    wrap("--tensor-parallel-size", type=int)
-    flags = {s for a in parser._actions for s in a.option_strings}
-    assert "--vllm-tensor-parallel-size" not in flags
-    assert "--tensor-parallel-size" not in flags
-
-
-@pytest.mark.unit
-def test_SKIPPED_DESTS_orchestrator_parallel_dims(args_mod):
-    """TP/multi-node dims are orchestrator-owned; PP/DP remain CLI-forwardable."""
-    assert "tensor_parallel_size" in args_mod.SKIPPED_DESTS
-    assert "pipeline_parallel_size" not in args_mod.SKIPPED_DESTS
-    assert "data_parallel_size" not in args_mod.SKIPPED_DESTS
-    assert "nnodes" in args_mod.SKIPPED_DESTS
-    assert "node_rank" in args_mod.SKIPPED_DESTS
-    assert "master_addr" in args_mod.SKIPPED_DESTS
-    assert "master_port" in args_mod.SKIPPED_DESTS
-    assert "data_parallel_backend" in args_mod.SKIPPED_DESTS
-    assert "distributed_executor_backend" in args_mod.SKIPPED_DESTS
-
-
-@pytest.mark.unit
-def test_detect_user_provided_value_form(args_mod):
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--foo", type=int, default=0)
-    user, raw = args_mod._detect_user_provided_dests(parser, ["--foo", "5"])
-    assert user == {"foo"}
-    assert raw == {"foo": "5"}
-
-
-@pytest.mark.unit
-def test_detect_user_provided_equals_form(args_mod):
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--bar", type=str, default="x")
-    user, raw = args_mod._detect_user_provided_dests(parser, ["--bar=hello"])
-    assert user == {"bar"}
-    assert raw == {"bar": "hello"}
-
-
-@pytest.mark.unit
-def test_detect_user_provided_omitted(args_mod):
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--baz", type=int, default=42)
-    user, raw = args_mod._detect_user_provided_dests(parser, ["--other", "1"])
-    assert "baz" not in user
-    assert "baz" not in raw
-
-
-@pytest.mark.unit
-def test_detect_user_provided_ignores_unregistered_flags(args_mod):
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--known", type=int)
-    user, raw = args_mod._detect_user_provided_dests(parser, ["--unknown", "v"])
-    assert user == set()
-    assert raw == {}
-
-
-@pytest.mark.unit
-def test_detect_user_provided_multiple(args_mod):
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--a", type=int, default=0)
-    parser.add_argument("--b", type=str, default="")
-    user, raw = args_mod._detect_user_provided_dests(parser, ["--a", "1", "--b=hello"])
-    assert user == {"a", "b"}
-    assert raw == {"a": "1", "b": "hello"}
-
-
 def _ns(**overrides):
     base = dict(
         vllm_data_parallel_size=1,
@@ -141,11 +43,6 @@ def test_validate_args_pp1(args_mod):
     args_mod.validate_args(ns)
     assert ns.vllm_pp_size == 1
     assert ns.vllm_dp_size == 1
-    # validate_args intentionally does NOT set a global ``vllm_tp_size`` anymore: a global TP
-    # (derived from the *global* rollout_num_gpus_per_engine) shadowed the per-engine value and
-    # broke heterogeneous per-group engines (the 300s "3/4 clients joined" rendezvous hang). TP is
-    # now derived per engine in vllm_engine._resolve_vllm_parallel_sizes (covered in
-    # test_vllm_engine.py::test_resolve_parallel_sizes_is_per_engine_not_global).
     assert not hasattr(ns, "vllm_tp_size")
 
 
@@ -162,9 +59,6 @@ def test_validate_args_records_pp_dp_but_no_global_tp(args_mod):
 
 @pytest.mark.unit
 def test_validate_args_no_longer_raises_on_pp_indivisible(args_mod):
-    # The pp-divisibility check moved out of validate_args and into the per-engine resolver
-    # (vllm_engine._resolve_vllm_parallel_sizes / compute_vllm_engine_topology), so validate_args
-    # itself is now agnostic to it. The enforcement is covered in test_vllm_engine.py.
     ns = _ns(vllm_pipeline_parallel_size=3, rollout_num_gpus_per_engine=4)
     args_mod.validate_args(ns)  # must not raise
     assert ns.vllm_pp_size == 3
@@ -250,53 +144,52 @@ def test_add_vllm_router_arguments_defaults_to_consistent_hash(args_mod):
     assert parsed.router_policy == "consistent_hash"
 
 
-@pytest.mark.unit
-def test_orchestration_dests_use_vllm_prefix(args_mod):
-    assert "vllm_router_ip" in args_mod._VIME_ORCHESTRATION_DESTS
-    assert "vllm_router_port" in args_mod._VIME_ORCHESTRATION_DESTS
-    assert "router_request_timeout_secs" in args_mod._VIME_ORCHESTRATION_DESTS
-    assert "router_ip" not in args_mod._VIME_ORCHESTRATION_DESTS
-    assert "router_port" not in args_mod._VIME_ORCHESTRATION_DESTS
-    assert "vllm_router_request_timeout_secs" not in args_mod._VIME_ORCHESTRATION_DESTS
+def _patch_device_config(monkeypatch):
+    """Patch DeviceConfig.__post_init__ to avoid GPU device detection on CPU CI."""
+    try:
+        from vllm.config.device import DeviceConfig
 
-
-def _realistic_add_vllm_arguments(parser):
-    parser.add_argument("--vllm-gpu-memory-utilization", dest="vllm_gpu_memory_utilization", type=float, default=0.92)
-    parser.add_argument("--vllm-enforce-eager", dest="vllm_enforce_eager", action="store_true", default=False)
-    parser.add_argument("--vllm-router-ip", dest="vllm_router_ip", type=str, default=None)
-    parser.add_argument("--vllm-router-port", dest="vllm_router_port", type=int, default=None)
-    parser.add_argument("--vllm-server-concurrency", dest="vllm_server_concurrency", type=int, default=512)
-    return parser
+        monkeypatch.setattr(DeviceConfig, "__post_init__", lambda self: setattr(self, "device_type", "cpu"))
+    except ImportError:
+        pass
 
 
 @pytest.mark.unit
-def test_action_table_caches(args_mod, monkeypatch):
-    monkeypatch.setattr(args_mod, "_VLLM_CLI_ACTION_TABLE_CACHE", None)
-    monkeypatch.setattr(args_mod, "add_vllm_arguments", _realistic_add_vllm_arguments)
-    t1 = args_mod.get_vllm_cli_action_table()
-    t2 = args_mod.get_vllm_cli_action_table()
-    assert t1 is t2
+def test_add_vllm_arguments_prefixes_regular_engine_flags(args_mod, monkeypatch):
+    _patch_device_config(monkeypatch)
+    parser = argparse.ArgumentParser(add_help=False)
+    args_mod.add_vllm_arguments(parser)
+    flags = {s for a in parser._actions for s in a.option_strings}
+    assert "--vllm-server-concurrency" in flags
+    assert "--vllm-tool-call-parser" in flags
+    assert "--vllm-weight-sync-packed" in flags
 
 
 @pytest.mark.unit
-def test_action_table_excludes_orchestration(args_mod, monkeypatch):
-    monkeypatch.setattr(args_mod, "_VLLM_CLI_ACTION_TABLE_CACHE", None)
-    monkeypatch.setattr(args_mod, "add_vllm_arguments", _realistic_add_vllm_arguments)
-    table = args_mod.get_vllm_cli_action_table()
-    assert "vllm_gpu_memory_utilization" in table
-    assert "vllm_enforce_eager" in table
-    assert "vllm_router_ip" not in table
-    assert "vllm_router_port" not in table
-    assert "vllm_server_concurrency" not in table
+def test_add_vllm_arguments_skips_orchestrator_owned_fields(args_mod, monkeypatch):
+    _patch_device_config(monkeypatch)
+    parser = argparse.ArgumentParser(add_help=False)
+    args_mod.add_vllm_arguments(parser)
+    flags = {s for a in parser._actions for s in a.option_strings}
+    dests = {a.dest for a in parser._actions if a.option_strings}
+    assert "--vllm-seed" not in flags
+    assert "--vllm-host" not in flags
+    assert "--vllm-master-addr" not in flags
+    assert "--vllm-tensor-parallel-size" not in flags
+    assert "seed" not in dests
+    assert "host" not in dests
+    assert "master_addr" not in dests
+    assert "tensor_parallel_size" not in dests
 
 
 @pytest.mark.unit
-def test_action_table_flag_format(args_mod, monkeypatch):
-    monkeypatch.setattr(args_mod, "_VLLM_CLI_ACTION_TABLE_CACHE", None)
-    monkeypatch.setattr(args_mod, "add_vllm_arguments", _realistic_add_vllm_arguments)
-    table = args_mod.get_vllm_cli_action_table()
-    flag, _action = table["vllm_gpu_memory_utilization"]
-    assert flag == "--gpu-memory-utilization"
+def test_add_vllm_arguments_parses_prefixed_engine_values(args_mod, monkeypatch):
+    _patch_device_config(monkeypatch)
+    parser = argparse.ArgumentParser(add_help=False)
+    args_mod.add_vllm_arguments(parser)
+    parsed, _ = parser.parse_known_args(["--vllm-server-concurrency", "128", "--vllm-tool-call-parser", "qwen3_coder"])
+    assert parsed.vllm_server_concurrency == 128
+    assert parsed.vllm_tool_call_parser == "qwen3_coder"
 
 
 @pytest.mark.unit
@@ -317,19 +210,6 @@ def test_parse_args_tp_default_with_pp(args_mod, monkeypatch):
     )
     ns = args_mod.vllm_parse_args()
     assert ns.vllm_tensor_parallel_size == 2
-
-
-@pytest.mark.unit
-def test_parse_args_records_user_provided(args_mod, monkeypatch):
-    def stub(parser):
-        parser.add_argument("--vllm-foo", dest="vllm_foo", type=int, default=0)
-        return parser
-
-    monkeypatch.setattr(args_mod, "add_vllm_arguments", stub)
-    monkeypatch.setattr(sys, "argv", ["train.py", "--vllm-foo", "7"])
-    ns = args_mod.vllm_parse_args()
-    assert "vllm_foo" in ns._vllm_user_provided
-    assert ns._vllm_raw_values["vllm_foo"] == "7"
 
 
 @pytest.mark.unit
@@ -385,6 +265,27 @@ def test_parse_args_tp_default_dp1_unchanged(args_mod, monkeypatch):
     )
     ns = args_mod.vllm_parse_args()
     assert ns.vllm_tensor_parallel_size == 4  # 4 / (1 * 1) = 4
+
+
+@pytest.mark.unit
+def test_validate_args_rejects_conflicting_rollout_external_and_vllm_config(args_mod):
+    ns = _ns(rollout_external=True, vllm_config="/tmp/vllm.yaml")
+    with pytest.raises(AssertionError, match="vllm_config cannot be set"):
+        args_mod.validate_args(ns)
+
+
+@pytest.mark.unit
+def test_validate_args_rejects_conflicting_prefill_and_vllm_config(args_mod):
+    ns = _ns(prefill_num_servers=2, vllm_config="/tmp/vllm.yaml")
+    with pytest.raises(AssertionError, match="mutually exclusive"):
+        args_mod.validate_args(ns)
+
+
+@pytest.mark.unit
+def test_validate_args_rejects_prefill_and_rollout_external(args_mod):
+    ns = _ns(prefill_num_servers=2, rollout_external=True)
+    with pytest.raises(AssertionError, match="cannot be set"):
+        args_mod.validate_args(ns)
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_vllm_engine.py
+++ b/tests/utils/test_vllm_engine.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import dataclasses
 import json
 import sys
 from pathlib import Path
@@ -40,6 +39,13 @@ def vllm_args() -> SimpleNamespace:
         use_critic=False,
         critic_num_gpus_per_node=0,
         critic_num_nodes=0,
+        seed=1234,
+        fp16=False,
+        offload_rollout=False,
+        use_rollout_routing_replay=False,
+        vllm_pipeline_parallel_size=1,
+        vllm_data_parallel_size=1,
+        vllm_dp_size=1,
     )
 
 
@@ -48,30 +54,10 @@ def vllm_engine(vllm_args):
     from vime.backends.vllm_utils.vllm_engine import VLLMEngine
 
     engine = VLLMEngine(vllm_args, rank=0)
+    engine.node_rank = 0
     engine.server_host = "127.0.0.1"
     engine.server_port = 8765
     return engine
-
-
-@pytest.fixture(autouse=True)
-def _seed_vllm_cli_action_table_cache():
-    """Skip the device-probing rebuild of the vLLM CLI action table on CPU.
-
-    ``get_vllm_cli_action_table()`` builds its table via ``AsyncEngineArgs.add_cli_args``,
-    which probes the accelerator and raises ``RuntimeError: Failed to infer device type``
-    on a GPU-less host. The table only drives which ``vllm_*`` values are forwarded to the
-    ``vllm serve`` subprocess; the cmd/topology/sleep-mode assertions in this module exercise
-    vime's own explicit flag logic, not forwarding. Seed an empty (already-built) cache so the
-    rebuild is skipped, and restore the original on teardown so we never leak across modules.
-    """
-    import vime.backends.vllm_utils.arguments as _args
-
-    saved = _args._VLLM_CLI_ACTION_TABLE_CACHE
-    _args._VLLM_CLI_ACTION_TABLE_CACHE = {}
-    try:
-        yield
-    finally:
-        _args._VLLM_CLI_ACTION_TABLE_CACHE = saved
 
 
 class _MockResponse:
@@ -107,92 +93,156 @@ def test_normalize_vllm_wake_tags_empty_becomes_none():
 
 
 @pytest.mark.unit
-def test_format_v6_uri_wraps_ipv6():
-    assert mod._format_v6_uri("2001:db8::1") == "[2001:db8::1]"
-
-
-@pytest.mark.unit
-def test_format_v6_uri_ipv4_unchanged():
-    assert mod._format_v6_uri("10.0.0.1") == "10.0.0.1"
-
-
-@pytest.mark.unit
-def test_compute_vllm_engine_topology_single_node(vllm_args):
+def test_launch_config_single_node(vllm_args):
     vllm_args.num_gpus_per_node = 8
     vllm_args.rollout_num_gpus_per_engine = 4
     vllm_args.vllm_pipeline_parallel_size = 1
-    vllm_args.vllm_tp_size = 4
-    topo = mod.compute_vllm_engine_topology(vllm_args, global_rank=0)
-    assert topo.nnodes == 1
-    assert topo.node_rank == 0
-    assert topo.local_num_gpus == 4
-    assert not topo.multi_node
-    assert not topo.headless
+    sa, _ = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
+    assert sa["nnodes"] == 1
+    assert sa["node_rank"] == 0
+    assert sa["_tp_size"] == 4
 
 
 @pytest.mark.unit
-def test_compute_vllm_engine_topology_multi_node_ranks(vllm_args):
+def test_compute_server_args_preserves_non_topology_vllm_flags(vllm_args, monkeypatch):
+    monkeypatch.setattr(mod, "_VLLM_SERVER_FIELDS", frozenset({"server_concurrency", "tool_call_parser"}))
+    vllm_args.vllm_server_concurrency = 256
+    vllm_args.vllm_tool_call_parser = "qwen3_coder"
+    sa, _ = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
+    assert sa["server_concurrency"] == 256
+    assert sa["tool_call_parser"] == "qwen3_coder"
+
+
+@pytest.mark.unit
+def test_compute_server_args_ignores_unrecognized_vllm_attrs(vllm_args, monkeypatch):
+    monkeypatch.setattr(mod, "_VLLM_SERVER_FIELDS", frozenset({"server_concurrency"}))
+    vllm_args.vllm_nonexistent_flag = "keep-out"
+    sa, _ = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
+    assert "nonexistent_flag" not in sa
+
+
+@pytest.mark.unit
+def test_launch_config_multi_node_ranks(vllm_args):
     vllm_args.num_gpus_per_node = 8
     vllm_args.rollout_num_gpus_per_engine = 16
     vllm_args.vllm_pipeline_parallel_size = 2
-    vllm_args.vllm_tp_size = 8
-    topo0 = mod.compute_vllm_engine_topology(vllm_args, global_rank=0)
-    topo1 = mod.compute_vllm_engine_topology(vllm_args, global_rank=1)
-    assert topo0.nnodes == 2
-    assert topo0.node_rank == 0
-    assert topo1.node_rank == 1
-    assert topo0.local_num_gpus == 8
-    assert topo0.headless is False
-    assert topo1.headless is True
+    sa0, _ = mod._compute_server_args(vllm_args, rank=0, dist_init_addr="10.0.0.1:15000", host="10.0.0.1", port=8000)
+    sa1, _ = mod._compute_server_args(vllm_args, rank=1, dist_init_addr="10.0.0.1:15000", host="10.0.0.2", port=8000)
+    assert sa0["nnodes"] == 2
+    assert sa0["node_rank"] == 0
+    assert sa1["node_rank"] == 1
 
 
 @pytest.mark.unit
-def test_append_distributed_flags_only_when_multi_node(vllm_args):
-    cmd: list[str] = ["vllm", "serve"]
-    single = mod.VllmEngineTopology(
-        nnodes=1,
-        node_rank=0,
-        local_num_gpus=4,
-        tensor_parallel_size=4,
-        pipeline_parallel_size=1,
-    )
-    mod.append_vllm_distributed_launch_flags(cmd, single, ("10.0.0.1", 15000), vllm_args)
-    assert cmd == ["vllm", "serve"]
+def test_distributed_flags_only_when_multi_node(vllm_args):
+    vllm_args.num_gpus_per_node = 8
+    vllm_args.rollout_num_gpus_per_engine = 4
+    vllm_args.vllm_pipeline_parallel_size = 1
+    sa, _ = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
+    assert "master_addr" not in sa
 
-    cmd_multi: list[str] = ["vllm", "serve"]
-    multi = mod.VllmEngineTopology(
-        nnodes=2,
-        node_rank=1,
-        local_num_gpus=8,
-        tensor_parallel_size=8,
-        pipeline_parallel_size=2,
+    vllm_args.rollout_num_gpus_per_engine = 16
+    vllm_args.vllm_pipeline_parallel_size = 2
+    sa_multi, _ = mod._compute_server_args(
+        vllm_args, rank=1, dist_init_addr="10.0.0.2:16000", host="10.0.0.2", port=8000
     )
-    mod.append_vllm_distributed_launch_flags(cmd_multi, multi, ("10.0.0.2", 16000), vllm_args)
-    assert "--nnodes" in cmd_multi
-    assert "--node-rank" in cmd_multi
-    assert "1" in cmd_multi
-    assert "--headless" in cmd_multi
-    assert "--master-addr" in cmd_multi
-    assert "10.0.0.2" in cmd_multi
-    assert cmd_multi[cmd_multi.index("--data-parallel-backend") + 1] == "mp"
-    assert cmd_multi[cmd_multi.index("--distributed-executor-backend") + 1] == "mp"
+    assert sa_multi["nnodes"] == 2
+    assert sa_multi["node_rank"] == 1
+    assert sa_multi["master_addr"] == "10.0.0.2"
+    assert sa_multi.get("headless") is True
+    assert sa_multi.get("data_parallel_backend") == "mp"
+    assert sa_multi.get("distributed_executor_backend") == "mp"
 
 
 @pytest.mark.unit
-def test_parse_dist_init_addr_ipv6():
-    host, port = mod.parse_dist_init_addr("[2001:db8::1]:15000")
-    assert host == "2001:db8::1"
-    assert port == 15000
+def test_compute_server_args_applies_worker_type_and_bootstrap_port(vllm_args):
+    sa_prefill, _ = mod._compute_server_args(
+        vllm_args,
+        rank=0,
+        dist_init_addr=None,
+        host="127.0.0.1",
+        port=8000,
+        worker_type="prefill",
+        disaggregation_bootstrap_port=12345,
+    )
+    assert sa_prefill["disaggregation_mode"] == "prefill"
+
+    sa_decode, _ = mod._compute_server_args(
+        vllm_args,
+        rank=0,
+        dist_init_addr=None,
+        host="127.0.0.1",
+        port=8000,
+        worker_type="decode",
+    )
+    assert sa_decode["disaggregation_mode"] == "decode"
+
+
+@pytest.mark.unit
+def test_compute_server_args_prefill_requires_bootstrap_port(vllm_args):
+    with pytest.raises(AssertionError, match="disaggregation_bootstrap_port"):
+        mod._compute_server_args(
+            vllm_args,
+            rank=0,
+            dist_init_addr=None,
+            host="127.0.0.1",
+            port=8000,
+            worker_type="prefill",
+        )
+
+
+@pytest.mark.unit
+def test_compute_server_args_applies_rollout_and_dtype_flags(vllm_args):
+    vllm_args.use_rollout_routing_replay = True
+    vllm_args.fp16 = True
+    sa, _ = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
+    assert sa["enable_return_routed_experts"] is True
+    assert sa["dtype"] == "float16"
+
+
+@pytest.mark.unit
+def test_compute_server_args_applies_max_model_len_from_rollout_context(vllm_args):
+    vllm_args.rollout_max_context_len = 8192
+    vllm_args.vllm_max_model_len = None
+    sa, _ = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
+    assert sa["max_model_len"] == 8192
+
+
+@pytest.mark.unit
+def test_compute_server_args_model_path_override_wins(vllm_args, monkeypatch):
+    monkeypatch.setattr(mod, "_VLLM_SERVER_FIELDS", frozenset({"model", "server_concurrency"}))
+    sa, _ = mod._compute_server_args(
+        vllm_args,
+        rank=0,
+        dist_init_addr=None,
+        host="127.0.0.1",
+        port=8000,
+        vllm_overrides={"model_path": "/tmp/override", "server-concurrency": 123},
+    )
+    assert sa["model"] == "/tmp/override"
+    assert sa["server_concurrency"] == 123
+
+
+@pytest.mark.unit
+def test_compute_server_args_external_check_fields_skip_orchestration_fields(vllm_args):
+    sa, check_fields = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
+    assert "model" not in check_fields
+    assert "host" not in check_fields
+    assert "port" not in check_fields
+    assert "nnodes" in check_fields
+    assert "node_rank" in check_fields
+    assert "weight_transfer_config" in check_fields
+    assert sa["weight_transfer_config"] == {"backend": "nccl"}
 
 
 @pytest.mark.unit
 def test_build_vllm_subprocess_env_colocate(vllm_args, monkeypatch):
     vllm_args.colocate = True
     monkeypatch.delenv("PYTHONPATH", raising=False)
-    env = mod.build_vllm_subprocess_env(
+    env = mod._build_subprocess_env(
         {
-            "args": vllm_args,
-            "visible_devices": "0,1",
+            "_args": vllm_args,
+            "_visible_devices": "0,1",
         }
     )
     assert "VLLM_ALLOW_INSECURE_SERIALIZATION" in env
@@ -204,7 +254,7 @@ def test_build_vllm_subprocess_env_colocate(vllm_args, monkeypatch):
 def test_build_vllm_subprocess_env_sets_batch_invariant_when_deterministic(vllm_args, monkeypatch):
     monkeypatch.delenv("VLLM_BATCH_INVARIANT", raising=False)
     vllm_args.vllm_enable_deterministic_inference = True
-    env = mod.build_vllm_subprocess_env({"args": vllm_args, "visible_devices": "0"})
+    env = mod._build_subprocess_env({"_args": vllm_args, "_visible_devices": "0"})
     assert env["VLLM_BATCH_INVARIANT"] == "1"
 
 
@@ -212,30 +262,40 @@ def test_build_vllm_subprocess_env_sets_batch_invariant_when_deterministic(vllm_
 def test_build_vllm_subprocess_env_no_batch_invariant_by_default(vllm_args, monkeypatch):
     monkeypatch.delenv("VLLM_BATCH_INVARIANT", raising=False)
     vllm_args.vllm_enable_deterministic_inference = False
-    env = mod.build_vllm_subprocess_env({"args": vllm_args, "visible_devices": "0"})
+    env = mod._build_subprocess_env({"_args": vllm_args, "_visible_devices": "0"})
     assert "VLLM_BATCH_INVARIANT" not in env
 
 
 @pytest.mark.unit
-def test_build_vllm_cmd_adds_sleep_mode_only_for_offload_rollout(vllm_args):
+def test_build_vllm_subprocess_env_sets_disaggregation_side_channel(vllm_args):
+    env = mod._build_subprocess_env(
+        {
+            "_args": vllm_args,
+            "_visible_devices": "0",
+            "_worker_type": "prefill",
+            "_disaggregation_bootstrap_port": 29999,
+            "node_rank": 0,
+            "host": "10.0.0.8",
+        }
+    )
+    assert env["VLLM_NIXL_SIDE_CHANNEL_HOST"] == "10.0.0.8"
+    assert env["VLLM_NIXL_SIDE_CHANNEL_PORT"] == "29999"
+
+
+@pytest.mark.unit
+def test_compute_server_args_adds_sleep_mode_for_offload_rollout(vllm_args):
     vllm_args.offload_rollout = True
-    server_args = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
-
-    cmd, _ = mod.build_vllm_cmd_and_env(server_args)
-
-    assert "--enable-sleep-mode" in cmd
+    sa, _ = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
+    assert sa.get("enable_sleep_mode") is True
     assert vllm_args.vllm_enable_sleep_mode is True
 
 
 @pytest.mark.unit
-def test_build_vllm_cmd_does_not_infer_sleep_mode_from_colocate(vllm_args):
+def test_compute_server_args_no_sleep_mode_from_colocate(vllm_args):
     vllm_args.colocate = True
     vllm_args.offload_rollout = False
-    server_args = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
-
-    cmd, _ = mod.build_vllm_cmd_and_env(server_args)
-
-    assert "--enable-sleep-mode" not in cmd
+    sa, _ = mod._compute_server_args(vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000)
+    assert "enable_sleep_mode" not in sa
     assert not getattr(vllm_args, "vllm_enable_sleep_mode", False)
 
 
@@ -354,11 +414,11 @@ def test_get_weight_version_worker_rank_returns_none_without_raise(vllm_engine):
 def test_update_weights_from_distributed_posts_update_weights_without_checkpoint_flag(vllm_engine, monkeypatch):
     calls: list[dict] = []
 
-    def fake_post_vllm(update_info: dict) -> dict:
-        calls.append(update_info)
+    def fake_make_request(endpoint: str, payload: dict) -> dict:
+        calls.append(payload.get("update_info", payload))
         return {"ok": True}
 
-    monkeypatch.setattr(vllm_engine, "_post_vllm_update_weights_http", fake_post_vllm)
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_make_request)
 
     names = ["layer.0.weight"]
     dtypes = [torch.float32]
@@ -384,79 +444,9 @@ def test_update_weights_from_distributed_posts_update_weights_without_checkpoint
 
 
 @pytest.mark.unit
-def test_post_vllm_update_weights_http_wraps_update_info(vllm_engine, monkeypatch):
-    seen: list[tuple] = []
-
-    def fake_post(endpoint: str, payload: dict):
-        seen.append((endpoint, payload))
-        return {"status": "ok"}
-
-    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
-
-    result = vllm_engine._post_vllm_update_weights_http({"names": ["w"], "packed": False})
-
-    assert result == {"status": "ok"}
-    assert seen[0][0] == "update_weights"
-    assert seen[0][1] == {"update_info": {"names": ["w"], "packed": False}}
-
-
-@pytest.mark.unit
-def test_response_json_parses_dict():
-    response = _MockResponse(json_data={"status": "ready"})
-    assert mod._response_json(response) == {"status": "ready"}
-
-
-@pytest.mark.unit
-def test_response_json_empty_body_returns_ok():
-    response = _MockResponse(text="")
-    assert mod._response_json(response) == {"ok": True}
-
-
-@pytest.mark.unit
-def test_response_json_invalid_json_raises():
-    response = _MockResponse(text="not-json")
-    response.json = lambda: (_ for _ in ()).throw(ValueError("no json"))  # type: ignore[method-assign]
-    with pytest.raises(ValueError, match="no json"):
-        mod._response_json(response)
-
-
-@pytest.mark.unit
-def test_response_json_http_error_adds_response_text_note():
-    response = _MockResponse(json_data={"error": "bad"}, text="server exploded", status_code=500)
-    with pytest.raises(requests.exceptions.HTTPError) as exc_info:
-        mod._response_json(response)
-    assert "response.text='server exploded'" in exc_info.value.__notes__
-
-
-@pytest.mark.unit
-def test_http_base_ipv6_host(vllm_engine):
+def test_get_url_ipv6_host(vllm_engine):
     vllm_engine.server_host = "[2001:db8::1]"
-    assert vllm_engine._http_base() == "http://[2001:db8::1]:8765"
-
-
-@pytest.mark.unit
-def test_redact_cmd_for_log_masks_hf_token():
-    cmd = ["vllm", "serve", "model", "--hf-token", "secret-token", "--port", "8000"]
-    logged = mod.redact_cmd_for_log(cmd)
-    assert "secret-token" not in logged
-    assert "***" in logged
-
-
-@pytest.mark.unit
-def test_serialize_for_cli_primitives():
-    assert mod.serialize_for_cli(42) == "42"
-    assert mod.serialize_for_cli(True) == "True"
-    assert mod.serialize_for_cli({"backend": "nccl"}) == json.dumps({"backend": "nccl"})
-
-
-@pytest.mark.unit
-def test_serialize_for_cli_dataclass():
-    @dataclasses.dataclass
-    class _Cfg:
-        backend: str = "nccl"
-
-    out = mod.serialize_for_cli(_Cfg())
-    assert json.loads(out) == {"backend": "nccl"}
+    assert vllm_engine.get_url() == "http://[2001:db8::1]:8765"
 
 
 @pytest.mark.unit
@@ -490,6 +480,20 @@ def test_resume_memory_occupation_wake_tags_query(vllm_engine, monkeypatch):
 
     assert len(seen) == 1
     assert seen[0][1] == [("tags", "weights")]
+
+
+@pytest.mark.unit
+def test_resume_memory_occupation_returns_none_for_unsupported_tags(vllm_engine, monkeypatch):
+    seen: list[tuple] = []
+
+    def fake_post(url, *, params=None, timeout=30, json=None):
+        seen.append((url, params, timeout, json))
+        return _MockResponse(json_data={"ok": True})
+
+    monkeypatch.setattr(mod.requests, "post", fake_post)
+
+    assert vllm_engine.resume_memory_occupation(tags=["cuda_graph"]) == {"ok": True}
+    assert seen[0][1] is None
 
 
 @pytest.mark.unit
@@ -530,17 +534,14 @@ def test_resume_memory_occupation_posts_wake_even_when_sleep_disabled(vllm_engin
 
 
 @pytest.mark.unit
-def test_init_weights_update_group_retries_then_succeeds(vllm_engine, monkeypatch):
-    attempts = {"n": 0}
+def test_init_weights_update_group_posts_init_info(vllm_engine, monkeypatch):
+    calls: list[tuple] = []
 
     def fake_post(endpoint: str, payload: dict):
-        attempts["n"] += 1
-        if attempts["n"] < 2:
-            raise requests.ConnectionError("transient")
+        calls.append((endpoint, payload))
         return {"initialized": True}
 
     monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
-    monkeypatch.setattr(mod.time, "sleep", lambda *_a, **_k: None)
 
     result = vllm_engine.init_weights_update_group(
         "127.0.0.1",
@@ -552,78 +553,35 @@ def test_init_weights_update_group_retries_then_succeeds(vllm_engine, monkeypatc
     )
 
     assert result == {"initialized": True}
-    assert attempts["n"] == 2
+    assert len(calls) == 1
+    assert calls[0][0] == "init_weight_transfer_engine"
+    assert calls[0][1]["init_info"]["master_address"] == "127.0.0.1"
+    assert calls[0][1]["init_info"]["rank_offset"] == 1
 
 
 @pytest.mark.unit
-def test_init_weights_update_group_raises_after_three_failures(vllm_engine, monkeypatch):
-    monkeypatch.setattr(
-        vllm_engine,
-        "_make_request",
-        lambda *a, **k: (_ for _ in ()).throw(requests.ConnectionError("down")),
-    )
-    monkeypatch.setattr(mod.time, "sleep", lambda *_a, **_k: None)
+def test_update_weights_from_disk_posts_collective_rpc(vllm_engine, monkeypatch):
+    seen: list[tuple] = []
 
-    with pytest.raises(RuntimeError, match="init_weight_transfer_engine failed"):
-        vllm_engine.init_weights_update_group(
-            "127.0.0.1",
-            29500,
-            rank_offset=1,
-            world_size=4,
-            group_name="g",
-            backend="nccl",
-        )
+    def fake_post(url, *, params=None, timeout=30, json=None):
+        seen.append((url, params, timeout, json))
+        return _MockResponse(json_data={"reloaded": True})
 
+    monkeypatch.setattr(mod.requests, "post", fake_post)
 
-def _stub_server_info(monkeypatch, parallel_config: dict) -> None:
-    def fake_get(url, *, params=None, timeout=30):
-        return _MockResponse(json_data={"vllm_config": {"parallel_config": parallel_config}})
-
-    monkeypatch.setattr(mod.requests, "get", fake_get)
+    assert vllm_engine.update_weights_from_disk("/tmp/model") == {"reloaded": True}
+    assert seen[0][0] == "http://127.0.0.1:8765/collective_rpc"
+    assert seen[0][3]["method"] == "reload_weights"
 
 
 @pytest.mark.unit
-def test_sanity_check_external_server_args_passes_on_match(vllm_engine, monkeypatch):
-    vllm_engine._server_args = {"tp_size": 2, "pp_size": 1, "dp_size": 1, "nnodes": 1}
-    _stub_server_info(
-        monkeypatch,
-        {"tensor_parallel_size": 2, "pipeline_parallel_size": 1, "data_parallel_size": 1, "nnodes": 1},
-    )
-    # All reported fields match the per-engine expectation → no raise.
-    vllm_engine._sanity_check_external_server_args()
+def test_update_weights_from_disk_surfaces_http_error(vllm_engine, monkeypatch):
+    def fake_post(url, *, params=None, timeout=30, json=None):
+        return _MockResponse(text="boom", status_code=500)
 
-
-@pytest.mark.unit
-def test_sanity_check_external_server_args_raises_on_tp_mismatch(vllm_engine, monkeypatch):
-    # Expect a tp=2 engine but the external server reports tp=1 → fail fast (the bug class
-    # that used to only warn and then hang the weight-sync rendezvous 300s later).
-    vllm_engine._server_args = {"tp_size": 2, "pp_size": 1, "dp_size": 1, "nnodes": 1}
-    _stub_server_info(
-        monkeypatch,
-        {"tensor_parallel_size": 1, "pipeline_parallel_size": 1, "data_parallel_size": 1, "nnodes": 1},
-    )
-    with pytest.raises(AssertionError, match="tp_size"):
-        vllm_engine._sanity_check_external_server_args()
-
-
-@pytest.mark.unit
-def test_sanity_check_external_server_args_skips_unreported_field(vllm_engine, monkeypatch):
-    # vLLM /server_info may not surface ``nnodes``: an unreported (None) field is skipped,
-    # not treated as a mismatch — so a single-node external engine doesn't false-fail.
-    vllm_engine._server_args = {"tp_size": 1, "pp_size": 1, "dp_size": 1, "nnodes": 2}
-    _stub_server_info(
-        monkeypatch,
-        {"tensor_parallel_size": 1, "pipeline_parallel_size": 1, "data_parallel_size": 1},
-    )
-    vllm_engine._sanity_check_external_server_args()
-
-
-@pytest.mark.unit
-def test_sanity_check_external_server_args_raises_when_parallel_config_missing(vllm_engine, monkeypatch):
-    vllm_engine._server_args = {"tp_size": 1, "pp_size": 1, "dp_size": 1, "nnodes": 1}
-    _stub_server_info(monkeypatch, {})
-    with pytest.raises(RuntimeError, match="missing vllm_config.parallel_config"):
-        vllm_engine._sanity_check_external_server_args()
+    monkeypatch.setattr(mod.requests, "post", fake_post)
+    with pytest.raises(requests.exceptions.HTTPError):
+        vllm_engine.update_weights_from_disk("/tmp/model")
 
 
 @pytest.mark.unit
@@ -633,20 +591,20 @@ def test_resolve_parallel_sizes_is_per_engine_not_global(vllm_args):
     vllm_args.rollout_num_gpus_per_engine = 1
     vllm_args.vllm_pipeline_parallel_size = 1
     vllm_args.vllm_tp_size = 1  # stale global; must be ignored now
-    tp, pp = mod._resolve_vllm_parallel_sizes(vllm_args, gpus_per_engine=2)
+    tp, pp, dp = mod._resolve_parallel_sizes(vllm_args, gpus_per_engine=2)
     assert (tp, pp) == (2, 1)
 
 
 @pytest.mark.unit
-def test_compute_topology_heterogeneous_per_group_tp(vllm_args):
-    # Reproduces the rendezvous bug's root: global=1 but a per-group engine uses 2 GPUs.
+def test_launch_config_heterogeneous_per_group_tp(vllm_args):
     vllm_args.num_gpus_per_node = 8
     vllm_args.rollout_num_gpus_per_engine = 1
     vllm_args.vllm_pipeline_parallel_size = 1
-    vllm_args.vllm_tp_size = 1  # stale global
-    topo = mod.compute_vllm_engine_topology(vllm_args, global_rank=0, num_gpus_per_engine=2)
-    assert topo.tensor_parallel_size == 2
-    assert topo.nnodes == 1
+    sa, _ = mod._compute_server_args(
+        vllm_args, rank=0, dist_init_addr=None, host="127.0.0.1", port=8000, num_gpus_per_engine=2
+    )
+    assert sa["_tp_size"] == 2
+    assert sa["nnodes"] == 1
 
 
 @pytest.mark.unit
@@ -656,7 +614,7 @@ def test_resolve_parallel_sizes_dp_consumes_gpus(vllm_args):
     vllm_args.vllm_pipeline_parallel_size = 1
     vllm_args.vllm_data_parallel_size = 2
     vllm_args.vllm_dp_size = 2
-    tp, pp = mod._resolve_vllm_parallel_sizes(vllm_args, gpus_per_engine=4)
+    tp, pp, dp = mod._resolve_parallel_sizes(vllm_args, gpus_per_engine=4)
     assert (tp, pp) == (2, 1)
 
 
@@ -666,7 +624,7 @@ def test_resolve_parallel_sizes_dp_and_pp_combined(vllm_args):
     vllm_args.vllm_pipeline_parallel_size = 2
     vllm_args.vllm_data_parallel_size = 2
     vllm_args.vllm_dp_size = 2
-    tp, pp = mod._resolve_vllm_parallel_sizes(vllm_args, gpus_per_engine=8)
+    tp, pp, dp = mod._resolve_parallel_sizes(vllm_args, gpus_per_engine=8)
     assert (tp, pp) == (2, 2)
 
 
@@ -677,7 +635,7 @@ def test_resolve_parallel_sizes_rejects_indivisible_dp(vllm_args):
     vllm_args.vllm_data_parallel_size = 2
     vllm_args.vllm_dp_size = 2
     with pytest.raises(ValueError, match="divisible"):
-        mod._resolve_vllm_parallel_sizes(vllm_args, gpus_per_engine=3)
+        mod._resolve_parallel_sizes(vllm_args, gpus_per_engine=3)
 
 
 @pytest.mark.unit
@@ -690,28 +648,6 @@ def test_make_request_short_circuits_on_headless(vllm_engine, monkeypatch):
     monkeypatch.setattr(mod.requests, "post", _boom)
     vllm_engine.node_rank = 1
     assert vllm_engine._make_request("whatever", {}) is None
-
-
-@pytest.mark.unit
-def test_control_plane_methods_noop_on_headless_worker(vllm_engine, monkeypatch):
-    """node_rank>0 (headless) workers own no HTTP server; every control-plane method must
-    no-op (return None) without issuing an HTTP request."""
-
-    def _boom(*a, **k):
-        raise AssertionError("control-plane HTTP must not be called on a headless worker")
-
-    monkeypatch.setattr(mod.requests, "post", _boom)
-    monkeypatch.setattr(mod.requests, "get", _boom)
-    vllm_engine.node_rank = 1
-    vllm_engine.args.vllm_enable_sleep_mode = True
-
-    assert vllm_engine.init_weight_transfer_engine({"init_info": {}}) is None
-    assert vllm_engine.start_weight_update() is None
-    assert vllm_engine.finish_weight_update() is None
-    assert vllm_engine.init_weights_update_group("addr", 1, 0, 4, "g", "nccl") is None
-    assert vllm_engine.update_weights_from_distributed(["w"], [torch.float32], [[1]], "g") is None
-    assert vllm_engine.release_memory_occupation() is None
-    assert vllm_engine.resume_memory_occupation() is None
 
 
 if __name__ == "__main__":

--- a/vime/backends/vllm_utils/arguments.py
+++ b/vime/backends/vllm_utils/arguments.py
@@ -1,12 +1,4 @@
-"""vLLM rollout backend argument definitions.
-
-Wholesale-imports ``AsyncEngineArgs.add_cli_args`` prefixed ``--vllm-``/``vllm_``,
-adds vime orchestration extras, and provides ``get_vllm_cli_action_table`` for
-subprocess CLI forwarding (vLLM is launched as ``vllm serve``).
-"""
-
 import argparse
-import sys
 
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.utils.argparse_utils import FlexibleArgumentParser
@@ -14,71 +6,7 @@ from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vime.utils.http_utils import _wrap_ipv6
 
 
-def _detect_user_provided_dests(parser, argv: list[str]) -> tuple[set[str], dict[str, str]]:
-    """Return (user_provided, raw_values) extracted from ``argv``.
-
-    ``user_provided``: dests explicitly named on the CLI — used to distinguish "user
-    passed a value equaling the default" from "user accepted the parsed default".
-
-    ``raw_values``: literal CLI strings per dest — used to forward dataclass-backed
-    flags (e.g. ``--vllm-compilation-config``) verbatim instead of re-serializing
-    the parsed runtime object.
-    """
-    flag_to_dest: dict[str, str] = {}
-    for action in parser._actions:
-        for flag in action.option_strings:
-            flag_to_dest[flag] = action.dest
-    user: set[str] = set()
-    raw: dict[str, str] = {}
-    i = 0
-    while i < len(argv):
-        token = argv[i]
-        if "=" in token and token.startswith("--"):
-            head, raw_val = token.split("=", 1)
-            dest = flag_to_dest.get(head)
-            if dest is not None:
-                user.add(dest)
-                raw[dest] = raw_val
-            i += 1
-            continue
-        dest = flag_to_dest.get(token)
-        if dest is not None:
-            user.add(dest)
-            if i + 1 < len(argv) and not argv[i + 1].startswith("--"):
-                raw[dest] = argv[i + 1]
-                i += 2
-                continue
-        i += 1
-    return user, raw
-
-
-# Dests orchestrator-owned or non-applicable to subprocess `vllm serve` mode.
-SKIPPED_DESTS = [
-    "model",
-    "served_model_name",
-    "config",
-    "tokenizer",
-    "tokenizer_mode",
-    "tokenizer_revision",
-    "trust_remote_code",
-    "seed",
-    "dtype",
-    # TP is orchestrator-owned; PP/DP remain user-controllable and auto-forward.
-    "tensor_parallel_size",
-    "nnodes",
-    "node_rank",
-    "master_addr",
-    "master_port",
-    "data_parallel_backend",
-    "distributed_executor_backend",
-    "port",
-    "host",
-    "enable_return_routed_experts",
-]
-
-
 def add_vllm_router_arguments(parser):
-    """vime's vllm-router endpoint flags (host/port are orchestrator-owned, excluded from RouterArgs CLI)."""
     parser.add_argument(
         "--vllm-router-ip",
         type=str,
@@ -91,16 +19,12 @@ def add_vllm_router_arguments(parser):
         default=None,
         help="Port of the vllm router.",
     )
-    # Bare --router-* namespace: this is a real vllm-router knob (RouterArgs field);
-    # host/port use --vllm-router-* because RouterArgs excludes them (exclude_host_port=True).
     parser.add_argument(
         "--router-request-timeout-secs",
         type=int,
         default=14400,
         help="Timeout (seconds) for HTTP requests vime makes to the vllm router.",
     )
-    # dest=router_policy (not vllm_router_policy): flows into RouterArgs.from_cli_args and
-    # is read by vllm_rollout.generate to decide whether to send x-session-id headers.
     parser.add_argument(
         "--vllm-router-policy",
         type=str,
@@ -115,66 +39,16 @@ def add_vllm_router_arguments(parser):
     return parser
 
 
-def _make_add_argument_wrapper(target_add_argument):
-    """Return a wrapper that skips dests in SKIPPED_DESTS and prefixes flags/dest with ``vllm-``/``vllm_``."""
-
-    def wrapper(*name_or_flags, **kwargs):
-        # determine canonical dest for skip check
-        canonical = kwargs.get("dest")
-        if canonical is None:
-            for s in name_or_flags:
-                if isinstance(s, str) and s.startswith("--"):
-                    canonical = s[2:].replace("-", "_")
-                    break
-        if canonical in SKIPPED_DESTS:
-            return None
-
-        # prefix flags
-        new_flags = []
-        for s in name_or_flags:
-            if isinstance(s, str) and s.startswith("-"):
-                new_flags.append(f"--vllm-{s.lstrip('-')}")
-            else:
-                new_flags.append(s)
-
-        # prefix dest
-        new_kwargs = kwargs.copy()
-        if "dest" in new_kwargs and isinstance(new_kwargs["dest"], str):
-            if not new_kwargs["dest"].startswith("vllm_"):
-                new_kwargs["dest"] = f"vllm_{new_kwargs['dest']}"
-
-        return target_add_argument(*new_flags, **new_kwargs)
-
-    return wrapper
-
-
 def add_vllm_arguments(parser):
-    """Register --vllm-* flags into parser.
-
-    Wholesale-imports ``AsyncEngineArgs.add_cli_args`` via a monkey-patched
-    ``parser.add_argument`` / ``parser.add_argument_group`` wrapper that prefixes
-    every flag with ``--vllm-`` and every dest with ``vllm_``, skipping dests in
-    ``SKIPPED_DESTS``. Both are patched because vLLM creates argument groups.
-    Pass a ``FlexibleArgumentParser`` so vLLM's ``deprecated`` kwarg is handled
-    natively on Python 3.12.
-    """
     parser = add_vllm_router_arguments(parser)
-    parser.add_argument(
-        "--vllm-server-concurrency",
-        type=int,
-        default=512,
-        help="Max concurrent inference requests sent to each vLLM server worker.",
-    )
+    parser.add_argument("--vllm-server-concurrency", type=int, default=512)
     parser.add_argument(
         "--vllm-enable-deterministic-inference",
         action="store_true",
         default=False,
         help=(
             "Make rollout sampling deterministic. Forwards a per-sample ``seed`` "
-            "(derived from ``--rollout-seed`` and the sample's index in the group) "
-            "AND exports ``VLLM_BATCH_INVARIANT=1`` to the vLLM subprocess so attention "
-            "/ comm / MM kernels pick batch-invariant variants. Both are required for "
-            "true determinism — seed alone does not control kernel selection."
+            "AND exports ``VLLM_BATCH_INVARIANT=1`` to the vLLM subprocess."
         ),
     )
     parser.add_argument(
@@ -189,36 +63,81 @@ def add_vllm_arguments(parser):
         "--vllm-weight-sync-packed",
         dest="vllm_weight_sync_packed",
         action="store_true",
-        help=(
-            "Use one-shot packed weight transfer for dense models (no MoE experts). "
-            "Automatically disabled for MoE or compressed-tensors quantization."
-        ),
     )
     _vllm_packed.add_argument(
         "--no-vllm-weight-sync-packed",
         dest="vllm_weight_sync_packed",
         action="store_false",
-        help="Disable packed sync; send weights per bucket via in-process NCCL (non-packed mode).",
     )
     parser.set_defaults(vllm_weight_sync_packed=True)
 
-    old_parser_add_argument = parser.add_argument
-    old_parser_add_argument_group = parser.add_argument_group
+    # Monkey-patch parser to prefix all engine flags with --vllm- / vllm_
+    old_add_argument = parser.add_argument
+    old_add_argument_group = parser.add_argument_group
+
+    skipped_args = [
+        "model",
+        "served_model_name",
+        "config",
+        "tokenizer",
+        "tokenizer_mode",
+        "tokenizer_revision",
+        "trust_remote_code",
+        "seed",
+        "dtype",
+        "tensor_parallel_size",
+        "nnodes",
+        "node_rank",
+        "master_addr",
+        "master_port",
+        "data_parallel_backend",
+        "distributed_executor_backend",
+        "port",
+        "host",
+        "enable_return_routed_experts",
+        "tool_call_parser",
+    ]
+
+    def _wrap_add_argument(target_add_argument):
+        def wrapper(*name_or_flags, **kwargs):
+            canonical = kwargs.get("dest")
+            if canonical is None:
+                for s in name_or_flags:
+                    if isinstance(s, str) and s.startswith("--"):
+                        canonical = s[2:].replace("-", "_")
+                        break
+            if canonical in skipped_args:
+                return None
+
+            new_flags = []
+            for s in name_or_flags:
+                if isinstance(s, str) and s.startswith("-"):
+                    new_flags.append(f"--vllm-{s.lstrip('-')}")
+                else:
+                    new_flags.append(s)
+
+            new_kwargs = kwargs.copy()
+            if "dest" in new_kwargs and isinstance(new_kwargs["dest"], str):
+                if not new_kwargs["dest"].startswith("vllm_"):
+                    new_kwargs["dest"] = f"vllm_{new_kwargs['dest']}"
+
+            return target_add_argument(*new_flags, **new_kwargs)
+
+        return wrapper
 
     def patched_add_argument_group(*g_args, **g_kwargs):
-        group = old_parser_add_argument_group(*g_args, **g_kwargs)
-        group.add_argument = _make_add_argument_wrapper(group.add_argument)
+        group = old_add_argument_group(*g_args, **g_kwargs)
+        group.add_argument = _wrap_add_argument(group.add_argument)
         return group
 
-    parser.add_argument = _make_add_argument_wrapper(old_parser_add_argument)
+    parser.add_argument = _wrap_add_argument(old_add_argument)
     parser.add_argument_group = patched_add_argument_group
     AsyncEngineArgs.add_cli_args(parser)
-    parser.add_argument = old_parser_add_argument
-    parser.add_argument_group = old_parser_add_argument_group
+    from vllm.entrypoints.openai.cli_args import FrontendArgs
 
-    # Deliberately no set_defaults for vllm flags: argparse.set_defaults mutates action.default,
-    # which would make _forward_vllm_cli_args skip forwarding values that equal the default.
-    # vime-preferred defaults are applied explicitly in vllm_engine.launch_server_process.
+    FrontendArgs.add_cli_args(parser)
+    parser.add_argument = old_add_argument
+    parser.add_argument_group = old_add_argument_group
 
     # PD disaggregation / multi-group config
     parser.add_argument(
@@ -234,7 +153,6 @@ def add_vllm_arguments(parser):
         dest="vllm_config",
         help=(
             "Path to a YAML config file for fine-grained vLLM rollout engine deployment. "
-            "Enables multi-model serving, PD disaggregation, and heterogeneous server groups. "
             "Mutually exclusive with --prefill-num-servers and --rollout-external."
         ),
     )
@@ -243,7 +161,6 @@ def add_vllm_arguments(parser):
 
 
 def validate_args(args):
-    """vLLM-specific validation."""
     args.vllm_dp_size = args.vllm_data_parallel_size
     args.vllm_pp_size = args.vllm_pipeline_parallel_size
 
@@ -266,10 +183,7 @@ def validate_args(args):
 def vllm_parse_args():
     """Parse vLLM flags via an independent ArgumentParser + parse_known_args.
 
-    Returns a Namespace with all attrs prefixed ``vllm_``, plus:
-      - ``_vllm_user_provided``: set of dests the user named on argv
-      - ``_vllm_raw_values``: literal CLI strings per dest (for verbatim forwarding
-        of dataclass-backed flags like ``--vllm-compilation-config``)
+    Returns a Namespace with all attrs prefixed ``vllm_``.
     """
     parser = FlexibleArgumentParser(add_help=False)
     add_vllm_arguments(parser)
@@ -286,63 +200,4 @@ def vllm_parse_args():
     parser.set_defaults(vllm_tensor_parallel_size=vllm_tp_size)
 
     args, _ = parser.parse_known_args()
-    user_provided, raw_values = _detect_user_provided_dests(parser, sys.argv[1:])
-    args._vllm_user_provided = user_provided
-    args._vllm_raw_values = raw_values
     return args
-
-
-# Dests that are vime orchestration flags (not part of `vllm serve` CLI) — excluded
-# from get_vllm_cli_action_table() so launch_server_process won't forward them.
-_VIME_ORCHESTRATION_DESTS = frozenset(
-    {
-        "vllm_router_ip",
-        "vllm_router_port",
-        "router_request_timeout_secs",
-        "router_policy",
-        "vllm_server_concurrency",
-        "vllm_enable_deterministic_inference",
-        "vllm_weight_sync_packed",
-        "vllm_tool_call_parser",
-        "vllm_config",
-        "prefill_num_servers",
-    }
-)
-
-
-_VLLM_CLI_ACTION_TABLE_CACHE: dict[str, tuple[str, argparse.Action]] | None = None
-
-
-def get_vllm_cli_action_table():
-    """Build {vime_dest -> (primary_flag, action)} mapping for forwardable flags.
-
-    Used by ``vllm_engine.launch_server_process`` to forward ``args.vllm_*`` values
-    that differ from vllm-side defaults to the ``vllm serve`` subprocess.
-
-    Excludes vime orchestration dests and non-vllm-prefixed actions. Cached after
-    first build — rebuilding the parser is expensive.
-    """
-    global _VLLM_CLI_ACTION_TABLE_CACHE
-    if _VLLM_CLI_ACTION_TABLE_CACHE is not None:
-        return _VLLM_CLI_ACTION_TABLE_CACHE
-
-    parser = FlexibleArgumentParser(add_help=False)
-    add_vllm_arguments(parser)
-
-    table: dict[str, tuple[str, argparse.Action]] = {}
-    for action in parser._actions:
-        if action.dest in _VIME_ORCHESTRATION_DESTS:
-            continue
-        if not action.dest.startswith("vllm_"):
-            continue
-        # Pick the first ``--vllm-xxx`` flag (skip ``--no-vllm-xxx`` companions).
-        primary_flag = None
-        for s in action.option_strings:
-            if s.startswith("--vllm-") and not s.startswith("--no-vllm-"):
-                primary_flag = "--" + s[len("--vllm-") :]
-                break
-        if primary_flag is None:
-            continue
-        table[action.dest] = (primary_flag, action)
-    _VLLM_CLI_ACTION_TABLE_CACHE = table
-    return table

--- a/vime/backends/vllm_utils/arguments.py
+++ b/vime/backends/vllm_utils/arguments.py
@@ -51,13 +51,6 @@ def add_vllm_arguments(parser):
             "AND exports ``VLLM_BATCH_INVARIANT=1`` to the vLLM subprocess."
         ),
     )
-    parser.add_argument(
-        "--vllm-tool-call-parser",
-        dest="vllm_tool_call_parser",
-        type=str,
-        default=None,
-        help="vLLM tool-call parser name for agent output parsing (e.g. qwen3_coder).",
-    )
     _vllm_packed = parser.add_mutually_exclusive_group()
     _vllm_packed.add_argument(
         "--vllm-weight-sync-packed",
@@ -77,14 +70,9 @@ def add_vllm_arguments(parser):
 
     skipped_args = [
         "model",
-        "served_model_name",
         "config",
-        "tokenizer",
-        "tokenizer_mode",
-        "tokenizer_revision",
         "trust_remote_code",
         "seed",
-        "dtype",
         "tensor_parallel_size",
         "nnodes",
         "node_rank",
@@ -95,7 +83,6 @@ def add_vllm_arguments(parser):
         "port",
         "host",
         "enable_return_routed_experts",
-        "tool_call_parser",
     ]
 
     def _wrap_add_argument(target_add_argument):

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -1,13 +1,4 @@
-"""Ray actor and launch helpers for vLLM OpenAI HTTP rollout.
-
-Per-Ray-actor ``server_args`` dict is built via :func:`_compute_server_args`,
-then :func:`build_vllm_cmd_and_env` turns it into ``vllm serve`` CLI + subprocess env.
-:class:`VLLMEngine` manages the runtime HTTP control plane.
-User-facing vLLM knobs remain on ``train.py`` as ``--vllm-*`` (see ``arguments.py``).
-"""
-
-from __future__ import annotations
-
+import argparse
 import base64
 import dataclasses
 import ipaddress
@@ -15,57 +6,22 @@ import logging
 import multiprocessing
 import os
 import time
-from argparse import BooleanOptionalAction
 from typing import Any
 from urllib.parse import quote
 
 import cloudpickle
 import requests
+from vllm.utils.system_utils import kill_process_tree
 
-from vime.backends.vllm_utils.arguments import SKIPPED_DESTS, get_vllm_cli_action_table
 from vime.ray.ray_actor import RayActor
 from vime.utils.http_utils import get_host_info
 
 logger = logging.getLogger(__name__)
 
-_spawn_ctx = multiprocessing.get_context("spawn")
-
-# Fields checked against external ``GET /server_info``.
-EXTERNAL_ENGINE_CHECK_FIELDS = ("tp_size", "pp_size", "dp_size", "nnodes")
-
-_REDACTED_FLAGS = frozenset({"--hf-token"})
-
-# vLLM sleep/wake only supports these tags (``cuda_graph`` is not supported).
 _VLLM_WAKE_TAGS = frozenset({"weights", "kv_cache"})
-
-_PRIMITIVE_TYPES = (str, int, float, bool)
-
-
-def _format_v6_uri(addr: str | None) -> str | None:
-    if not addr or addr.startswith("["):
-        return addr
-    try:
-        if ipaddress.ip_address(addr).version == 6:
-            return f"[{addr}]"
-    except ValueError:
-        pass
-    return addr
-
-
-def _response_json(response: requests.Response) -> dict:
-    try:
-        response.raise_for_status()
-    except requests.exceptions.HTTPError as e:
-        e.add_note(f"{response.text=}")
-        raise
-    # vLLM sleep/wake endpoints may return 200 with an empty body.
-    if not response.content or not response.content.strip():
-        return {"ok": True}
-    return response.json()
 
 
 def get_base_gpu_id(args, rank):
-    """First local GPU index on this node for rollout engine *rank* (colocate vs actor[/critic]-offset layout)."""
     num_gpus = min(args.num_gpus_per_node, args.rollout_num_gpus_per_engine)
     if args.colocate:
         start_index = (rank * num_gpus) % args.num_gpus_per_node
@@ -78,263 +34,32 @@ def get_base_gpu_id(args, rank):
     return start_index
 
 
-@dataclasses.dataclass(frozen=True)
-class VllmEngineTopology:
-    """Per-Ray-actor placement for one slice of a logical rollout engine."""
+def launch_server_process(server_args_dict: dict) -> multiprocessing.Process:
+    env = _build_subprocess_env(server_args_dict)
+    kwargs = {k: v for k, v in server_args_dict.items() if not k.startswith("_")}
+    logger.info("Launching vLLM server: %s", kwargs)
 
-    nnodes: int
-    node_rank: int
-    local_num_gpus: int
-    tensor_parallel_size: int
-    pipeline_parallel_size: int
+    multiprocessing.set_start_method("spawn", force=True)
+    p = multiprocessing.Process(target=_run_vllm_server, args=(kwargs, env))
+    p.start()
 
-    @property
-    def headless(self) -> bool:
-        return self.node_rank != 0
+    if server_args_dict.get("node_rank", 0) != 0:
+        return p
 
-    @property
-    def multi_node(self) -> bool:
-        return self.nnodes > 1
-
-
-def _get_vllm_pp_size(args) -> int:
-    return int(getattr(args, "vllm_pipeline_parallel_size", 1) or 1)
-
-
-def _get_vllm_dp_size(args) -> int:
-    return int(getattr(args, "vllm_dp_size", None) or getattr(args, "vllm_data_parallel_size", 1) or 1)
-
-
-def _resolve_vllm_parallel_sizes(args, *, gpus_per_engine: int) -> tuple[int, int]:
-    pp = _get_vllm_pp_size(args)
-    dp = _get_vllm_dp_size(args)
-    if gpus_per_engine % (pp * dp) != 0:
-        raise ValueError(
-            f"num_gpus_per_engine ({gpus_per_engine}) must be divisible by "
-            f"vllm_pipeline_parallel_size * vllm_data_parallel_size ({pp} * {dp} = {pp * dp})"
-        )
-    tp = gpus_per_engine // (pp * dp)
-    return tp, pp
-
-
-def compute_vllm_engine_topology(
-    args,
-    global_rank: int,
-    *,
-    num_gpus_per_engine: int | None = None,
-) -> VllmEngineTopology:
-    """Compute nnodes / node_rank / local GPU slice for one Ray actor."""
-    gpus_per_engine = num_gpus_per_engine if num_gpus_per_engine is not None else args.rollout_num_gpus_per_engine
-    nnodes = max(1, gpus_per_engine // args.num_gpus_per_node)
-    node_rank = global_rank % nnodes
-    if nnodes == 1:
-        local_num_gpus = min(args.num_gpus_per_node, gpus_per_engine)
-    else:
-        if gpus_per_engine % nnodes != 0:
-            raise ValueError(
-                f"rollout_num_gpus_per_engine ({gpus_per_engine}) must be divisible by the number of "
-                f"nodes per engine ({nnodes})"
-            )
-        local_num_gpus = gpus_per_engine // nnodes
-    tp, pp = _resolve_vllm_parallel_sizes(args, gpus_per_engine=gpus_per_engine)
-    return VllmEngineTopology(
-        nnodes=nnodes,
-        node_rank=node_rank,
-        local_num_gpus=local_num_gpus,
-        tensor_parallel_size=tp,
-        pipeline_parallel_size=pp,
+    _wait_server_healthy(
+        base_url=f"http://{(server_args_dict['host'] or '127.0.0.1').strip('[]')}:{server_args_dict['port']}",
+        is_process_alive=lambda: p.is_alive(),
     )
 
-
-def parse_dist_init_addr(dist_init_addr: str) -> tuple[str, int]:
-    """Split ``host:port`` (IPv6-safe) into master host and port."""
-    ip_part, port_part = dist_init_addr.rsplit(":", 1)
-    host = _format_v6_uri(ip_part) or ip_part
-    return host.strip("[]"), int(port_part)
+    return p
 
 
-def append_vllm_distributed_launch_flags(
-    cmd: list[str],
-    topology: VllmEngineTopology,
-    master: tuple[str, int],
-    args,
-) -> None:
-    """Append vLLM multi-node flags when ``topology.multi_node`` (no-op for single-node)."""
-    if not topology.multi_node:
-        return
-    master_host, master_port = master
-    cmd += [
-        "--nnodes",
-        str(topology.nnodes),
-        "--node-rank",
-        str(topology.node_rank),
-        "--master-addr",
-        master_host,
-        "--master-port",
-        str(master_port),
-    ]
-    if not _user_overrode(args, "vllm_data_parallel_backend"):
-        cmd += ["--data-parallel-backend", "mp"]
-    if not _user_overrode(args, "vllm_distributed_executor_backend"):
-        cmd += ["--distributed-executor-backend", "mp"]
-    if topology.headless:
-        cmd.append("--headless")
-
-
-def _user_overrode(args, dest: str) -> bool:
-    user_provided: set[str] = getattr(args, "_vllm_user_provided", set())
-    if dest in user_provided:
-        return True
-    entry = get_vllm_cli_action_table().get(dest)
-    if entry is None:
-        return False
-    _, action = entry
-    return getattr(args, dest, action.default) != action.default
-
-
-def _apply_vllm_overrides(args, server_args: dict[str, Any], vllm_overrides: dict | None, rank: int) -> None:
-    """Merge per-group ``overrides`` from rollout YAML into ``args`` / ``server_args``."""
-    if not vllm_overrides:
-        return
-    for key, value in vllm_overrides.items():
-        normalized = key.replace("-", "_")
-        if normalized == "model_path":
-            server_args["model_path"] = value
-            continue
-        if normalized.startswith("disaggregation"):
-            logger.debug("vllm_overrides: skipping unsupported key %s (rank=%s)", key, rank)
-            continue
-        dest = normalized if normalized.startswith("vllm_") else f"vllm_{normalized}"
-        if hasattr(args, dest):
-            logger.info("vllm_overrides: %s=%r (rank=%s)", dest, value, rank)
-            setattr(args, dest, value)
-            continue
-        if normalized in server_args:
-            server_args[normalized] = value
-            continue
-        logger.debug("vllm_overrides: unrecognized key %s (rank=%s)", key, rank)
-
-
-class _RobustJsonEncoder:
-    @staticmethod
-    def default(obj):
-        import enum
-        from pathlib import Path
-
-        if dataclasses.is_dataclass(obj):
-            return dataclasses.asdict(obj)
-        if isinstance(obj, (set, frozenset)):
-            return list(obj)
-        if isinstance(obj, enum.Enum):
-            return obj.value
-        if isinstance(obj, Path):
-            return str(obj)
-        if isinstance(obj, bytes):
-            return obj.decode("utf-8", errors="replace")
-        raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
-
-
-def serialize_for_cli(value) -> str | None:
-    import json
-
-    if isinstance(value, str):
-        return value
-    if isinstance(value, (int, float, bool)):
-        return str(value)
-    if dataclasses.is_dataclass(value) or isinstance(value, (dict, list, tuple)):
-        try:
-            return json.dumps(value, default=_RobustJsonEncoder.default)
-        except (TypeError, ValueError) as exc:
-            logger.debug("JSON serialization failed for %r: %s", type(value).__name__, exc)
-            return None
-    return None
-
-
-def _serialize_weight_transfer_config(value) -> str:
-    serialized = serialize_for_cli(value)
-    if serialized is None:
-        import json
-
-        return json.dumps({"backend": str(value)})
-    return serialized
-
-
-def _forward_vllm_cli_args(args, cmd: list[str]) -> None:
-    """Append user ``--vllm-*`` overrides not already set by the orchestrator."""
-    fixed = {flag for flag in cmd if isinstance(flag, str) and flag.startswith("--")}
-    raw_values: dict[str, str] = getattr(args, "_vllm_raw_values", {})
-
-    for vime_dest, (vllm_flag, action) in get_vllm_cli_action_table().items():
-        if vime_dest in SKIPPED_DESTS:
-            continue
-        if vllm_flag in fixed:
-            continue
-        if not hasattr(args, vime_dest):
-            continue
-        value = getattr(args, vime_dest)
-        default = action.default
-        if value == default or value is None:
-            continue
-
-        if isinstance(action, BooleanOptionalAction):
-            cmd.append(vllm_flag if value else f"--no-{vllm_flag[2:]}")
-            continue
-        if action.nargs == 0:
-            cmd.append(vllm_flag)
-            continue
-        if action.nargs == "?" and action.const is not None and value == action.const:
-            cmd.append(vllm_flag)
-            continue
-        if action.nargs in ("+", "*") or (action.nargs not in (None, "?") and isinstance(value, (list, tuple))):
-            if not isinstance(value, (list, tuple)):
-                value = [value]
-            if not value:
-                continue
-            if not all(isinstance(v, _PRIMITIVE_TYPES) for v in value):
-                logger.debug("Skipping %s: list contains non-primitive items (%r)", vllm_flag, value)
-                continue
-            cmd.append(vllm_flag)
-            cmd.extend(str(v) for v in value)
-            continue
-        if not isinstance(value, _PRIMITIVE_TYPES):
-            raw = raw_values.get(vime_dest)
-            if raw is not None:
-                cmd.extend([vllm_flag, raw])
-                continue
-        serialized = serialize_for_cli(value)
-        if serialized is None:
-            logger.debug(
-                "Skipping forward of %s: parsed value %r (%s) cannot be serialized",
-                vllm_flag,
-                value,
-                type(value).__name__,
-            )
-            continue
-        cmd.extend([vllm_flag, serialized])
-
-
-def redact_cmd_for_log(cmd: list[str]) -> str:
-    """Stringify ``cmd`` for logging, redacting credential flags."""
-    parts: list[str] = []
-    redact_next = False
-    for token in cmd:
-        if redact_next:
-            parts.append("***")
-            redact_next = False
-            continue
-        parts.append(token)
-        if isinstance(token, str) and token in _REDACTED_FLAGS:
-            redact_next = True
-    return " ".join(parts)
-
-
-def build_vllm_subprocess_env(server_args: dict[str, Any]) -> dict[str, str]:
-    """Child-process environment for ``vllm serve``."""
-    args = server_args["args"]
+def _build_subprocess_env(server_args_dict: dict[str, Any]) -> dict[str, str]:
+    args = server_args_dict["_args"]
     env = os.environ.copy()
     env.pop("PYTORCH_CUDA_ALLOC_CONF", None)
     env.setdefault("NCCL_CUMEM_ENABLE", "0")
-    env["CUDA_VISIBLE_DEVICES"] = server_args["visible_devices"]
+    env["CUDA_VISIBLE_DEVICES"] = server_args_dict["_visible_devices"]
     env.setdefault("VLLM_SERVER_DEV_MODE", "1")
     if getattr(args, "vllm_enable_deterministic_inference", False):
         env["VLLM_BATCH_INVARIANT"] = "1"
@@ -346,150 +71,46 @@ def build_vllm_subprocess_env(server_args: dict[str, Any]) -> dict[str, str]:
         if vime_root not in {p for p in existing_pp.split(os.pathsep) if p}:
             env["PYTHONPATH"] = os.pathsep.join(filter(None, [vime_root, existing_pp]))
         env.setdefault("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+
+    worker_type = server_args_dict.get("_worker_type", "regular")
+    if worker_type in ("prefill", "decode") and server_args_dict.get("node_rank", 0) == 0:
+        host_for_subprocess = (server_args_dict.get("host") or "127.0.0.1").strip("[]")
+        env["VLLM_NIXL_SIDE_CHANNEL_HOST"] = host_for_subprocess
+        env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = str(server_args_dict["_disaggregation_bootstrap_port"])
+
     return env
 
 
-def build_vllm_cmd_and_env(server_args: dict[str, Any]) -> tuple[list[str], dict[str, str]]:
-    """Translate ``server_args`` to ``vllm serve`` argv and subprocess environment."""
-    args = server_args["args"]
-    topology: VllmEngineTopology = server_args["topology"]
-    env = build_vllm_subprocess_env(server_args)
-    host_for_subprocess = (server_args["host"] or "127.0.0.1").strip("[]")
+def _run_vllm_server(kwargs: dict, env: dict) -> None:
+    os.environ.update(env)
 
-    cmd = [
-        "vllm",
-        "serve",
-        str(server_args["model_path"]),
-        "--tensor-parallel-size",
-        str(server_args["tp_size"]),
-        "--port",
-        str(server_args["port"]),
-        "--host",
-        host_for_subprocess,
-        "--seed",
-        str(server_args["seed"]),
-        "--trust-remote-code",
-    ]
+    from vllm.entrypoints.cli.serve import ServeSubcommand
+    from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
 
-    if server_args["pp_size"] > 1:
-        cmd += ["--pipeline-parallel-size", str(server_args["pp_size"])]
-
-    if topology.multi_node:
-        if server_args["master_addr"] is None or server_args["master_port"] is None:
-            raise ValueError("master_addr/master_port required for multi-node vLLM engine")
-        append_vllm_distributed_launch_flags(
-            cmd,
-            topology,
-            (server_args["master_addr"], server_args["master_port"]),
-            args,
-        )
-
-    if getattr(args, "fp16", False):
-        cmd += ["--dtype", "float16"]
-
-    if getattr(args, "offload_rollout", False) and not getattr(args, "vllm_enable_sleep_mode", False):
-        cmd += ["--enable-sleep-mode"]
-        args.vllm_enable_sleep_mode = True
-
-    if (
-        getattr(args, "rollout_max_context_len", None) is not None
-        and getattr(args, "vllm_max_model_len", None) is None
-    ):
-        cmd += ["--max-model-len", str(args.rollout_max_context_len)]
-
-    if getattr(args, "use_rollout_routing_replay", False):
-        cmd += ["--enable-return-routed-experts"]
-
-    # gpu_memory_utilization: no vime-forced default. In colocate, training and rollout do not
-    # occupy the GPU simultaneously (sleep/offload cycles), so vLLM's own default is fine. A user
-    # value passed via --vllm-gpu-memory-utilization is auto-forwarded by _forward_vllm_cli_args.
-
-    # 2) logprobs_mode: vllm's raw_logprobs are pre-temperature, while Megatron
-    #    replay compares against rollout-temperature-scaled logprobs.
-    if not _user_overrode(args, "vllm_logprobs_mode"):
-        cmd += ["--logprobs-mode", "processed_logprobs"]
-
-    # 3) weight_transfer_config: vllm default None disables /init_weight_transfer_engine,
-    #    so vime's weight sync would fail.
-    #    - Colocated mode: use IPC backend. UpdateWeightFromTensor calls
-    #      IPCWeightTransferEngine.trainer_send_weights and passes an empty init_info
-    #      dict, which is the correct signature for the IPC backend.
-    #    - Non-colocated mode: use NCCL backend. Weight sync goes through
-    #      update_weights_from_distributed; the vLLM engine still needs
-    #      init_weight_transfer_engine to succeed (with NCCL the caller must supply
-    #      master_address, master_port, rank_offset, and world_size separately).
-    #    Users who pass ``--vllm-weight-transfer-config`` explicitly are honored.
-    if _user_overrode(args, "vllm_weight_transfer_config"):
-        cmd += [
-            "--weight-transfer-config",
-            _serialize_weight_transfer_config(args.vllm_weight_transfer_config),
-        ]
-    elif getattr(args, "colocate", False):
-        cmd += ["--weight-transfer-config", '{"backend":"ipc"}']
-    else:
-        cmd += ["--weight-transfer-config", '{"backend":"nccl"}']
-
-    worker_type = server_args.get("worker_type", "regular")
-    if worker_type in ("prefill", "decode") and topology.node_rank == 0:
-        env["VLLM_NIXL_SIDE_CHANNEL_HOST"] = host_for_subprocess
-        env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = str(server_args["disaggregation_bootstrap_port"])
-
-    _forward_vllm_cli_args(args, cmd)
-    logger.info("Launching vLLM server: %s", redact_cmd_for_log(cmd))
-    return cmd, env
+    ns = argparse.Namespace(**kwargs)
+    parser = make_arg_parser(FlexibleArgumentParser())
+    args = parser.parse_args(args=[], namespace=ns)
+    validate_parsed_serve_args(args)
+    ServeSubcommand.cmd(args)
 
 
-def _exec_vllm_cmd(cmd: list[str], env: dict[str, str]) -> None:
-    """Entry point for multiprocessing child process."""
-    os.execvpe(cmd[0], cmd, env)
-
-
-def _normalize_vllm_wake_tags(tags: list[str] | None) -> list[str] | None:
-    if not tags:
-        return tags
-    normalized = [t for t in tags if t in _VLLM_WAKE_TAGS]
-    dropped = set(tags) - set(normalized)
-    if dropped:
-        logger.debug("vLLM wake_up: dropped tags not supported by vLLM: %s", sorted(dropped))
-    return normalized or None
-
-
-def launch_server_process(server_args: dict) -> multiprocessing.Process:
-    """Spawn ``vllm serve`` from a :func:`_compute_server_args` dict."""
-    cmd, env = build_vllm_cmd_and_env(server_args)
-    p = _spawn_ctx.Process(target=_exec_vllm_cmd, args=(cmd, env))
-    p.start()
-    return p
-
-
-def _wait_worker_process_alive(process: multiprocessing.Process, timeout_s: float = 300.0) -> None:
-    """Non-head nodes have no HTTP health endpoint; ensure the subprocess stays up."""
-    start = time.time()
-    while process.is_alive():
-        if time.time() - start > timeout_s:
-            return
-        time.sleep(2)
-    raise RuntimeError(f"vLLM worker process exited unexpectedly with code {process.exitcode}")
-
-
-def _wait_server_healthy(base_url: str, process: multiprocessing.Process | None) -> None:
-    """Wait until the vLLM server responds on ``GET /health``."""
+def _wait_server_healthy(base_url, is_process_alive):
     while True:
         try:
             response = requests.get(f"{base_url}/health")
             if response.status_code == 200:
-                return
+                break
         except requests.RequestException:
             pass
 
-        if process is not None and not process.is_alive():
-            raise RuntimeError(f"vLLM server exited unexpectedly with code {process.exitcode}")
+        if not is_process_alive():
+            raise Exception("Server process terminated unexpectedly.")
+
         time.sleep(2)
 
 
 class VLLMEngine(RayActor):
-    """Ray actor for vLLM OpenAI HTTP rollout (connect or spawn local ``vllm serve``)."""
-
     def __init__(
         self,
         args,
@@ -505,14 +126,7 @@ class VLLMEngine(RayActor):
         self.base_gpu_id = base_gpu_id
         self.vllm_overrides = vllm_overrides or {}
         self.num_gpus_per_engine = num_gpus_per_engine
-        self.process: multiprocessing.Process | None = None
         self._weight_version: str | None = None
-        self.node_rank = 0
-        self._topology: VllmEngineTopology | None = None
-        self._server_args: dict | None = None
-
-    def _http_base(self) -> str:
-        return f"http://{self.server_host}:{self.server_port}"
 
     def init(
         self,
@@ -524,168 +138,123 @@ class VLLMEngine(RayActor):
         router_ip=None,
         router_port=None,
     ):
-        # ``nccl_port`` is allocated by rollout but unused by vLLM (rendezvous uses ``dist_init_addr``).
         del nccl_port
 
-        gpus_per_engine = self.num_gpus_per_engine or self.args.rollout_num_gpus_per_engine
+        self.router_ip = router_ip
+        self.router_port = router_port
+
         host = host or get_host_info()[1]
 
-        self._server_args = _compute_server_args(
+        def _format_v6_uri(addr):
+            if not addr or addr.startswith("["):
+                return addr
+            try:
+                if ipaddress.ip_address(addr).version == 6:
+                    return f"[{addr}]"
+            except ValueError:
+                pass
+            return addr
+
+        host = _format_v6_uri(host)
+        ip_part, port_part = dist_init_addr.rsplit(":", 1)
+        dist_init_addr = f"{_format_v6_uri(ip_part)}:{port_part}"
+
+        server_args_dict, external_engine_need_check_fields = _compute_server_args(
             self.args,
             self.rank,
             dist_init_addr,
             host,
             port,
-            worker_type=self.worker_type,
+            self.worker_type,
+            disaggregation_bootstrap_port,
             base_gpu_id=self.base_gpu_id,
             vllm_overrides=self.vllm_overrides,
-            num_gpus_per_engine=gpus_per_engine,
-            disaggregation_bootstrap_port=disaggregation_bootstrap_port,
+            num_gpus_per_engine=self.num_gpus_per_engine,
         )
-        self._topology = self._server_args["topology"]
-        self.node_rank = self._topology.node_rank
 
-        # rollout always passes the resolved router (engine.init(router_ip=self.router_ip, ...))
-        # and _start_router always returns a real address, so no fallback to args is needed.
-        self.router_ip = router_ip
-        self.router_port = router_port
-        self.server_host = self._server_args["host"]
-        self.server_port = port
-        self.disaggregation_bootstrap_port = disaggregation_bootstrap_port
-
-        if self.worker_type != "regular":
-            logger.warning(
-                "vLLMEngine: worker_type=%s is not used by current vLLM deployment (treated as regular).",
-                self.worker_type,
-            )
+        self.node_rank = server_args_dict["node_rank"]
+        self.server_host = server_args_dict["host"]
+        self.server_port = server_args_dict["port"]
 
         if self.args.rollout_external:
-            # Only the HTTP-owning head node (node_rank 0) can hit /health and
-            # /server_info. Headless workers (node_rank>0) expose no HTTP endpoint,
-            # so skip the check for them — mirrors the head/worker split in _init_normal.
-            if self.node_rank == 0:
-                self._init_external()
-            else:
-                logger.info(
-                    "External vLLM headless worker (rank=%s node_rank=%s): skip HTTP health/config "
-                    "check (only node_rank 0 owns HTTP).",
-                    self.rank,
-                    self.node_rank,
-                )
+            self._init_external(server_args_dict, external_engine_need_check_fields=external_engine_need_check_fields)
         else:
-            self._init_normal()
+            self._init_normal(server_args_dict)
+
+    def _init_external(self, expect_server_args, external_engine_need_check_fields):
+        logger.info(f"Use external vLLM engine (rank={self.rank}, expect_server_args={expect_server_args})")
+
+        def _sanity_check_server_args(actual_server_args, expect_server_args):
+            for name in external_engine_need_check_fields:
+                expect_value = expect_server_args.get(name)
+                actual_value = actual_server_args.get(name)
+                assert (
+                    actual_value == expect_value
+                ), f"{name=} {expect_value=} {actual_value=} {expect_server_args=} {actual_server_args=}"
+
+        _wait_server_healthy(
+            f"http://{self.server_host}:{self.server_port}",
+            is_process_alive=lambda: True,
+        )
+
+        response = requests.get(
+            f"http://{self.server_host}:{self.server_port}/server_info",
+            params={"config_format": "json"},
+        )
+        body = response.json()
+        actual_server_args = body.get("vllm_config", {}).get("parallel_config", {})
+        _sanity_check_server_args(actual_server_args, expect_server_args)
+
+    def _init_normal(self, server_args_dict):
+        logger.info(f"Launch vLLM api_server at: {self.server_host}:{self.server_port}")
+        self.process = launch_server_process(server_args_dict)
+
+        if self.worker_type == "encoder":
+            return
 
         if self.node_rank == 0 and self.router_ip and self.router_port:
-            self._register_worker_with_router()
+            payload = {
+                "url": f"http://{self.server_host}:{self.server_port}",
+                "worker_type": self.worker_type,
+            }
+            response = requests.post(
+                f"http://{self.router_ip}:{self.router_port}/workers",
+                json=payload,
+            )
+            response.raise_for_status()
 
-    def _register_worker_with_router(self) -> None:
-        worker_url = self._http_base()
-        payload = {"url": worker_url, "worker_type": self.worker_type}
-        response = requests.post(
-            f"http://{self.router_ip}:{self.router_port}/workers",
-            json=payload,
-        )
-        response.raise_for_status()
+    def _make_request(self, endpoint: str, payload: dict | None = None):
+        """Make a POST request to the specified endpoint with the given payload.
 
-    def _deregister_worker_from_router(self) -> None:
-        if self.node_rank != 0 or not self.router_ip or not self.router_port:
-            return
-        worker_url = self._http_base()
-        try:
-            all_workers = requests.get(f"http://{self.router_ip}:{self.router_port}/workers").json()["workers"]
-            for worker in all_workers:
-                if worker["url"] == worker_url:
-                    response = requests.delete(
-                        f"http://{self.router_ip}:{self.router_port}/workers/{quote(worker_url, safe='')}",
-                    )
-                    response.raise_for_status()
-                    return
-            logger.warning("Worker %s not found in vllm-router during shutdown.", worker_url)
-        except Exception as e:
-            logger.warning("Failed to list/remove worker on vllm-router: %s", e)
+        Args:
+            endpoint: The API endpoint to call
+            payload: The JSON payload to send (default: empty dict)
 
-    def _init_external(self) -> None:
-        logger.info("Use external vLLM engine (rank=%s) at %s:%s", self.rank, self.server_host, self.server_port)
-        _wait_server_healthy(self._http_base(), process=None)
-        self._sanity_check_external_server_args()
-
-    def _sanity_check_external_server_args(self) -> None:
-        """Strictly verify an external engine's parallel config matches what we expect; raise on mismatch.
-
-        Replaces the previous warn-only check, which (a) compared against the *global*
-        ``rollout_num_gpus_per_engine`` — wrong for heterogeneous / multi-node groups — and
-        (b) only logged a warning, so a misconfigured external engine sailed through and then
-        hung the weight-sync rendezvous ~300s later with no clear error.
-
-        We now compare every field in ``EXTERNAL_ENGINE_CHECK_FIELDS`` against the per-engine
-        expectation in ``self._server_args`` and raise immediately on mismatch. A field that the
-        engine's ``/server_info`` does not report (``actual is None``) is skipped rather than
-        treated as a mismatch (e.g. vLLM ``parallel_config`` may not surface ``nnodes``), so the
-        check stays strict for reported fields without false-failing on unreported ones.
+        Returns:
+            The JSON response from the server
         """
-        response = requests.get(f"{self._http_base()}/server_info", params={"config_format": "json"})
-        body = _response_json(response)
-        parallel_cfg = body.get("vllm_config", {}).get("parallel_config", {})
-        if not parallel_cfg:
-            raise RuntimeError(f"External vLLM /server_info missing vllm_config.parallel_config: {body}")
-        actual = {
-            "tp_size": parallel_cfg.get("tensor_parallel_size"),
-            "pp_size": parallel_cfg.get("pipeline_parallel_size"),
-            "dp_size": parallel_cfg.get("data_parallel_size"),
-            "nnodes": parallel_cfg.get("nnodes"),
-        }
-        expect = {name: self._server_args.get(name) for name in EXTERNAL_ENGINE_CHECK_FIELDS}
-        for name in EXTERNAL_ENGINE_CHECK_FIELDS:
-            actual_value = actual.get(name)
-            if actual_value is None:
-                logger.debug("External vLLM /server_info did not report %s; skipping that check.", name)
-                continue
-            if actual_value != expect.get(name):
-                raise AssertionError(
-                    f"External vLLM server arg mismatch: {name}: expect={expect.get(name)} "
-                    f"actual={actual_value} (full expect={expect} actual={actual})"
-                )
-
-    def _init_normal(self) -> None:
-        topology = self._topology
-        assert topology is not None and self._server_args is not None
-        logger.info(
-            "Launch vLLM OpenAI api_server at: %s:%s (rank=%s node_rank=%s/%s)",
-            self.server_host,
-            self.server_port,
-            self.rank,
-            topology.node_rank,
-            topology.nnodes,
-        )
-        self.process = launch_server_process(self._server_args)
-        if topology.node_rank == 0:
-            _wait_server_healthy(self._http_base(), process=self.process)
-        else:
-            _wait_worker_process_alive(self.process)
-
-    def _make_request(self, endpoint: str, payload: dict | None = None) -> dict | None:
-        """Control-plane POST returning parsed JSON."""
         if self.node_rank != 0:
-            return None
-        url = f"{self._http_base()}/{endpoint.lstrip('/')}"
-        return _response_json(requests.post(url, json=payload or {}))
+            return
 
-    def _post_vllm_update_weights_http(self, update_info: dict) -> dict:
-        """POST ``/update_weights`` with ``{"update_info": ...}`` (vLLM RLHF control plane).
-
-        Caller must invoke ``start_weight_update`` / ``finish_weight_update`` around a batch of
-        ``/update_weights`` calls (see ``UpdateWeightFromTensor`` / ``UpdateWeightFromDistributed``).
-        """
-        return self._make_request(
-            "update_weights",
-            {"update_info": update_info},
-        )
+        url = f"http://{self.server_host}:{self.server_port}/{endpoint}"
+        response = requests.post(url, json=payload or {})
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            e.add_note(f"{response.text=}")
+            raise
+        if not response.content or not response.content.strip():
+            return {"ok": True}
+        return response.json()
 
     def health_generate(self, timeout: float = 5.0) -> bool:
-        """Return True if ``GET /health`` succeeds."""
         if self.node_rank != 0:
             return True
-        response = requests.get(f"{self._http_base()}/health", timeout=timeout)
+
+        response = requests.get(
+            f"http://{self.server_host}:{self.server_port}/health",
+            timeout=timeout,
+        )
         response.raise_for_status()
         return True
 
@@ -696,176 +265,124 @@ class VLLMEngine(RayActor):
         dtype_names: list[str],
         shapes: list[list[int]],
         ipc_handles: list[dict] | None = None,
-        weight_version: str | None = None,
+        weight_version: str,
         flush_cache: bool = False,
-    ) -> dict | None:
-        """POST IPC update payload to vLLM's native ``/update_weights`` endpoint.
-
-        Uses vLLM's built-in ``IPCWeightTransferEngine.receive_weights`` which
-        handles GPU UUID routing and device_index remapping internally.
-        """
-        if self.node_rank != 0:
-            return None
-
+    ):
         payload: dict = {"names": names, "dtype_names": dtype_names, "shapes": shapes}
         if ipc_handles is not None:
             payload["ipc_handles_pickled"] = base64.b64encode(cloudpickle.dumps(ipc_handles)).decode("utf-8")
         if flush_cache:
             self.flush_cache()
-
-        response = self._post_vllm_update_weights_http(payload)
-        if weight_version is not None:
-            self._weight_version = str(weight_version)
-        return response
+        result = self._make_request("update_weights", {"update_info": payload})
+        self._weight_version = str(weight_version)
+        return result
 
     def flush_cache(self):
-        """Reset the prefix cache via ``POST /reset_prefix_cache``."""
         if self.node_rank != 0:
             return
         params = {"reset_running_requests": False}
-        requests.post(f"{self._http_base()}/reset_prefix_cache", params=params).raise_for_status()
+        requests.post(
+            f"http://{self.server_host}:{self.server_port}/reset_prefix_cache", params=params
+        ).raise_for_status()
 
     def get_url(self):
-        """Worker HTTP base URL, or ``None`` when ``node_rank != 0``."""
         if self.node_rank != 0:
             return None
-        return self._http_base()
+        return f"http://{self.server_host}:{self.server_port}"
 
     def shutdown(self):
-        logger.info("Shutdown engine %s:%s...", self.server_host, self.server_port)
-        self._deregister_worker_from_router()
         if self.args.rollout_external:
             return
 
-        if self.process is None or not self.process.is_alive():
-            return
-        pid = self.process.pid
-        try:
-            from vllm.utils.system_utils import kill_process_tree
+        logger.info(f"Shutdown engine {self.server_host}:{self.server_port}...")
+        if self.worker_type != "encoder" and self.node_rank == 0:
+            worker_url = f"http://{self.server_host}:{self.server_port}"
+            try:
+                all_workers = requests.get(f"http://{self.router_ip}:{self.router_port}/workers").json()["workers"]
+                for worker in all_workers:
+                    if worker["url"] == worker_url:
+                        response = requests.delete(
+                            f"http://{self.router_ip}:{self.router_port}/workers/{quote(worker_url, safe='')}",
+                        )
+                        response.raise_for_status()
+                        break
+                else:
+                    logger.warning(f"Worker {worker_url} not found in vllm-router during shutdown.")
+            except Exception as e:
+                logger.warning(f"Failed to fetch workers list or remove worker: {e}")
 
-            kill_process_tree(pid)
-        except Exception as e:
-            logger.warning("vLLM kill_process_tree failed (%s); terminate root only.", e)
-            if self.process.is_alive():
-                self.process.terminate()
-                try:
-                    self.process.join(timeout=15)
-                except Exception:
-                    pass
-                if self.process.is_alive():
-                    self.process.kill()
-        try:
-            self.process.join(timeout=30)
-        except Exception:
-            pass
-        self.process = None
+        kill_process_tree(self.process.pid)
 
-    def get_weight_version(self) -> str | None:
-        """Return the version recorded by the last successful weight transfer.
-
-        Raises ``RuntimeError`` if no weight transfer has recorded a version
-        yet — we don't fall back to a ``/v1/models`` lookup, which would
-        return the model path string and never match the trainer's integer
-        counter (i.e. produce a misleading "mismatch" downstream).
-        Worker ranks (``node_rank != 0``) short-circuit per the class idiom.
-        """
+    def get_weight_version(self):
         if self.node_rank != 0:
-            return None
+            return
         if self._weight_version is None:
             raise RuntimeError(
-                "VLLMEngine.get_weight_version called before any successful "
-                "weight transfer recorded a version (update_weights_from_tensor "
-                "/ update_weights_from_distributed never reached their "
-                "post-POST version write)."
+                "VLLMEngine.get_weight_version called before any successful " "weight transfer recorded a version."
             )
         return self._weight_version
 
-    def release_memory_occupation(self, level: int = 2):
-        """Flush prefix cache, then ``POST /sleep?level={level}``."""
-        if self.node_rank != 0:
-            return None
-        self.flush_cache()
-        response = requests.post(
-            f"{self._http_base()}/sleep",
-            params={"level": level},
-        )
-        return _response_json(response)
+    def set_weight_version(self, new_version: str):
+        self._weight_version = str(new_version)
 
-    def resume_memory_occupation(self, tags: list[str] | None = None):
-        """``POST /wake_up`` with vLLM-supported wake tags."""
-        if self.node_rank != 0:
-            return None
+    def release_memory_occupation(self, level: int = 2):
+        self.flush_cache()
+        response = requests.post(f"http://{self.server_host}:{self.server_port}/sleep", params={"level": level})
+        response.raise_for_status()
+        if not response.content or not response.content.strip():
+            return {"ok": True}
+        return response.json()
+
+    def resume_memory_occupation(self, tags: list[str] = None):
         tags = _normalize_vllm_wake_tags(tags)
         wake_params: list[tuple[str, str]] | None = [("tags", t) for t in tags] if tags else None
-        response = requests.post(
-            f"{self._http_base()}/wake_up",
-            params=wake_params,
-        )
-        return _response_json(response)
+        response = requests.post(f"http://{self.server_host}:{self.server_port}/wake_up", params=wake_params)
+        response.raise_for_status()
+        if not response.content or not response.content.strip():
+            return {"ok": True}
+        return response.json()
+
+    def check_weights(self, action: str):
+        del action
+        return {"ok": True, "supported": False}
 
     def init_weight_transfer_engine(self, payload: dict) -> dict:
-        """``POST /init_weight_transfer_engine`` with a caller-supplied payload (IPC path).
-
-        For IPC mode the payload is ``{"init_info": {}}``; for NCCL use
-        ``init_weights_update_group`` which constructs the payload from typed args.
-        """
-        last_error = None
-        for attempt in range(1, 4):
-            try:
-                return self._make_request("init_weight_transfer_engine", payload)
-            except Exception as e:
-                last_error = e
-                if attempt < 3:
-                    logger.warning("init_weight_transfer_engine attempt %s/3 failed: %s", attempt, e)
-                    time.sleep(2 * attempt)
-        raise RuntimeError(f"vLLM init_weight_transfer_engine failed: {last_error}") from last_error
+        return self._make_request("init_weight_transfer_engine", payload)
 
     def start_weight_update(self, is_checkpoint_format: bool = False) -> dict:
-        """``POST /start_weight_update`` — signals vLLM to enter IPC weight-update mode."""
         return self._make_request("start_weight_update", {"is_checkpoint_format": is_checkpoint_format})
 
     def finish_weight_update(self) -> dict:
-        """``POST /finish_weight_update`` — signals vLLM to exit IPC weight-update mode.
-
-        Purely a state-machine bookend now; ``_weight_version`` is recorded by
-        ``update_weights_from_tensor`` (the IPC data-carrying RPC), matching vime's
-        single-RPC version-with-data semantics.
-        """
         return self._make_request("finish_weight_update", {})
 
-    def check_weights(self, action: str):
-        """No vLLM ``weights_checker`` route; return a placeholder dict."""
-        del action
-        return {"ok": True, "supported": False, "note": "vLLM has no weights_checker endpoint."}
+    def update_weights_from_disk(self, model_path: str, load_format: str | None = None):
+        del load_format
+        response = requests.post(
+            f"http://{self.server_host}:{self.server_port}/collective_rpc",
+            json={"method": "reload_weights", "kwargs": {"weights_path": model_path, "is_checkpoint_format": True}},
+        )
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            e.add_note(f"{response.text=}")
+            raise
+        return response.json()
 
     def init_weights_update_group(self, master_address, master_port, rank_offset, world_size, group_name, backend):
-        """Call ``POST /init_weight_transfer_engine`` with an ``init_info`` block.
-
-        ``group_name`` / ``backend`` are accepted for a uniform caller signature but are not sent to vLLM.
-        Always uses the vllm-native weight transfer engine; reload-on-continue fallback is no longer supported.
-        """
         del group_name, backend
-        payload = {
-            "init_info": {
-                "master_address": master_address,
-                "master_port": master_port,
-                "rank_offset": rank_offset,
-                "world_size": world_size,
-            }
-        }
-        last_error = None
-        for attempt in range(1, 4):
-            try:
-                return self._make_request("init_weight_transfer_engine", payload)
-            except Exception as e:
-                last_error = e
-                if attempt < 3:
-                    logger.warning("init_weight_transfer_engine attempt %s/3 failed: %s", attempt, e)
-                    time.sleep(2 * attempt)
-        raise RuntimeError(f"vLLM init_weight_transfer_engine failed: {last_error}") from last_error
+        return self._make_request(
+            "init_weight_transfer_engine",
+            {
+                "init_info": {
+                    "master_address": master_address,
+                    "master_port": master_port,
+                    "rank_offset": rank_offset,
+                    "world_size": world_size,
+                }
+            },
+        )
 
     def destroy_weights_update_group(self, group_name):
-        """No vLLM destroy call; return ``None``."""
         del group_name
         return None
 
@@ -875,17 +392,12 @@ class VLLMEngine(RayActor):
         dtypes,
         shapes,
         group_name,
+        *,
         flush_cache=False,
-        weight_version: str | None = None,
+        weight_version: str,
         packed: bool = True,
     ):
-        """NCCL path: ``POST /update_weights`` with packed tensor metadata.
-
-        Payload matches vLLM NCCL weight transfer (see upstream rlhf_http_nccl example).
-        """
         del group_name
-        if weight_version is not None:
-            self._weight_version = str(weight_version)
         if flush_cache:
             self.flush_cache()
         dtype_names = [str(d).replace("torch.", "") for d in dtypes]
@@ -895,28 +407,13 @@ class VLLMEngine(RayActor):
             "shapes": [list(s) for s in shapes],
             "packed": bool(packed),
         }
-        return self._post_vllm_update_weights_http(update_info)
-
-    def update_weights_from_disk(self, model_path: str, load_format: str | None = None):
-        """``POST /collective_rpc`` with ``reload_weights`` and ``weights_path``."""
-        if self.node_rank != 0:
-            return
-        del load_format
-        response = requests.post(
-            f"{self._http_base()}/collective_rpc",
-            json={
-                "method": "reload_weights",
-                "kwargs": {"weights_path": model_path, "is_checkpoint_format": True},
-            },
-        )
-        return _response_json(response)
+        result = self._make_request("update_weights", {"update_info": update_info})
+        self._weight_version = str(weight_version)
+        return result
 
     def pause_generation(self):
-        """``POST /pause`` with mode="keep"; returns the ``requests.Response``."""
-        if self.node_rank != 0:
-            return None
         response = requests.post(
-            f"{self._http_base()}/pause",
+            f"http://{self.server_host}:{self.server_port}/pause",
             params={"mode": "keep", "clear_cache": "false"},
             json={},
         )
@@ -924,10 +421,7 @@ class VLLMEngine(RayActor):
         return response
 
     def continue_generation(self):
-        """``POST /resume`` to continue generation after pause."""
-        if self.node_rank != 0:
-            return None
-        response = requests.post(f"{self._http_base()}/resume", json={})
+        response = requests.post(f"http://{self.server_host}:{self.server_port}/resume", json={})
         response.raise_for_status()
         return response
 
@@ -936,9 +430,8 @@ class VLLMEngine(RayActor):
         restore_weights_before_load: bool = False,
         post_process_quantization: bool = False,
     ):
-        """No vLLM HTTP hook for post-load processing; return a noop placeholder dict."""
         del restore_weights_before_load, post_process_quantization
-        return {"ok": True, "noop": True, "note": "vLLM post_process is internal to load; no HTTP API."}
+        return {"ok": True, "noop": True}
 
     def start_profile(
         self,
@@ -950,31 +443,12 @@ class VLLMEngine(RayActor):
         with_stack: bool | None = None,
         record_shapes: bool | None = None,
     ):
-        """``POST /start_profile`` with an empty JSON body; kwargs are not forwarded and may be ignored by the server."""
-        if self.node_rank != 0:
-            return None
-        if any(
-            x is not None and x is not False
-            for x in (
-                output_dir,
-                start_step,
-                num_steps,
-                activities,
-                profile_by_stage,
-                with_stack,
-                record_shapes,
-            )
-        ):
-            logger.warning("vLLM start_profile: extra kwargs may be ignored by server; see vLLM profiling docs.")
-        response = requests.post(f"{self._http_base()}/start_profile", json={})
+        response = requests.post(f"http://{self.server_host}:{self.server_port}/start_profile", json={})
         response.raise_for_status()
         return response
 
     def stop_profile(self):
-        """POST ``/stop_profile`` to stop an active server-side profile."""
-        if self.node_rank != 0:
-            return None
-        response = requests.post(f"{self._http_base()}/stop_profile", json={})
+        response = requests.post(f"http://{self.server_host}:{self.server_port}/stop_profile", json={})
         response.raise_for_status()
         return response
 
@@ -985,8 +459,31 @@ class VLLMEngine(RayActor):
                 self.args.rollout_external,
             )
             return
-        logger.info("Simulating crash on engine %s:%s...", self.server_host, self.server_port)
+
+        logger.info(f"Simulating crash on engine {self.server_host}:{self.server_port}...")
         self.shutdown()
+
+
+def _normalize_vllm_wake_tags(tags: list[str] | None) -> list[str] | None:
+    if not tags:
+        return tags
+    normalized = [t for t in tags if t in _VLLM_WAKE_TAGS]
+    dropped = set(tags) - set(normalized)
+    if dropped:
+        logger.debug("vLLM wake_up: dropped tags not supported by vLLM: %s", sorted(dropped))
+    return normalized or None
+
+
+def _resolve_parallel_sizes(args, *, gpus_per_engine: int) -> tuple[int, int, int]:
+    pp = int(getattr(args, "vllm_pipeline_parallel_size", 1) or 1)
+    dp = int(getattr(args, "vllm_dp_size", None) or getattr(args, "vllm_data_parallel_size", 1) or 1)
+    if gpus_per_engine % (pp * dp) != 0:
+        raise ValueError(
+            f"num_gpus_per_engine ({gpus_per_engine}) must be divisible by "
+            f"vllm_pipeline_parallel_size * vllm_data_parallel_size ({pp} * {dp} = {pp * dp})"
+        )
+    tp = gpus_per_engine // (pp * dp)
+    return tp, pp, dp
 
 
 def _compute_server_args(
@@ -995,51 +492,162 @@ def _compute_server_args(
     dist_init_addr,
     host,
     port,
-    *,
     worker_type: str = "regular",
+    disaggregation_bootstrap_port: int | None = None,
     base_gpu_id: int | None = None,
     vllm_overrides: dict | None = None,
     num_gpus_per_engine: int | None = None,
-    disaggregation_bootstrap_port: int | None = None,
-) -> dict[str, Any]:
-    """Build per-actor launch config for ``launch_server_process``."""
-    gpus_per_engine = num_gpus_per_engine or args.rollout_num_gpus_per_engine
-    if gpus_per_engine > args.num_gpus_per_node and gpus_per_engine % args.num_gpus_per_node != 0:
-        raise ValueError(
-            "vLLM multi-node rollout requires rollout_num_gpus_per_engine to be divisible by "
-            f"num_gpus_per_node, got rollout_num_gpus_per_engine={gpus_per_engine} "
-            f"num_gpus_per_node={args.num_gpus_per_node}."
-        )
+):
+    _gpus_per_engine = num_gpus_per_engine or args.rollout_num_gpus_per_engine
+    nnodes = max(1, _gpus_per_engine // args.num_gpus_per_node)
+    node_rank = rank % nnodes
+    if nnodes == 1:
+        local_num_gpus = min(args.num_gpus_per_node, _gpus_per_engine)
+    else:
+        if _gpus_per_engine % nnodes != 0:
+            raise ValueError(
+                f"rollout_num_gpus_per_engine ({_gpus_per_engine}) must be divisible by "
+                f"the number of nodes per engine ({nnodes})"
+            )
+        local_num_gpus = _gpus_per_engine // nnodes
 
-    topology = compute_vllm_engine_topology(args, rank, num_gpus_per_engine=gpus_per_engine)
+    tp, pp, dp = _resolve_parallel_sizes(args, gpus_per_engine=_gpus_per_engine)
     base = base_gpu_id if base_gpu_id is not None else get_base_gpu_id(args, rank)
 
     master_addr: str | None = None
     master_port: int | None = None
-    if topology.multi_node:
+    if nnodes > 1:
         if not dist_init_addr:
             raise ValueError("dist_init_addr is required when launching a multi-node vLLM engine")
-        master_addr, master_port = parse_dist_init_addr(dist_init_addr)
+        ip_part, port_part = dist_init_addr.rsplit(":", 1)
+        master_addr = ip_part.strip("[]")
+        master_port = int(port_part)
 
-    server_args = {
-        "args": args,
-        "rank": rank,
-        "worker_type": worker_type,
-        "model_path": args.hf_checkpoint,
-        "host": _format_v6_uri(host),
+    host_for_subprocess = (host or "127.0.0.1").strip("[]")
+
+    kwargs: dict[str, Any] = {
+        "model": str(args.hf_checkpoint),
+        "trust_remote_code": True,
+        "seed": args.seed + rank,
+        "host": host_for_subprocess,
         "port": port,
-        "master_addr": master_addr,
-        "master_port": master_port,
-        "dist_init_addr": dist_init_addr,
-        "nnodes": topology.nnodes,
-        "node_rank": topology.node_rank,
-        "topology": topology,
-        "visible_devices": ",".join(str(base + i) for i in range(topology.local_num_gpus)),
-        "tp_size": topology.tensor_parallel_size,
-        "pp_size": topology.pipeline_parallel_size,
-        "dp_size": _get_vllm_dp_size(args),
-        "seed": getattr(args, "seed", 1234) + rank,
-        "disaggregation_bootstrap_port": disaggregation_bootstrap_port,
+        "nnodes": nnodes,
+        "node_rank": node_rank,
+        "tensor_parallel_size": tp,
+        "logprobs_mode": "processed_logprobs",
+        "enable_prompt_tokens_details": True,
+        "enable_server_load_tracking": True,
     }
-    _apply_vllm_overrides(args, server_args, vllm_overrides, rank)
-    return server_args
+
+    if pp > 1:
+        kwargs["pipeline_parallel_size"] = pp
+
+    if nnodes > 1:
+        kwargs["master_addr"] = master_addr
+        kwargs["master_port"] = master_port
+        kwargs["data_parallel_backend"] = "mp"
+        kwargs["distributed_executor_backend"] = "mp"
+        if node_rank != 0:
+            kwargs["headless"] = True
+
+    if worker_type == "prefill":
+        kwargs["disaggregation_mode"] = "prefill"
+        assert (
+            disaggregation_bootstrap_port is not None
+        ), "disaggregation_bootstrap_port must be set for prefill worker"
+    elif worker_type == "decode":
+        kwargs["disaggregation_mode"] = "decode"
+
+    if args.use_rollout_routing_replay:
+        kwargs["enable_return_routed_experts"] = True
+    if args.fp16:
+        kwargs["dtype"] = "float16"
+
+    if args.offload_rollout and not getattr(args, "vllm_enable_sleep_mode", False):
+        kwargs["enable_sleep_mode"] = True
+        args.vllm_enable_sleep_mode = True
+
+    if (
+        getattr(args, "rollout_max_context_len", None) is not None
+        and getattr(args, "vllm_max_model_len", None) is None
+    ):
+        kwargs["max_model_len"] = args.rollout_max_context_len
+
+    if args.colocate:
+        kwargs["weight_transfer_config"] = {"backend": "ipc"}
+    else:
+        kwargs["weight_transfer_config"] = {"backend": "nccl"}
+
+    external_engine_need_check_fields = [k for k in kwargs.keys() if k not in _EXTERNAL_ENGINE_SKIP_CHECK_FIELDS]
+
+    global _VLLM_SERVER_FIELDS  # noqa: PLW0603
+    if _VLLM_SERVER_FIELDS is None:
+        _VLLM_SERVER_FIELDS = _vllm_server_field_names()
+
+    for key, value in vars(args).items():
+        if not key.startswith("vllm_"):
+            continue
+        field_name = key[len("vllm_") :]
+        if field_name not in _VLLM_SERVER_FIELDS:
+            continue
+        if field_name in kwargs:
+            continue
+        if value is None:
+            continue
+        kwargs[field_name] = value
+
+    # Per-server-group overrides from --vllm-config YAML.
+    # Applied after base args so they take highest priority.
+    if vllm_overrides:
+        for key, value in vllm_overrides.items():
+            normalized_key = key.replace("-", "_")
+            if normalized_key != key:
+                logger.warning(
+                    f"vllm_overrides key '{key}' normalized to '{normalized_key}' (rank={rank}). "
+                    "Please use underscore style in YAML overrides."
+                )
+            if normalized_key in ("model_path",) or normalized_key.startswith("disaggregation"):
+                continue
+            if normalized_key in kwargs:
+                logger.info(
+                    f"vllm_overrides: overriding {normalized_key}={kwargs[normalized_key]} -> {value} (rank={rank})"
+                )
+            kwargs[normalized_key] = value
+        if "model_path" in {k.replace("-", "_") for k in vllm_overrides}:
+            kwargs["model"] = str(vllm_overrides.get("model_path") or vllm_overrides.get("model-path"))
+
+    # vLLM-specific: topology metadata consumed by launch_server_process / _build_subprocess_env.
+    # These keys are stripped before passing to vLLM's argparse.
+    kwargs["_args"] = args
+    kwargs["_rank"] = rank
+    kwargs["_worker_type"] = worker_type
+    kwargs["_visible_devices"] = ",".join(str(base + i) for i in range(local_num_gpus))
+    kwargs["_tp_size"] = tp
+    kwargs["_pp_size"] = pp
+    kwargs["_dp_size"] = dp
+    kwargs["_disaggregation_bootstrap_port"] = disaggregation_bootstrap_port
+
+    return kwargs, external_engine_need_check_fields
+
+
+def _vllm_server_field_names() -> frozenset[str]:
+    from vllm.engine.arg_utils import AsyncEngineArgs
+    from vllm.entrypoints.openai.cli_args import FrontendArgs
+
+    return frozenset(f.name for f in (*dataclasses.fields(AsyncEngineArgs), *dataclasses.fields(FrontendArgs)))
+
+
+_VLLM_SERVER_FIELDS: frozenset[str] | None = None
+
+
+_EXTERNAL_ENGINE_SKIP_CHECK_FIELDS = [
+    "model",
+    "trust_remote_code",
+    "seed",
+    "host",
+    "port",
+    "tensor_parallel_size",
+    "logprobs_mode",
+    "enable_prompt_tokens_details",
+    "enable_server_load_tracking",
+]

--- a/vime/utils/arguments.py
+++ b/vime/utils/arguments.py
@@ -1849,16 +1849,6 @@ def vime_validate_args(args):
             if hasattr(args, k):
                 logger.info(f"Warning: Argument {k} is already set to {getattr(args, k)}, will override with {v}.")
             setattr(args, k, v)
-            # vllm launch_server_process distinguishes "user-supplied value" from
-            # "argparse default" via ``args._vllm_user_provided``. YAML overrides
-            # bypass argparse, so we register them explicitly here — without this,
-            # YAML values that happen to equal the vllm-side default (e.g.
-            # ``vllm_gpu_memory_utilization: 0.92``) would be treated as "default"
-            # and silently replaced by vime's preferred value.
-            if isinstance(k, str) and k.startswith("vllm_"):
-                if not hasattr(args, "_vllm_user_provided"):
-                    args._vllm_user_provided = set()
-                args._vllm_user_provided.add(k)
 
     if args.eval_max_context_len is None:
         logger.info(


### PR DESCRIPTION
## Summary

- Switch vLLM engine launch from CLI subprocess (`os.execvpe`) to in-process Python API (`ServeSubcommand.cmd` via `multiprocessing.Process`), eliminating all CLI serialization code
- Replace `_ORCHESTRATION_DESTS` manual skip-set with `dataclasses.fields()` introspection (`AsyncEngineArgs` + `FrontendArgs`), matching slime's `ServerArgs.fields()` pattern
- Register `FrontendArgs.add_cli_args` alongside `AsyncEngineArgs.add_cli_args` to cover `enable_prompt_tokens_details`, `enable_server_load_tracking`, etc.

<img width="694" height="344" alt="image" src="https://github.com/user-attachments/assets/17e004db-c799-4226-9df9-5ec0ad72c1fc" />
<img width="726" height="350" alt="image" src="https://github.com/user-attachments/assets/d0a43e34-9a56-49f2-a5ae-60a0e27f641e" />

## Test plan

- [x] 90 unit tests pass (test_vllm_arguments + test_vllm_engine + test_sample + test_agent_trajectory + test_megatron_argument_validation)
- [x] Zero dead-symbol references (grep for all 20+ deleted names)
- [x] Import smoke test
- [ ] GPU smoke test on h200/gb200

🤖 Generated with [Claude Code](https://claude.com/claude-code)