### PR TITLE
[NPU] fix qwen3-30b ep

### DIFF
--- a/scripts/run-qwen3-30B-A3B-npu.sh
+++ b/scripts/run-qwen3-30B-A3B-npu.sh
@@ -15,7 +15,7 @@ unset http_proxy
 unset https_proxy
 
 
-SCRIPT_DIR="/root/vime/scripts/"
+SCRIPT_DIR="/root/vime/scripts"
 source "${SCRIPT_DIR}/models/qwen3-30B-A3B-npu.sh"
 MODEL_ROOT="${MODEL_ROOT:-/root}"
 
@@ -39,6 +39,7 @@ python /root/vime/train.py \
   --rollout-backend vllm \
   --vllm-weight-sync-mode native \
   --vllm-gpu-memory-utilization 0.7 \
+  --vllm-enable-expert-parallel \
   --vllm-enable-sleep-mode \
   --vllm-max-model-len $((1024 * 20)) \
   \

--- a/train_async.py
+++ b/train_async.py
@@ -4,7 +4,9 @@ from vime.ray.placement_group import create_placement_groups, create_rollout_man
 from vime.utils.arguments import parse_args
 from vime.utils.logging_utils import configure_logger, finish_tracking, init_tracking, update_tracking_open_metrics
 from vime.utils.misc import should_run_periodic_action
-
+from vime.utils.common import is_npu
+if is_npu():
+    import mindspeed.megatron_adaptor
 
 # The framework supports other asynchronous approaches such as fully async (which is shown in examples/full_async).
 def train(args):

--- a/train_async.py
+++ b/train_async.py
@@ -2,11 +2,13 @@ import ray
 
 from vime.ray.placement_group import create_placement_groups, create_rollout_manager, create_training_models
 from vime.utils.arguments import parse_args
+from vime.utils.common import is_npu
 from vime.utils.logging_utils import configure_logger, finish_tracking, init_tracking, update_tracking_open_metrics
 from vime.utils.misc import should_run_periodic_action
-from vime.utils.common import is_npu
+
 if is_npu():
-    import mindspeed.megatron_adaptor
+    import mindspeed.megatron_adaptor  # noqa: F401
+
 
 # The framework supports other asynchronous approaches such as fully async (which is shown in examples/full_async).
 def train(args):

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -12,7 +12,6 @@ https://docs.vllm.ai/en/stable/examples/rl/rlhf_ipc/
 
 from __future__ import annotations
 
-import logging
 import os
 from argparse import Namespace
 from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -20,8 +19,6 @@ from typing import Any
 
 import ray
 import torch
-
-logger = logging.getLogger(__name__)
 import torch.distributed as dist
 from megatron.core import mpu
 from ray import ObjectRef
