### PR TITLE
fix(ascend): apply npu_patch from build context and fix pre-commit

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -1,0 +1,73 @@
+# vime CI on Buildkite
+
+Buildkite runs the always-on CPU jobs and the manual GPU-suite gate for vime.
+
+The always-on steps live in [`pipeline.yml`](./pipeline.yml) and run on every
+build (PR and push to `main`):
+
+| Step | Purpose | Queue (machine) |
+|---|---|---|
+| `pre-commit` | pre-commit gate | `small_cpu_queue_premerge` (r6in.large) |
+| `plugin-contracts` | plugin contract tests (19 files) | `medium_cpu_queue_premerge` (r6in.4xlarge) |
+| `agent-adapter` | agent adapter tests (3 files) | `small_cpu_queue_premerge` |
+| `utils` | utils tests (`pytest tests/utils`) | `medium_cpu_queue_premerge` |
+
+The three test steps depend on the pre-commit gate. Each suite runs its files
+sequentially inside one step because these queues boot a fresh EC2 instance
+per job — a per-file matrix would be mostly boot + pip-install time. All
+always-on CPU steps use the standard `python:3.11` image and install their
+lightweight dependencies at runtime.
+
+## Creating the pipeline (one-time, Buildkite UI)
+
+Org `vllm`, cluster **CI** (the premerge queues live there).
+
+1. New pipeline: name `vime-ci`, repository
+   `https://github.com/vllm-project/vime.git`.
+2. Leave the pipeline's Steps field as the default upload step — it reads the
+   committed `.buildkite/pipeline.yml`:
+
+   ```yaml
+   steps:
+     - command: buildkite-agent pipeline upload
+       agents:
+         queue: small_cpu_queue_premerge
+   ```
+
+3. GitHub settings on the pipeline:
+   - Trigger builds after pushing code; branch filter: `main`.
+   - Build pull requests (same-repository PRs only); skip builds for existing
+     commits.
+   - Update commit statuses.
+   The Buildkite GitHub app must have access to `vllm-project/vime`.
+4. Pipeline settings: enable **Skip Intermediate Builds** and
+   **Cancel Intermediate Builds**.
+
+No secrets are required for these steps (WANDB etc. is GPU-suite only).
+
+## GPU suites
+
+The GPU suites are behind a **block step** (`:rocket: Run GPU test suites?`):
+click it in the Buildkite UI, multi-select the suites (`short`,
+`vllm-config`, `megatron`, `precision`, `ckpt`), and the follow-up step
+generates one job per test via [`gpu_suites.py`](./gpu_suites.py) — the same
+`gpu_lock_exec.py` + `docker run` invocations used by the GPU jobs, including
+the per-test `VIME_TEST_USE_DEEPEP` / `VIME_TEST_USE_FP8_ROLLOUT` /
+`VIME_TEST_ENABLE_EVAL` combos.
+
+The block uses `blocked_state: passed`, so a build whose CPU steps are green
+reports a passing commit status even if nobody unblocks the GPU gate.
+
+GPU jobs run on the shared **`mithril-h100-pool`** queue, following the same
+pattern vllm-omni uses for it: each job is a Kubernetes pod (agent-stack-k8s
+`kubernetes` plugin) on an H100 SXM node, with GPUs allocated via
+`nvidia.com/gpu` limits (4 or 8), a memory-backed `/dev/shm`, and the node's
+`/mnt/hf-cache` mounted as `HF_HOME`. vime tests `hf download` their models at
+startup, so a warm HF cache is all they need. `WANDB_API_KEY` is not wired up
+yet; runs report without wandb until it's added (e.g. as a k8s secret in the
+pod spec).
+
+## Keeping it in sync
+
+The test lists live in `pipeline.yml` and `gpu_suites.py`; update both together
+when adding or removing suites.

