### PR TITLE
fix/applying working changes (tested on 4H100)

### DIFF
--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -38,7 +38,7 @@ docker run --rm --gpus all --ipc=host --shm-size=16g \
 ```
 
 #### Option B: Docker / Podman Manual Mapping Fallback:
-Use this command if the automated container device (nvidia-ctk cdi generate)
+Use this command if the automated container device generation (nvidia-ctk cdi generate) fails or is not supported:
 ```shell
 
 docker run --rm --ipc=host \

--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -27,13 +27,54 @@ Please execute the following commands to pull the latest image and start an inte
 ```shell
 # Pull the latest image
 docker pull inferactinc/public:vime-latest
+```
+#### Option A: Standard Startup (Recommended):
 
+```shell
 # Start the container
 docker run --rm --gpus all --ipc=host --shm-size=16g \
   --ulimit memlock=-1 --ulimit stack=67108864 \
   -it inferactinc/public:vime-latest /bin/bash
 ```
 
+#### Option B: Docker / Podman Manual Mapping Fallback:
+Use this command if the automated container device (nvidia-ctk cdi generate)
+```shell
+
+docker run --rm --ipc=host \
+   --ulimit memlock=-1 --ulimit stack=67108864 \
+   --pids-limit 8192 \
+   --device /dev/nvidia0 \
+   --device /dev/nvidia1 \
+   --device /dev/nvidia2 \
+   --device /dev/nvidia3 \
+   --device /dev/nvidiactl \
+   --device /dev/nvidia-uvm \
+   --device /dev/nvidia-uvm-tools \
+   -v ~/vime:/root/vime \
+   -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro \
+   -v /usr/lib64/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro \
+   -v /usr/lib64/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro \
+   -v /usr/lib64/libnvidia-ml.so.610.43.02:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.610.43.02:ro \
+   -v /usr/lib64/libcuda.so.610.43.02:/usr/lib/x86_64-linux-gnu/libcuda.so.610.43.02:ro \
+   -it inferactinc/public:vime-latest /bin/bash
+```
+Notes: 
+
+1. make sure `nvidia-smi`, and `nvcc --version` works on host, and verify that the exact library version strings (e.g., 610.43.02) and source paths in the -v flags match your actual host driver configuration.
+2. if you have more than 4GPUs or less you will need to modify the `--device /dev/nvidia*` as needed.
+3. **Increase PID limit with `--pids-limit 8192`**: Ray + vLLM workers create many threads during initialization. The default Docker PID limit (check with `cat /sys/fs/cgroup/pids/pids.max` inside container) may be too low, causing `pthread_create failed: Resource temporarily unavailable` errors.
+4. **Refresh the linker cache after starting the container:**
+
+```bash
+# Inside the container, run this once after starting
+ldconfig
+
+# Verify CUDA libraries are found
+ldconfig -p | grep libcuda
+```
+
+This ensures that Triton (used by vLLM for GPU kernel compilation) can find the manually mounted CUDA libraries. Without this, you'll see `AssertionError: libcuda.so cannot found!` errors during model compilation.                                                                                                            
 ### Install vime
 
 vime is already installed in the docker image. To update to the latest verison, please execute the following command:
@@ -51,7 +92,7 @@ You can download required models and datasets from platforms like Hugging Face, 
 
 ```bash
 # Download model weights (Qwen3-4B)
-hf download zai-org/Qwen3-4B --local-dir /root/Qwen3-4B
+hf download Qwen/Qwen3-4B --local-dir /root/Qwen3-4B
 
 # Download training dataset (dapo-math-17k)
 hf download --repo-type dataset zhuzilin/dapo-math-17k \
@@ -94,8 +135,8 @@ You can use the following script to convert the saved Megatron checkpoints back 
 
 ```bash
 PYTHONPATH=/root/Megatron-LM python tools/convert_torch_dist_to_hf.py \