@@ -388,7 +385,7 @@ def _send_to_colocated_engine(
 
 
 # ---------------------------------------------------------------------------
-# vLLM worker extension (loaded by ``--worker-extension-cls`` in colocate mode)
+# vLLM worker extension (loaded by ``--worker-extension-cls``)
 # ---------------------------------------------------------------------------
 
 
@@ -403,9 +400,6 @@ class _VLLMHijack:
       (mindspeed/megatron backends introduce flash_attn as a dummy module,
       but vllm_ascend does not use it).
     """
-
-    _npu_worker_patched = False
-    _npu_rotary_patched = False
 
     @staticmethod
     def hijack() -> None:
@@ -422,20 +416,15 @@ class _VLLMHijack:
         IPCWeightTransferEngine.receive_weights = _vime_receive_weights
         IPCWeightTransferEngine._vime_receive_patched = True  # type: ignore[attr-defined]
 
-        _VLLMHijack._patch_npu_worker()
-        _VLLMHijack._patch_npu_rotary_emb()
-
     @staticmethod
     def _patch_npu_worker() -> None:
-        if _VLLMHijack._npu_worker_patched or not is_npu():
+        from vllm_ascend.worker.worker import NPUWorker
+
+        if getattr(NPUWorker, "_npu_worker_patched", False):
             return
-        try:
-            from vllm_ascend.worker.worker import NPUWorker
-        except ImportError:
-            return
+
         _VLLMHijack._patch_one_worker(NPUWorker)
-        _VLLMHijack._npu_worker_patched = True
-        logger.info("vime MoE weight_loader patch: patched NPUWorker")
+        NPUWorker._npu_worker_patched = True
 
     @staticmethod
     def _patch_one_worker(worker_cls: type) -> None:
@@ -470,7 +459,6 @@ class _VLLMHijack:
             if inner_model is None or not hasattr(inner_model, "layers"):
                 return
 
-        patched = False
         for layer in inner_model.layers:
             mlp = getattr(layer, "mlp", None) or getattr(layer, "block_sparse_moe", None)
             if mlp is None:
@@ -482,17 +470,12 @@ class _VLLMHijack:
                 if "w13_weight" in name or "w2_weight" in name:
                     if not hasattr(param, "weight_loader"):
                         param.weight_loader = experts.weight_loader  # type: ignore[attr-defined]
-                        patched = True
-        if patched:
-            logger.info("vime MoE weight_loader patch applied")
 
     @staticmethod
     def _patch_npu_rotary_emb() -> None:
-        if _VLLMHijack._npu_rotary_patched or not is_npu():
-            return
-        try:
-            from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
-        except ImportError:
+        from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
+        
+        if getattr(ApplyRotaryEmb, "_npu_rotary_patched", False):
             return
 
         def _npu_rotary_emb_init(
@@ -507,8 +490,7 @@ class _VLLMHijack:
             self.apply_rotary_emb_flash_attn = None
 
         ApplyRotaryEmb.__init__ = _npu_rotary_emb_init  # type: ignore[attr-defined]
-        _VLLMHijack._npu_rotary_patched = True
-        logger.info("vime NPU patch: ApplyRotaryEmb.__init__ patched to skip flash_attn")
+        ApplyRotaryEmb._npu_rotary_patched = True
 
 
 class vLLMColocateWorkerExtension:
@@ -595,3 +577,12 @@ class vLLMColocateWorkerExtension:
         # Ensure the receiver has finished consuming the IPC tensors before
         # the sender drops its reference on the next barrier.
         torch.accelerator.synchronize()
+
+class vLLMWorkerExtension:
+    """vLLM ``--worker-extension-cls`` entry for general bugfix."""
+
+    def __new__(cls, **kwargs):
+        if is_npu():
+            _VLLMHijack._patch_npu_worker()
+            _VLLMHijack._patch_npu_rotary_emb()
+        return super().__new__(cls)

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -12,6 +12,7 @@ https://docs.vllm.ai/en/stable/examples/rl/rlhf_ipc/
 
 from __future__ import annotations
 
+import logging
 import os
 from argparse import Namespace
 from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -19,11 +20,14 @@ from typing import Any
 
 import ray
 import torch
+
+logger = logging.getLogger(__name__)
 import torch.distributed as dist
 from megatron.core import mpu
 from ray import ObjectRef
 from ray.actor import ActorHandle
 
+from vime.utils.common import is_npu
 from vime.utils.distributed_utils import get_gloo_group
 
 from .hf_weight_iterator_base import HfWeightIteratorBase
@@ -389,7 +393,19 @@ def _send_to_colocated_engine(
 
 
 class _VLLMHijack:
-    """Monkey-patch vLLM IPC receive so CUDA IPC handles deserialize on the correct GPU."""
+    """Monkey-patch vLLM IPC receive so CUDA IPC handles deserialize on the correct GPU.
+
+    On NPU only:
+    - Patches NPUWorker.load_model and NPUWorker.start_weight_update to fix
+      MoE weight_loader missing on EP (a vLLM bug where w13_weight/w2_weight
+      params lack weight_loader attr when EP is enabled).
+    - Patches ApplyRotaryEmb.__init__ to skip flash_attn import
+      (mindspeed/megatron backends introduce flash_attn as a dummy module,
+      but vllm_ascend does not use it).
+    """
+
+    _npu_worker_patched = False
+    _npu_rotary_patched = False
 
     @staticmethod
     def hijack() -> None:
@@ -405,6 +421,94 @@ class _VLLMHijack:
 
         IPCWeightTransferEngine.receive_weights = _vime_receive_weights
         IPCWeightTransferEngine._vime_receive_patched = True  # type: ignore[attr-defined]
+
+        _VLLMHijack._patch_npu_worker()
+        _VLLMHijack._patch_npu_rotary_emb()
+
+    @staticmethod
+    def _patch_npu_worker() -> None:
+        if _VLLMHijack._npu_worker_patched or not is_npu():
+            return
+        try:
+            from vllm_ascend.worker.worker import NPUWorker
+        except ImportError:
+            return
+        _VLLMHijack._patch_one_worker(NPUWorker)
+        _VLLMHijack._npu_worker_patched = True
+        logger.info("vime MoE weight_loader patch: patched NPUWorker")
+
+    @staticmethod
+    def _patch_one_worker(worker_cls: type) -> None:
+        import inspect
+        _orig_load_model = worker_cls.load_model
+        _orig_start_weight_update = worker_cls.start_weight_update
+        has_dummy_kw = "load_dummy_weights" in inspect.signature(_orig_load_model).parameters
+
+        if has_dummy_kw:
+            def _patched_load_model(self, *, load_dummy_weights: bool = False, _orig=_orig_load_model) -> None:
+                _orig(self, load_dummy_weights=load_dummy_weights)
+                _VLLMHijack.patch_moe_weight_loader(self.model_runner.model)
+        else:
+            def _patched_load_model(self, _orig=_orig_load_model) -> None:
+                _orig(self)
+                _VLLMHijack.patch_moe_weight_loader(self.model_runner.model)
+
+        def _patched_start_weight_update(self, is_checkpoint_format: bool = True, _orig=_orig_start_weight_update) -> None:
+            _VLLMHijack.patch_moe_weight_loader(self.model_runner.model)
+            _orig(self, is_checkpoint_format=is_checkpoint_format)
+
+        worker_cls.load_model = _patched_load_model  # type: ignore[attr-defined]
+        worker_cls.start_weight_update = _patched_start_weight_update  # type: ignore[attr-defined]
+
+    @staticmethod
+    def patch_moe_weight_loader(model: torch.nn.Module) -> None:
+        inner_model = getattr(model, "model", None) or getattr(model, "language_model", None)
+        if inner_model is None:
+            return
+        if not hasattr(inner_model, "layers"):
+            inner_model = getattr(inner_model, "model", None)
+            if inner_model is None or not hasattr(inner_model, "layers"):
+                return
+
+        patched = False
+        for layer in inner_model.layers:
+            mlp = getattr(layer, "mlp", None) or getattr(layer, "block_sparse_moe", None)
+            if mlp is None:
+                continue
+            experts = getattr(mlp, "experts", None)
+            if experts is None or not hasattr(experts, "weight_loader"):
+                continue
+            for name, param in mlp.named_parameters():
+                if "w13_weight" in name or "w2_weight" in name:
+                    if not hasattr(param, "weight_loader"):
+                        param.weight_loader = experts.weight_loader  # type: ignore[attr-defined]
+                        patched = True
+        if patched:
+            logger.info("vime MoE weight_loader patch applied")
+
+    @staticmethod
+    def _patch_npu_rotary_emb() -> None:
+        if _VLLMHijack._npu_rotary_patched or not is_npu():
+            return
+        try:
+            from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
+        except ImportError:
+            return
+
+        def _npu_rotary_emb_init(
+            self,
+            enforce_enable: bool = False,
+            is_neox_style: bool = True,
+            enable_fp32_compute: bool = False,
+        ) -> None:
+            super(ApplyRotaryEmb, self).__init__(enforce_enable=enforce_enable)
+            self.is_neox_style = is_neox_style
+            self.enable_fp32_compute = enable_fp32_compute
+            self.apply_rotary_emb_flash_attn = None
+
+        ApplyRotaryEmb.__init__ = _npu_rotary_emb_init  # type: ignore[attr-defined]
+        _VLLMHijack._npu_rotary_patched = True
+        logger.info("vime NPU patch: ApplyRotaryEmb.__init__ patched to skip flash_attn")
 
 
 class vLLMColocateWorkerExtension:

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -429,20 +429,26 @@ class _VLLMHijack:
     @staticmethod
     def _patch_one_worker(worker_cls: type) -> None:
         import inspect
+
         _orig_load_model = worker_cls.load_model
         _orig_start_weight_update = worker_cls.start_weight_update
         has_dummy_kw = "load_dummy_weights" in inspect.signature(_orig_load_model).parameters
 
         if has_dummy_kw:
+
             def _patched_load_model(self, *, load_dummy_weights: bool = False, _orig=_orig_load_model) -> None:
                 _orig(self, load_dummy_weights=load_dummy_weights)
                 _VLLMHijack.patch_moe_weight_loader(self.model_runner.model)
+
         else:
+
             def _patched_load_model(self, _orig=_orig_load_model) -> None:
                 _orig(self)
                 _VLLMHijack.patch_moe_weight_loader(self.model_runner.model)
 
-        def _patched_start_weight_update(self, is_checkpoint_format: bool = True, _orig=_orig_start_weight_update) -> None:
+        def _patched_start_weight_update(
+            self, is_checkpoint_format: bool = True, _orig=_orig_start_weight_update
+        ) -> None:
             _VLLMHijack.patch_moe_weight_loader(self.model_runner.model)
             _orig(self, is_checkpoint_format=is_checkpoint_format)
 
@@ -474,7 +480,7 @@ class _VLLMHijack:
     @staticmethod
     def _patch_npu_rotary_emb() -> None:
         from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
-        
+
         if getattr(ApplyRotaryEmb, "_npu_rotary_patched", False):
             return
 
@@ -577,6 +583,7 @@ class vLLMColocateWorkerExtension:
         # Ensure the receiver has finished consuming the IPC tensors before
         # the sender drops its reference on the next barrier.
         torch.accelerator.synchronize()
+
 
 class vLLMWorkerExtension:
     """vLLM ``--worker-extension-cls`` entry for general bugfix."""

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -458,9 +458,13 @@ def build_vllm_cmd_and_env(server_args: dict[str, Any]) -> tuple[list[str], dict
         cmd += ["--weight-transfer-config", '{"backend":"nccl"}']
 
     if "--worker-extension-cls" not in cmd:
+        if getattr(args, "colocate", False):
+            _ext_cls = "vime.backends.megatron_utils.update_weight.update_weight_from_tensor.vLLMColocateWorkerExtension"
+        else:
+            _ext_cls = "vime.backends.megatron_utils.update_weight.update_weight_from_tensor.vLLMWorkerExtension"
         cmd += [
             "--worker-extension-cls",
-            "vime.backends.megatron_utils.update_weight.update_weight_from_tensor.vLLMColocateWorkerExtension",
+            _ext_cls,
         ]
 
     worker_type = server_args.get("worker_type", "regular")

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -459,7 +459,9 @@ def build_vllm_cmd_and_env(server_args: dict[str, Any]) -> tuple[list[str], dict
 
     if "--worker-extension-cls" not in cmd:
         if getattr(args, "colocate", False):
-            _ext_cls = "vime.backends.megatron_utils.update_weight.update_weight_from_tensor.vLLMColocateWorkerExtension"
+            _ext_cls = (
+                "vime.backends.megatron_utils.update_weight.update_weight_from_tensor.vLLMColocateWorkerExtension"
+            )
         else:
             _ext_cls = "vime.backends.megatron_utils.update_weight.update_weight_from_tensor.vLLMWorkerExtension"
         cmd += [

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -457,7 +457,7 @@ def build_vllm_cmd_and_env(server_args: dict[str, Any]) -> tuple[list[str], dict
     else:
         cmd += ["--weight-transfer-config", '{"backend":"nccl"}']
 
-    if getattr(args, "colocate", False) and "--worker-extension-cls" not in cmd:
+    if "--worker-extension-cls" not in cmd:
         cmd += [
             "--worker-extension-cls",
             "vime.backends.megatron_utils.update_weight.update_weight_from_tensor.vLLMColocateWorkerExtension",


### PR DESCRIPTION
This pr mainly includes two bugfixs to qwen3-30b ep functionality, which should also be applicable to other MoE models in the Qwen series.
1. Parameter Object has no attribute `weight_loader` error ( ref to https://github.com/verl-project/verl/blob/main/verl/utils/vllm/patch.py )
2. no module named `flash_attn.ops` error (ref to https://github.com/verl-project/verl/pull/5640)

It uses `--worker-extension-cls` to monkey-patch the vllm-ascend NPU worker during the worker initialization phase.

The training log curve (job submitted with ray and enabled one-step-off-policy async):
<img width="2384" height="2063" alt="plot_0618_600steps" src="https://github.com/user-attachments/assets/cf7c24cc-cdb5-46e1-8d7f-d7a98a1bc66a" />

Test in  `ascend/vime:vime-latest` docker:
- vllm 9090368b650896bf5fc990c921df7eb4c20355a5