--- a/.buildkite/gpu_suites.py
+++ b/.buildkite/gpu_suites.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Emit Buildkite steps for the GPU suites selected at the gpu-gate block step.
+
+Piped into `buildkite-agent pipeline upload` by the gpu-suites-upload step in
+pipeline.yml. The suites and their env-var combinations are defined here.
+
+GPU jobs run on the shared `mithril-h100-pool` queue the same way vllm-omni
+uses it: one Kubernetes pod per job via the agent-stack-k8s `kubernetes`
+plugin, GPUs allocated with `nvidia.com/gpu` limits on H100 SXM nodes,
+memory-backed /dev/shm, and the node's /mnt/hf-cache mounted as HF_HOME (vime
+tests `hf download` their models at startup, so a warm cache is all they
+need — no pre-staged model mounts).
+
+The selection is read from the block step's multi-select field (newline-
+separated values in the `gpu-suites` build meta-data key). For local testing,
+set GPU_SUITES=short,ckpt instead of having a buildkite-agent on PATH.
+
+stdlib only — runs with the agent host's python3.
+"""
+
+import json
+import os
+import subprocess
+
+GPU_QUEUE = "mithril-h100-pool"
+CI_IMAGE = "inferactinc/public:vime-latest"
+HF_CACHE_HOST_PATH = "/mnt/hf-cache"
+HF_HOME = "/root/.cache/huggingface"
+NODE_INSTANCE_TYPE = "gpu-h100-sxm"
+
+# Known hardware-fit failures on the pool's 80 GB H100s — test-level issues,
+# not pipeline ones (PR #239, builds #6/#7):
+#   * gsm8k_async_short: FIXED — max-tokens-per-gpu reduced 9216→2048 (peak
+#     39.6 GB on H200, well within H100 80 GB). Root cause was Qwen3.5 248k
+#     vocab × 5 logits copies in calculate_log_probs_and_entropy.
+#   * parallel_check: cross-layout grad-norm invariance (TP4+per-token-loss)
+#     diverges ~12% on ~11% of rollout data (bimodal: most <1.5%, outliers
+#     10-20%). Confirmed same behavior in slime — Megatron FP reduction-order
+#     non-invariance, not a vime bug.
+# soft_fail keeps them running and visible (orange) without failing the build.
+SOFT_FAIL_ON_H100 = {
+    "test_qwen3_0.6B_parallel_check.py",
+}
+
+# (test_file, num_gpus, extra_args, env overrides)
+SUITES = {
+    "short": [
+        ("test_qwen3.5_0.8B_gsm8k_async_short.py", 4, "", {}),
+        ("test_qwen3.5_0.8B_gsm8k_short.py", 4, "", {}),
+        ("test_qwen2.5_0.5B_ppo_critic_only_short.py", 4, "", {}),
+        ("test_qwen2.5_0.5B_fully_async_short.py", 4, "", {}),
+    ],
+    "vllm-config": [
+        ("test_qwen2.5_0.5B_vllm_config.py", 8, "", {}),
+        ("test_qwen2.5_0.5B_vllm_config_distributed.py", 8, "", {}),
+        ("test_vllm_config_mixed_offload.py", 8, "", {}),
+        ("test_vllm_config_mixed_offload_ft.py", 8, "", {}),
+    ],
+    "megatron": [
+        ("test_quick_start_glm4_9B.py", 8, "", {}),
+        ("test_glm4.7_30B_A3B_pd_mooncake.py", 8, "", {}),
+        ("test_qwen3_30B_A3B.py", 8, "", {"USE_DEEPEP": "1", "USE_FP8_ROLLOUT": "1"}),
+        ("test_qwen3.6_35B_A3B_pd_mooncake.py", 8, "", {"USE_DEEPEP": "1"}),
+        ("test_qwen3_30B_A3B_r3.py", 8, "", {"USE_DEEPEP": "1", "USE_FP8_ROLLOUT": "1", "ENABLE_EVAL": "0"}),
+        ("test_qwen3_30B_A3B_r3.py", 8, "", {"ENABLE_EVAL": "0"}),
+        ("test_qwen3_4B_ppo.py", 8, "", {}),
+        ("test_qwen3_4B_ppo_disaggregate.py", 8, "", {}),
+        ("test_qwen3_4B_ppo_train_critic_only.py", 8, "", {}),
+        ("test_qwen3_4B_streaming_partial_rollout.py", 8, "", {}),
+        ("test_moonlight_16B_A3B.py", 8, "", {}),
+        ("test_moonlight_16B_A3B_r3.py", 8, "", {"ENABLE_EVAL": "0"}),
+        ("test_qwen2.5_0.5B_debug_rollout_then_train.py", 8, "", {}),
+        ("test_qwen2.5_0.5B_opd_vllm.py", 8, "", {}),
+    ],
+    "precision": [
+        ("test_qwen3_0.6B_parallel_check.py", 8, "", {}),
+    ],
+    "ckpt": [
+        ("test_qwen3_4B_ckpt.py", 8, "", {}),
+        ("test_qwen3_4B_ckpt.py", 8, "--async-save", {}),
+    ],
+}
+
+
+def selected_suites() -> list:
+    raw = os.environ.get("GPU_SUITES")
+    if raw is None:
+        raw = subprocess.run(
+            ["buildkite-agent", "meta-data", "get", "gpu-suites"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    # multi-select meta-data is newline-separated; accept commas too
+    values = [v.strip() for v in raw.replace(",", "\n").splitlines()]
+    unknown = [v for v in values if v and v not in SUITES]
+    if unknown:
+        raise SystemExit(f"unknown suite(s) {unknown}; expected {sorted(SUITES)}")
+    return [s for s in SUITES if s in values]
+
+
+def gpu_step(suite: str, test_file: str, num_gpus: int, extra_args: str, env: dict) -> dict:
+    vime_flags = {k: v for k, v in env.items() if k in ("USE_DEEPEP", "USE_FP8_ROLLOUT", "ENABLE_EVAL")}
+    pod_env = [
+        {"name": "HF_HOME", "value": HF_HOME},
+        {"name": "VIME_TEST_ENABLE_INFINITE_RUN", "value": "false"},
+        {"name": "VIME_TEST_USE_DEEPEP", "value": vime_flags.get("USE_DEEPEP", "0")},
+        {"name": "VIME_TEST_USE_FP8_ROLLOUT", "value": vime_flags.get("USE_FP8_ROLLOUT", "0")},
+        {"name": "VIME_TEST_ENABLE_EVAL", "value": vime_flags.get("ENABLE_EVAL", "1")},
+    ]
+    # anything else in env is passed to the pod verbatim (e.g. allocator knobs)
+    pod_env += [{"name": k, "value": v} for k, v in env.items() if k not in vime_flags]
+    # Set a stable commit identifier for downstream tooling.
+    command = "\n".join(
+        [
+            'PR="${BUILDKITE_PULL_REQUEST:-false}"',
+            '[ "$PR" = "false" ] && PR="non-pr"',
+            'export GITHUB_COMMIT_NAME="${BUILDKITE_COMMIT}_${PR}"',
+            "pip install -e . --no-deps --break-system-packages",
+            f"python tests/ci/gpu_lock_exec.py --count {num_gpus} -- "
+            f"python tests/{test_file}{' ' + extra_args if extra_args else ''}",
+        ]
+    )
+    label = f":fire: {suite}: {test_file}{' ' + extra_args if extra_args else ''}"
+    flag_note = ",".join(f"{k.lower()}={v}" for k, v in vime_flags.items())
+    if flag_note:
+        label += f" ({flag_note})"
+    step = {
+        "label": label,
+        "command": command,
+        "agents": {"queue": GPU_QUEUE},
+        "timeout_in_minutes": 360,
+        "retry": {"automatic": [{"exit_status": -1, "limit": 2}]},
+        "plugins": [
+            {
+                "kubernetes": {
+                    "podSpec": {
+                        "containers": [
+                            {
+                                "image": CI_IMAGE,
+                                "resources": {"limits": {"nvidia.com/gpu": num_gpus}},
+                                "volumeMounts": [
+                                    {"name": "devshm", "mountPath": "/dev/shm"},
+                                    {"name": "hf-cache", "mountPath": HF_HOME},
+                                ],
+                                "env": pod_env,
+                            }
+                        ],
+                        "nodeSelector": {"node.kubernetes.io/instance-type": NODE_INSTANCE_TYPE},
+                        "volumes": [
+                            {"name": "devshm", "emptyDir": {"medium": "Memory"}},
+                            {
+                                "name": "hf-cache",
+                                "hostPath": {"path": HF_CACHE_HOST_PATH, "type": "DirectoryOrCreate"},
+                            },
+                        ],
+                    }
+                }
+            }
+        ],
+    }
+    if test_file in SOFT_FAIL_ON_H100:
+        step["soft_fail"] = True
+        step["label"] = ":warning: " + step["label"]
+    return step
+
+
+def main() -> None:
+    steps = [gpu_step(suite, *entry) for suite in selected_suites() for entry in SUITES[suite]]
+    if not steps:
+        raise SystemExit("no GPU suites selected")
+    print(json.dumps({"steps": steps}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,163 @@
+# Buildkite CI for vime — always-on (CPU) jobs.
+#
+# This pipeline runs the always-on CPU jobs plus a manual block-step gate for
+# the GPU suites. See .buildkite/README.md for one-time setup.
+#
+# Notes that explain the otherwise-cryptic bits below:
+#   * Steps run inside containers (python:3.11 for the CPU suites) because the
+#     elastic-stack agent host's python is not pinned to 3.11.
+#   * $$PWD is escaped so the buildkite-agent expands it at run time instead of
+#     Buildkite interpolating it (to empty) at pipeline-upload time.
+#   * GIT_CONFIG_PARAMETERS marks the host-owned checkout as a safe directory so
+#     git (invoked by pre-commit) doesn't abort with "dubious ownership" when
+#     the container runs as root over a tree owned by the buildkite-agent user.
+#   * Each non-gate step depends_on the pre-commit gate, so a failing lint run
+#     skips the heavier test steps.
+#   * Test files are listed one per line on purpose: with `set -e` the run stops
+#     at the first failure and the log names it.
+
+steps:
+  - label: ":lint-roller: pre-commit"
+    key: pre-commit
+    agents:
+      queue: small_cpu_queue_premerge
+    timeout_in_minutes: 15
+    retry:
+      automatic:
+        - exit_status: -1  # agent lost (fresh instance failed to boot)
+          limit: 2
+    command: |
+      docker run --rm \
+        -e GIT_CONFIG_PARAMETERS="'safe.directory=/workspace'" \
+        -v "$$PWD:/workspace" -w /workspace \
+        python:3.11 bash -c '
+          set -euo pipefail
+          pip install -q pre-commit
+          pre-commit run --all-files --show-diff-on-failure --color=always
+        '
+
+  - label: ":python: plugin contracts & CPU tests"
+    key: plugin-contracts
+    depends_on: pre-commit
+    agents:
+      queue: medium_cpu_queue_premerge
+    timeout_in_minutes: 30
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+    command: |
+      # GLOO/TP_SOCKET_IFNAME=lo: the torch.distributed tests (e.g.
+      # test_metric_report_dist) rendezvous over localhost; inside a
+      # bridge-network container gloo sometimes picks the wrong interface and
+      # hangs until the step times out (build #4). Pin it to loopback.
+      docker run --rm --shm-size=2g \
+        -e GIT_CONFIG_PARAMETERS="'safe.directory=/workspace'" \
+        -e GLOO_SOCKET_IFNAME=lo -e TP_SOCKET_IFNAME=lo \
+        -v "$$PWD:/workspace" -w /workspace \
+        python:3.11 bash -c '
+          set -euo pipefail
+          pip install -q torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -q pytest numpy packaging pyyaml omegaconf tqdm httpx requests ray pybase64 pylatexenc sympy aiohttp pillow safetensors transformers cloudpickle
+          pip install -q -e . --no-deps
+          python tests/test_megatron_argument_validation.py
+          python tests/test_value_temperature.py
+          python tests/test_rollout_validation.py
+          python tests/plugin_contracts/test_plugin_rollout_contracts.py
+          python tests/plugin_contracts/test_plugin_runtime_hook_contracts.py
+          python tests/plugin_contracts/test_plugin_path_loading_contracts.py
+          python tests/plugin_contracts/test_plugin_generate_contracts.py
+          python tests/test_rm_deepscaler.py
+          python tests/test_rm_f1.py
+          python tests/test_rm_gpqa.py
+          python tests/test_rm_math.py
+          python tests/test_rm_math_dapo.py
+          python tests/test_dp_schedule.py
+          python tests/test_cp_utils.py
+          python tests/test_metric_report.py
+          python tests/test_metric_report_dist.py
+          python tests/test_loss_cp_invariance.py
+          python tests/test_sample.py
+          python tests/utils/test_hf_checkpoint_saver.py
+        '
+
+  - label: ":robot_face: agent adapter tests"
+    key: agent-adapter
+    depends_on: pre-commit
+    agents:
+      queue: small_cpu_queue_premerge
+    timeout_in_minutes: 30
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+    command: |
+      docker run --rm --shm-size=2g \
+        -e GIT_CONFIG_PARAMETERS="'safe.directory=/workspace'" \
+        -v "$$PWD:/workspace" -w /workspace \
+        python:3.11 bash -c '
+          set -euo pipefail
+          pip install -q torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -q pytest numpy packaging pyyaml omegaconf tqdm httpx requests ray pybase64 pylatexenc sympy aiohttp pillow safetensors transformers cloudpickle
+          pip install -q openai openai-agents anthropic
+          pip install -q -e . --no-deps
+          python tests/test_agent_trajectory.py
+          python tests/test_agent_adapters.py
+          python tests/test_agent_sdk_adapters.py
+        '
+
+  - label: ":pytest: utils tests"
+    key: utils
+    depends_on: pre-commit
+    agents:
+      queue: medium_cpu_queue_premerge
+    timeout_in_minutes: 45
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+    command: |
+      docker run --rm --network host --ipc=host \
+        -e GIT_CONFIG_PARAMETERS="'safe.directory=/workspace'" \
+        -v "$$PWD:/workspace" -w /workspace \
+        python:3.11 bash -lc '
+          set -euo pipefail
+          pip install -q torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -q pytest numpy packaging pyyaml omegaconf tqdm httpx requests ray pybase64 pylatexenc sympy aiohttp pillow safetensors transformers cloudpickle
+          pip install -q -e . --no-deps
+          python -m pytest tests/utils
+        '
+
+  # The GPU suites are launched from this manual gate: unblocking presents a
+  # multi-select of suites, and the follow-up step uploads only the selected
+  # ones (see gpu_suites.py). `blocked_state: passed` keeps the build green
+  # when nobody needs GPU suites on a PR.
+  - block: ":rocket: Run GPU test suites?"
+    key: gpu-gate
+    depends_on: pre-commit
+    blocked_state: passed
+    prompt: "Select the suites to run."
+    fields:
+      - select: "GPU suites"
+        key: gpu-suites
+        multiple: true
+        required: true
+        options:
+          - label: "run-ci-short — 4 GPU, 4 tests"
+            value: short
+          - label: "run-ci-vllm-config — 8 GPU, 4 tests"
+            value: vllm-config
+          - label: "run-ci-megatron — 8 GPU, 14 runs"
+            value: megatron
+          - label: "run-ci-precision — 8 GPU, 1 test"
+            value: precision
+          - label: "run-ci-ckpt — 8 GPU, 2 runs"
+            value: ckpt
+
+  - label: ":pipeline: upload selected GPU suites"
+    key: gpu-suites-upload
+    depends_on: gpu-gate
+    agents:
+      queue: small_cpu_queue_premerge
+    timeout_in_minutes: 10
+    command: python3 .buildkite/gpu_suites.py | buildkite-agent pipeline upload

--- a/docker/Dockerfile.npu
+++ b/docker/Dockerfile.npu
@@ -26,7 +26,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     HYDRA_FULL_ERROR=1 \
     PYTHONPATH=/root/Megatron-Bridge/src:/root/Megatron-LM:/root/vime
 
-# Patches copied early; vllm-ascend colocate patch is applied after clone, before pip install.
+# Patches copied from build context; always apply from /tmp/npu_patch so local/PR
+# builds use the same files as the build context (not the later git-cloned vime tree).
 COPY docker/npu_patch /tmp/npu_patch
 
 # System and pip dependencies.
@@ -79,8 +80,8 @@ RUN git clone https://gitcode.com/Ascend/MindSpeed.git /root/MindSpeed && \
 RUN git clone https://github.com/ISEEKYAN/mbridge.git /root/mbridge && \
     git -C /root/mbridge checkout "${MBRIDGE_COMMIT}"
 
-# Apply NPU training-stack patches shipped by Vime.
-RUN for patch_file in /root/vime/docker/npu_patch/*.patch; do \
+# Apply NPU training-stack patches from build context (/tmp/npu_patch).
+RUN for patch_file in /tmp/npu_patch/*.patch; do \
       base="$(basename "${patch_file}")"; \
       case "${base}" in \
         vllm-ascend.patch|vllm.patch) continue ;; \
@@ -90,13 +91,13 @@ RUN for patch_file in /root/vime/docker/npu_patch/*.patch; do \
       fi; \
     done && \
     git -C /root/Megatron-LM apply --whitespace=nowarn \
-      /root/vime/docker/npu_patch/meagtron_comm.patch && \
+      /tmp/npu_patch/meagtron_comm.patch && \
     git -C /root/Megatron-LM apply --whitespace=nowarn \
-      /root/vime/docker/npu_patch/megatron.patch && \
+      /tmp/npu_patch/megatron.patch && \
     git -C /root/Megatron-Bridge apply --whitespace=nowarn \
-      /root/vime/docker/npu_patch/megatron-bridge.patch && \
+      /tmp/npu_patch/megatron-bridge.patch && \
     git -C /root/MindSpeed apply --whitespace=nowarn \
-      /root/vime/docker/npu_patch/mindspeed.patch
+      /tmp/npu_patch/mindspeed.patch
 
 # Megatron-Bridge is used directly from PYTHONPATH. Installing its package
 # metadata would pull CUDA-only dependencies into the Ascend environment.
@@ -118,7 +119,7 @@ RUN git clone --depth 1 --branch 2026.6.0 \
     bash build.sh -a kernels && \
     bash build.sh -a memory-saver && \
     pip install --no-deps \
-      output/torch_memory_saver-0.0.8-cp312-cp312-linux_aarch64.whl && \
+      output/torch_memory_saver-*.whl && \
     cd /root && \
     rm -rf /root/sgl-kernel-npu
 

--- a/docker/npu_patch/README.md
+++ b/docker/npu_patch/README.md
@@ -23,11 +23,11 @@ export WORKSPACE=/root
 cd "${WORKSPACE}"
 ```
 
-Vime's Ascend NPU adaptation lives on the **`npu`** branch, so clone that
+Vime's Ascend NPU adaptation lives on the **`ascend`** branch, so clone that
 branch (not `main`):
 
 ```bash
-git clone --branch npu https://github.com/vllm-project/vime.git "${WORKSPACE}/vime"
+git clone --branch ascend https://github.com/vllm-project/vime.git "${WORKSPACE}/vime"
 export PATCH_DIR="${WORKSPACE}/vime/docker/npu_patch"
 ```
 
@@ -39,7 +39,7 @@ Used via `PYTHONPATH` (no editable install); it requires `nvidia-modelopt`.
 ```bash
 export MEGATRON_BRIDGE_COMMIT=3fd3768045422d0aa5c97e90a4e6c659aea9acb9
 export MBRIDGE_COMMIT=89eb10887887bc74853f89a4de258c0702932a1c
-pip install "git+https://ghproxy.com/https://github.com/ISEEKYAN/mbridge.git@${MBRIDGE_COMMIT}" --no-deps
+pip install "git+https://github.com/ISEEKYAN/mbridge.git@${MBRIDGE_COMMIT}" --no-deps
 git clone --branch bridge https://github.com/radixark/Megatron-Bridge.git "${WORKSPACE}/Megatron-Bridge"
 git -C "${WORKSPACE}/Megatron-Bridge" checkout "${MEGATRON_BRIDGE_COMMIT}"
 

--- a/tests/_unit_stubs.py
+++ b/tests/_unit_stubs.py
@@ -1,0 +1,267 @@
+"""Shared import stubs so CPU-only unit tests can import production modules.
+
+Why this module exists
+----------------------
+The CPU CI image and many dev machines do not ship the full training stack
+(Megatron, Ray, vLLM, transformers, Triton, …). Production code still imports
+those packages at module load time. These helpers stub ``sys.modules`` so
+tests can exercise vime logic without installing every optional dependency.
+
+Stubs must not leak across pytest collection: install them in the test file
+(or inside a fixture) immediately before the import under test, and restore
+on teardown when sibling modules need the real package.
+
+Patterns
+--------
+* **Optional deps** (``install_rollout_optional_stubs``, ``install_vllm_cli_stubs``):
+  stub only when the real package is absent — safe at the top of a test file.
+* **Scoped stubs** (``save_sys_modules`` / ``restore_sys_modules``): pop, install,
+  import, then restore inside a module-scoped fixture so collection stays clean.
+
+Import via ``import _unit_stubs`` after prepending ``tests/`` to ``sys.path``
+(each test file bootstraps this; CI runs ``python tests/…`` or ``python tests/utils/…``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from collections.abc import Iterable
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock
+
+
+def real_module_available(name: str) -> bool:
+    """True when the real package is importable and should not be shadowed."""
+    if name in sys.modules:
+        return True
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def ensure_ray_stub() -> None:
+    if real_module_available("ray"):
+        return
+    ray = MagicMock()
+    sys.modules["ray"] = ray
+    sys.modules["ray._private"] = MagicMock()
+    sys.modules["ray._private.services"] = MagicMock()
+    sys.modules["ray.actor"] = MagicMock()
+
+
+def install_rollout_optional_stubs() -> None:
+    """Stub rollout-side optional imports when not installed."""
+    ensure_ray_stub()
+
+    install_vllm_router_stub()
+
+    if not real_module_available("PIL"):
+        pil = types.ModuleType("PIL")
+        image_mod = types.ModuleType("PIL.Image")
+        pil.Image = image_mod
+        sys.modules["PIL"] = pil
+        sys.modules["PIL.Image"] = image_mod
+
+    if not real_module_available("transformers"):
+
+        def _raise_os_error(*args, **kwargs):
+            raise OSError()
+
+        mod = types.ModuleType("transformers")
+        mod.AutoTokenizer = type(
+            "AutoTokenizer",
+            (),
+            {"from_pretrained": staticmethod(lambda *args, **kwargs: object())},
+        )
+        mod.AutoProcessor = type(
+            "AutoProcessor",
+            (),
+            {"from_pretrained": staticmethod(_raise_os_error)},
+        )
+        mod.PreTrainedTokenizerBase = type("PreTrainedTokenizerBase", (), {})
+        mod.ProcessorMixin = type("ProcessorMixin", (), {})
+        sys.modules["transformers"] = mod
+
+    if not real_module_available("aiohttp"):
+        sys.modules["aiohttp"] = MagicMock()
+
+    if not real_module_available("pylatexenc"):
+        pylatexenc = types.ModuleType("pylatexenc")
+        latex2text = types.ModuleType("pylatexenc.latex2text")
+        pylatexenc.latex2text = latex2text
+        sys.modules["pylatexenc"] = pylatexenc
+        sys.modules["pylatexenc.latex2text"] = latex2text
+
+    install_wandb_stub()
+
+
+def install_vllm_router_stub() -> None:
+    if real_module_available("vllm_router"):
+        return
+
+    class RouterArgs:
+        @classmethod
+        def add_cli_args(cls, parser, *args, **kwargs):  # noqa: ARG003
+            return parser
+
+        @classmethod
+        def from_cli_args(cls, args, *unused_args, **unused_kwargs):  # noqa: ARG003
+            return types.SimpleNamespace()
+
+    router_mod = types.ModuleType("vllm_router")
+    router_mod.__path__ = []
+    launch_router_mod = types.ModuleType("vllm_router.launch_router")
+    router_args_mod = types.ModuleType("vllm_router.router_args")
+    launch_router_mod.RouterArgs = RouterArgs
+    router_args_mod.RouterArgs = RouterArgs
+    router_mod.launch_router = launch_router_mod
+    router_mod.router_args = router_args_mod
+    sys.modules["vllm_router"] = router_mod
+    sys.modules["vllm_router.launch_router"] = launch_router_mod
+    sys.modules["vllm_router.router_args"] = router_args_mod
+
+
+def install_wandb_stub() -> None:
+    if real_module_available("wandb"):
+        return
+    wandb_mod = types.ModuleType("wandb")
+    wandb_mod.run = None
+    wandb_mod.log = MagicMock()
+    wandb_mod.finish = MagicMock()
+    wandb_mod.login = MagicMock()
+    wandb_mod.init = MagicMock()
+    wandb_mod.Settings = MagicMock()
+    wandb_mod.util = types.SimpleNamespace(generate_id=lambda: "unit-test")
+    sys.modules["wandb"] = wandb_mod
+
+
+def save_sys_modules(names: Iterable[str]) -> dict[str, Any]:
+    return {k: sys.modules.get(k) for k in names}
+
+
+def restore_sys_modules(saved: dict[str, Any]) -> None:
+    for k, original in saved.items():
+        if original is None:
+            sys.modules.pop(k, None)
+        else:
+            sys.modules[k] = original
+
+
+@contextmanager
+def isolated_sys_modules(names: Iterable[str]):
+    saved = save_sys_modules(names)
+    for k in names:
+        sys.modules.pop(k, None)
+    try:
+        yield
+    finally:
+        restore_sys_modules(saved)
+
+
+def install_megatron_mpu_stub() -> MagicMock:
+    """Stub ``megatron.core.mpu`` (and minimal submodules) when Megatron is absent."""
+    mpu_stub = MagicMock()
+    mpu_stub.get_data_parallel_rank.return_value = 0
+    mpu_stub.get_tensor_model_parallel_rank.return_value = 0
+    mpu_stub.get_tensor_model_parallel_world_size.return_value = 2
+    mpu_stub.get_tensor_model_parallel_group.return_value = "tp_group"
+    mpu_stub.get_pipeline_model_parallel_rank.return_value = 0
+    mpu_stub.get_expert_model_parallel_world_size.return_value = 1
+    mpu_stub.get_expert_model_parallel_group.return_value = "ep_group"
+
+    megatron_core = types.ModuleType("megatron.core")
+    megatron_core.__path__ = []
+    megatron_core.mpu = mpu_stub
+    parallel_state_mod = types.ModuleType("megatron.core.parallel_state")
+    parallel_state_mod.get_tensor_model_parallel_rank = mpu_stub.get_tensor_model_parallel_rank
+    parallel_state_mod.get_tensor_model_parallel_world_size = mpu_stub.get_tensor_model_parallel_world_size
+    transformer_mod = types.ModuleType("megatron.core.transformer")
+    transformer_mod.__path__ = []
+    transformer_layer_mod = types.ModuleType("megatron.core.transformer.transformer_layer")
+    transformer_layer_mod.get_transformer_layer_offset = lambda *args, **kwargs: 0
+    transformer_mod.transformer_layer = transformer_layer_mod
+    megatron_core.parallel_state = parallel_state_mod
+    megatron_core.transformer = transformer_mod
+    megatron_mod = types.ModuleType("megatron")
+    megatron_mod.core = megatron_core
+    sys.modules.setdefault("megatron", megatron_mod)
+    sys.modules.setdefault("megatron.core", megatron_core)
+    sys.modules.setdefault("megatron.core.parallel_state", parallel_state_mod)
+    sys.modules.setdefault("megatron.core.transformer", transformer_mod)
+    sys.modules.setdefault("megatron.core.transformer.transformer_layer", transformer_layer_mod)
+    return mpu_stub
+
+
+def install_ray_stub() -> None:
+    ray_mod = types.ModuleType("ray")
+    ray_mod.get = lambda refs: refs
+    ray_mod.ObjectRef = object
+    ray_mod.actor = types.ModuleType("ray.actor")
+    ray_mod.actor.ActorHandle = object
+    ray_mod._private = types.SimpleNamespace(services=types.SimpleNamespace(get_node_ip_address=lambda: "127.0.0.1"))
+    sys.modules.setdefault("ray", ray_mod)
+    sys.modules.setdefault("ray.actor", ray_mod.actor)
+
+
+def install_vllm_cli_stubs() -> None:
+    """Stub vLLM CLI/parser imports for ``vime.backends.vllm_utils.arguments`` when vLLM is absent."""
+    if real_module_available("vllm"):
+        return
+
+    vllm_mod = types.ModuleType("vllm")
+    vllm_mod.__path__ = []
+
+    utils_mod = types.ModuleType("vllm.utils")
+    argparse_utils = types.ModuleType("vllm.utils.argparse_utils")
+
+    import argparse
+
+    class FlexibleArgumentParser(argparse.ArgumentParser):
+        pass
+
+    argparse_utils.FlexibleArgumentParser = FlexibleArgumentParser
+    utils_mod.argparse_utils = argparse_utils
+
+    engine_mod = types.ModuleType("vllm.engine")
+    engine_mod.__path__ = []
+    arg_utils = types.ModuleType("vllm.engine.arg_utils")
+
+    class AsyncEngineArgs:
+        @classmethod
+        def add_cli_args(cls, parser):  # noqa: ARG003
+            return parser
+
+    arg_utils.AsyncEngineArgs = AsyncEngineArgs
+    engine_mod.arg_utils = arg_utils
+    vllm_mod.engine = engine_mod
+    vllm_mod.utils = utils_mod
+
+    sys.modules["vllm"] = vllm_mod
+    sys.modules["vllm.utils"] = utils_mod
+    sys.modules["vllm.utils.argparse_utils"] = argparse_utils
+    sys.modules["vllm.engine"] = engine_mod
+    sys.modules["vllm.engine.arg_utils"] = arg_utils
+
+
+def install_triton_stub() -> None:
+    # CPU CI images may have a broken/partial triton install that imports
+    # but fails during module init, so always override it for unit tests.
+    triton_mod = MagicMock()
+    triton_mod.jit = lambda fn: fn
+    triton_mod.cdiv = lambda a, b: (a + b - 1) // b
+    triton_mod.next_power_of_2 = lambda x: x
+    triton_mod.__version__ = "0.0.0"
+    language = MagicMock()
+    triton_mod.language = language
+    sys.modules["triton"] = triton_mod
+    sys.modules["triton.language"] = language
+
+
+def install_vime_distributed_utils_stub() -> None:
+    vime_utils = types.ModuleType("vime.utils.distributed_utils")
+    vime_utils.get_gloo_group = MagicMock(return_value="gloo")
+    sys.modules.setdefault("vime.utils.distributed_utils", vime_utils)

--- a/tests/utils/test_megatron_role_config.py
+++ b/tests/utils/test_megatron_role_config.py
@@ -1,10 +1,21 @@
 """Unit tests for Megatron role config parsing and application."""
 
+import sys
 import tempfile
 from argparse import Namespace
+from pathlib import Path
 
 import pytest
 import yaml
+
+_tests_root = Path(__file__).resolve().parents[1]
+if str(_tests_root) not in sys.path:
+    sys.path.insert(0, str(_tests_root))
+
+import _unit_stubs
+
+_unit_stubs.install_rollout_optional_stubs()
+_unit_stubs.install_vllm_cli_stubs()
 
 
 def _write_yaml(data: dict) -> str:

--- a/tests/utils/test_vllm_config.py
+++ b/tests/utils/test_vllm_config.py
@@ -1,9 +1,19 @@
 """Unit tests for VllmConfig multi-model parsing and get_model_url."""
 
+import sys
 import tempfile
+from pathlib import Path
 
 import pytest
 import yaml
+
+_tests_root = Path(__file__).resolve().parents[1]
+if str(_tests_root) not in sys.path:
+    sys.path.insert(0, str(_tests_root))
+
+import _unit_stubs
+
+_unit_stubs.install_rollout_optional_stubs()
 
 
 def _write_yaml(data: dict) -> str:

--- a/tools/convert_hf_to_torch_dist.py
+++ b/tools/convert_hf_to_torch_dist.py
@@ -14,9 +14,9 @@ from mbridge import AutoBridge
 from vime.backends.megatron_utils.arguments import set_default_megatron_args
 from vime.backends.megatron_utils.initialize import init
 from vime.backends.megatron_utils.model_provider import get_model_provider_func
+from vime.utils.common import is_npu
 from vime.utils.logging_utils import configure_logger
 from vime.utils.memory_utils import print_memory
-from vime.utils.common import is_npu
 
 
 def add_convertion_args(parser):

--- a/train.py
+++ b/train.py
@@ -2,11 +2,12 @@ import ray
 
 from vime.ray.placement_group import create_placement_groups, create_rollout_manager, create_training_models
 from vime.utils.arguments import parse_args
+from vime.utils.common import is_npu
 from vime.utils.logging_utils import configure_logger, finish_tracking, init_tracking, update_tracking_open_metrics
 from vime.utils.misc import should_run_periodic_action
-from vime.utils.common import is_npu
+
 if is_npu():
-    import mindspeed.megatron_adaptor
+    import mindspeed.megatron_adaptor  # noqa: F401
 
 
 def train(args):

--- a/vime/backends/megatron_utils/__init__.py
+++ b/vime/backends/megatron_utils/__init__.py
@@ -2,8 +2,9 @@ import logging
 
 import torch
 from vime.utils.common import is_npu
+
 if is_npu():
-    import mindspeed.megatron_adaptor
+    import mindspeed.megatron_adaptor  # noqa: F401
 
 try:
     import deep_ep

--- a/vime/backends/megatron_utils/actor.py
+++ b/vime/backends/megatron_utils/actor.py
@@ -9,8 +9,8 @@ import ray
 import torch
 import torch.distributed as dist
 from vime.utils.common import is_npu
+
 if is_npu():
-    import mindspeed.megatron_adaptor
     from mindspeed.megatron_adaptor import repatch
 from megatron.core import mpu
 from torch_memory_saver import torch_memory_saver
@@ -216,9 +216,7 @@ class MegatronTrainRayActor(TrainRayActor):
         # TODO: this is ugly, move to somewhere else?
         # move tokens to GPU in advance
         device = torch.npu.current_device() if is_npu() else torch.cuda.current_device()
-        rollout_data["tokens"] = [
-            torch.tensor(t, dtype=torch.long, device=device) for t in rollout_data["tokens"]
-        ]
+        rollout_data["tokens"] = [torch.tensor(t, dtype=torch.long, device=device) for t in rollout_data["tokens"]]
         rollout_data["loss_masks"] = [
             torch.tensor(t, dtype=torch.int, device=device) for t in rollout_data["loss_masks"]
         ]

--- a/vime/backends/megatron_utils/update_weight/common.py
+++ b/vime/backends/megatron_utils/update_weight/common.py
@@ -9,8 +9,8 @@ from megatron.core import mpu
 from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
 
 from vime.backends.megatron_utils.misc_utils import strip_param_name_prefix
-from vime.utils.types import ParamInfo
 from vime.utils.common import is_npu
+from vime.utils.types import ParamInfo
 
 
 def all_gather_param(name: str, param: torch.nn.Parameter) -> torch.Tensor:

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -18,13 +18,12 @@ from tqdm import tqdm
 from vllm.distributed.weight_transfer.nccl_engine import NCCLTrainerSendWeightsArgs, NCCLWeightTransferEngine
 from vllm_ascend.distributed.weight_transfer.hccl_engine import HCCLTrainerSendWeightsArgs, HCCLWeightTransferEngine
 
+from vime.utils.common import is_npu
 from vime.utils.distributed_utils import get_gloo_group
 
 from ..megatron_to_hf import convert_to_hf
 from .common import all_gather_param, named_params_and_buffers
 from .hf_weight_iterator_base import HfWeightIteratorBase
-
-from vime.utils.common import is_npu
 
 logger = logging.getLogger(__name__)
 
@@ -392,6 +391,7 @@ def connect_rollout_engines_from_distributed(
         )
         # 使用HCCLWeightTransferEngine
         from vllm_ascend.distributed.weight_transfer.hccl_engine import HCCLWeightTransferEngine
+
         model_update_groups = HCCLWeightTransferEngine.trainer_init(
             {
                 "master_address": master_address,

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -24,8 +24,8 @@ import requests
 
 from vime.backends.vllm_utils.arguments import SKIPPED_DESTS, get_vllm_cli_action_table
 from vime.ray.ray_actor import RayActor
-from vime.utils.http_utils import get_host_info
 from vime.utils.common import is_npu
+from vime.utils.http_utils import get_host_info
 
 logger = logging.getLogger(__name__)
 
@@ -773,7 +773,7 @@ class VLLMEngine(RayActor):
         if weight_version is not None:
             self._weight_version = str(weight_version)
         return response
-    
+
     def update_weights_chunk(self, update_info: dict) -> dict:
         """POST ``/update_weights_chunk`` with a single named-tensor chunk.
 
@@ -906,7 +906,7 @@ class VLLMEngine(RayActor):
         last_error = None
         for attempt in range(1, 4):
             try:
-                return self._make_request("init_weight_transfer_engine", payload, timeout=init_timeout_s)
+                return self._make_request("init_weight_transfer_engine", payload)
             except Exception as e:
                 last_error = e
                 if attempt < 3:

--- a/vime/ray/actor_group.py
+++ b/vime/ray/actor_group.py
@@ -103,7 +103,7 @@ class RayTrainGroup:
                     placement_group=pg,
                     placement_group_bundle_index=reordered_bundle_indices[rank],
                 ),
-                resources={device_name:num_gpus_per_actor}
+                resources={device_name: num_gpus_per_actor},
             ).remote(world_size, rank, master_addr, master_port)
             if rank == 0:
                 master_addr, master_port = ray.get(actor.get_master_addr_and_port.remote())

--- a/vime/ray/placement_group.py
+++ b/vime/ray/placement_group.py
@@ -6,10 +6,10 @@ import ray
 from ray.util.placement_group import placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
+from vime.utils.common import is_npu
+
 from .actor_group import RayTrainGroup
 from .rollout import RolloutManager
-
-from vime.utils.common import is_npu
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,7 @@ def _create_placement_group(num_gpus):
                     placement_group=pg,
                     placement_group_bundle_index=i,
                 ),
-                resources={device_name:1}
+                resources={device_name: 1},
             ).remote()
         )
     gpu_ids = ray.get([actor.get_ip_and_gpu_id.remote() for actor in info_actors])
@@ -197,7 +197,7 @@ def create_rollout_manager(args, pg):
     rollout_manager = RolloutManager.options(
         num_cpus=1,
         # num_gpus=0,
-        resources={device_name:0}
+        resources={device_name: 0},
     ).remote(args, pg)
 
     # calculate num_rollout from num_epoch

--- a/vime/ray/rollout.py
+++ b/vime/ray/rollout.py
@@ -21,6 +21,7 @@ GPU_MEMORY_TYPE_WEIGHTS = "weights"
 GPU_MEMORY_TYPE_CUDA_GRAPH = "cuda_graph"
 from vime.rollout.base_types import call_rollout_fn
 from vime.utils import logging_utils
+from vime.utils.common import is_npu
 from vime.utils.dp_schedule import build_dp_schedule
 from vime.utils.health_monitor import RolloutHealthMonitor
 from vime.utils.http_utils import _wrap_ipv6, find_available_port, get_host_info, init_http_client
@@ -32,7 +33,6 @@ from vime.utils.types import Sample
 from ..utils.metric_utils import has_repetition
 from .rollout_validation import validate_server_group_gpu_indices
 from .utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST, Lock
-from vime.utils.common import is_npu
 
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("httpcore").setLevel(logging.WARNING)
@@ -132,7 +132,7 @@ class ServerGroup:
                 runtime_env={
                     "env_vars": env_vars,
                 },
-                resources={device_name:num_gpus}
+                resources={device_name: num_gpus},
             ).remote(
                 self.args,
                 rank=global_rank,
@@ -384,7 +384,7 @@ class RolloutManager:
 
         init_tracking(args, primary=False)
         device_name = "NPU" if is_npu() else "GPU"
-        self.rollout_engine_lock = Lock.options(num_cpus=1, num_gpus=0, resources={device_name:0}).remote()
+        self.rollout_engine_lock = Lock.options(num_cpus=1, num_gpus=0, resources={device_name: 0}).remote()
         self.rollout_id = -1
 
         self._health_monitors = []

--- a/vime/ray/train_actor.py
+++ b/vime/ray/train_actor.py
@@ -10,10 +10,10 @@ import torch.distributed as dist
 
 import vime.utils.eval_config
 from vime.ray.ray_actor import RayActor
+from vime.utils.common import is_npu
 from vime.utils.distributed_utils import init_gloo_group
 from vime.utils.logging_utils import configure_logger
 from vime.utils.memory_utils import clear_memory, print_memory
-from vime.utils.common import is_npu
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +30,7 @@ def get_local_gpu_id():
         return device_ids[0]
     else:
         return cvd.split(",").index(str(device_ids[0]))
+
 
 class TrainRayActor(RayActor):
     def __init__(self, world_size, rank, master_addr, master_port):

--- a/vime/utils/common.py
+++ b/vime/utils/common.py
@@ -1,12 +1,11 @@
 import torch
 
+
 def is_npu() -> bool:
     if not hasattr(torch, "npu"):
         return False
 
     if not torch.npu.is_available():
-        raise RuntimeError(
-            "torch_npu detected, but NPU device is not available or visible."
-        )
+        raise RuntimeError("torch_npu detected, but NPU device is not available or visible.")
 
     return True

--- a/vime/utils/reloadable_process_group.py
+++ b/vime/utils/reloadable_process_group.py
@@ -5,8 +5,8 @@ from contextlib import contextmanager
 import torch
 import torch.distributed as dist
 
-from vime.utils.memory_utils import available_memory, clear_memory, print_memory
 from vime.utils.common import is_npu
+from vime.utils.memory_utils import available_memory, clear_memory, print_memory
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Follow-up to #266 / #267:

- Apply Megatron / MindSpeed / Megatron-Bridge patches from `/tmp/npu_patch` (build context) instead of the git-cloned `/root/vime/docker/npu_patch/`, so local and PR docker builds use the correct patch files before they land on remote `ascend`.
- Use a wildcard for `torch_memory_saver` wheel install.
- Fix pre-commit on the ascend NPU baseline (`init_weight_transfer_engine` F821, mindspeed side-effect imports, formatters).
- Align `docker/npu_patch/README.md` with the `ascend` branch.

## Test plan

- [x] `pre-commit run --all-files` passes locally
- [ ] `docker build -f docker/Dockerfile.npu -t vime-ascend-npu:local .` (NPU host)
- Buildkite GPU suites not required for this docker-only change; CPU gates only.