-  --input-dir /path/to/torch_dist_ckpt/iter_xxx/ \
-  --output-dir /root/Qwen3-4B-iter_xxx \
+  --input-dir /root/Qwen3-4B_torch_dist/release/iter_0000001/ \
+  --output-dir /root/Qwen3-4B-iter_0000001/ \
   --origin-hf-dir /root/Qwen3-4B
 ```
 

--- a/scripts/run-qwen3-4B.sh
+++ b/scripts/run-qwen3-4B.sh
@@ -131,9 +131,9 @@ MISC_ARGS=(
 )
 
 # launch the master node of ray in container
-export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
-ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus ${NUM_GPUS} --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
-
+export MASTER_ADDR=$(hostname -I | awk '{print $1}')
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus ${NUM_GPUS} --num-cpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+#--num-cpus 8 
 # Build the runtime environment JSON with proper variable substitution
 RUNTIME_ENV_JSON="{
   \"env_vars\": {
@@ -143,7 +143,7 @@ RUNTIME_ENV_JSON="{
   }
 }"
 
-ray job submit --address="http://127.0.0.1:8265" \
+ray job submit --address="http://${MASTER_ADDR}:8265" \
    --runtime-env-json="${RUNTIME_ENV_JSON}" \
    -- python3 train.py \
    --train-backend megatron \

--- a/scripts/run-qwen3-4B.sh
+++ b/scripts/run-qwen3-4B.sh
@@ -143,7 +143,9 @@ MISC_ARGS=(
 NUM_CPUS=${NUM_CPUS:-8}  
 echo "NUM_CPUS: $NUM_CPUS"
 # launch the master node of ray in container
-export MASTER_ADDR=$(hostname -I | awk '{print $1}')
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"} 
+# If initialization fails, replace 127.0.0.1 with your local network IP
+# export MASTER_ADDR=$(hostname -I | awk '{print $1}')
 ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus ${NUM_GPUS} --num-cpus ${NUM_CPUS} --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
 # Build the runtime environment JSON with proper variable substitution
 RUNTIME_ENV_JSON="{

--- a/scripts/run-qwen3-4B.sh
+++ b/scripts/run-qwen3-4B.sh
@@ -8,6 +8,16 @@ sleep 3
 pkill -9 ray
 pkill -9 python
 
+GPU_PIDs=$(nvidia-smi --query-compute-apps=pid --format=csv,noheader,nounits)
+if [ -z "$GPU_PIDs" ]; then
+    echo "No active GPU processes found."
+else
+    for pid in $GPU_PIDs; do
+        echo "Killing GPU processes pid number: $pid"
+        kill -9 "$pid"
+    done
+fi
+
 set -ex
 
 # will prevent ray from buffering stdout/stderr
@@ -130,10 +140,11 @@ MISC_ARGS=(
    --train-memory-margin-bytes 2147483648
 )
 
+NUM_CPUS=${NUM_CPUS:-8}  
+echo "NUM_CPUS: $NUM_CPUS"
 # launch the master node of ray in container
 export MASTER_ADDR=$(hostname -I | awk '{print $1}')
-ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus ${NUM_GPUS} --num-cpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
-#--num-cpus 8 
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus ${NUM_GPUS} --num-cpus ${NUM_CPUS} --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
 # Build the runtime environment JSON with proper variable substitution
 RUNTIME_ENV_JSON="{
   \"env_vars\": {


### PR DESCRIPTION
following `docs/en/get_started/quick_start.md` i encountered several errors.

Fixes:
- Corrected model path: zai-org/Qwen3-4B → Qwen/Qwen3-4B
- added a  Docker / Podman Manual Mapping Fallback
   - map the device
   - pthread issue with triton(`--pids-limit 8192`)
   - Refresh the linker cache after starting the container.
-  in the`scripts/run-qwen3-4B.sh`
   - add `num_cpu`( without it it will error and crash)
    -  ${MASTER_ADDR}- pickup from host
    -   killing `nvidia-smi`(gpu process id)