### PR TITLE
[NPU] default megatron-to-hf-mode to bridge on Ascend

### DIFF
--- a/vime/utils/arguments.py
+++ b/vime/utils/arguments.py
@@ -10,6 +10,7 @@ from vllm_router.launch_router import RouterArgs
 
 from vime.backends.vllm_utils.arguments import validate_args as vllm_validate_args
 from vime.backends.vllm_utils.arguments import vllm_parse_args
+from vime.utils.common import is_npu
 from vime.utils.eval_config import EvalDatasetConfig, build_eval_dataset_configs, ensure_dataset_list
 from vime.utils.logging_utils import configure_logger
 
@@ -131,10 +132,14 @@ def get_vime_extra_args_provider(add_custom_arguments=None):
                 default=1024**3,
                 help="Add margin for train memory allocation. By default we will reserve 1GB as margin.",
             )
+            try:
+                default_megatron_to_hf_mode = "bridge" if is_npu() else "raw"
+            except RuntimeError:
+                default_megatron_to_hf_mode = "raw"
             parser.add_argument(
                 "--megatron-to-hf-mode",
                 choices=["raw", "bridge"],
-                default="raw",
+                default=default_megatron_to_hf_mode,
                 help="The method to convert megatron weights to hugging face weights for vLLM.",
             )
             parser.add_argument(


### PR DESCRIPTION
Fixes #274

## Summary

On Ascend NPU, the default `--megatron-to-hf-mode raw` causes abnormally high `train_rollout_logprob_abs_diff` (0.05–0.18 vs GPU ~0.025) and prevents GRPO from converging (`pg_loss` / `pg_clipfrac` stay at 0).

This PR defaults to `bridge` when `is_npu()` is true, so NPU users do not need to pass `--megatron-to-hf-mode bridge` explicitly. GPU behavior is unchanged (`raw`).

Full spike / experiment log (investigation timeline, test logs, charts): [#274](https://github.com/vllm-project/vime/issues/274)

## Problem

See [#274](https://github.com/vllm-project/vime/issues/274) for the full investigation. Short version:

| Config | step 0 logprob_abs_diff | Status |
|--------|-------------------------|--------|
| GPU reference | ~0.011 – 0.025 | OK |
| NPU, TP=2, `raw` (default) | 0.075 – **0.178** | Broken |
| NPU, TP=4, `bridge` | **0.0139** | OK |
| NPU, TP=2, `bridge` | **0.035 – 0.039** | Much improved |

**Root cause**: In `raw` mode, Megatron QKV weights are split then restacked for vLLM (`megatron_to_hf/qwen2.py` → vLLM `load_weights`). That double transform introduces numerical drift on NPU. `bridge` mode exports weights in vLLM’s expected layout and avoids it.

We ruled out:
- Issue #64 / PR #69 (`processed_logprobs`) — already fixed in tree
- HCCL weight transfer corruption — SEND/RECV checksums match per parameter

## Solution

```python
# vime/utils/arguments.py
default="bridge" if is_npu() else "raw"
```

Users can still override with `--megatron-to-hf-mode raw` or `bridge`.

## Changes

- `vime/utils/arguments.py`: import `is_npu`; set NPU-aware default for `--megatron-to-hf-mode`

No changes to weight transfer, HCCL engine, or bridge iterator logic.

## Test plan

Validated on Ascend 910B1, Qwen3-4B, 4-train / 4-rollout (non-colocate). Details in [#274](https://github.com/vllm-project/vime/issues/274).

- [x] TP=2 + `raw` (default): logprob_abs_diff 0.05–0.18, GRPO does not converge
- [x] TP=4 + `bridge`: step 0 logprob_abs_diff ~0.0139
- [x] TP=2 + `bridge`: step 0 ~0.039, step 1 ~0.035, 57+ steps completed
- [ ] After merge: launch on NPU **without** `--megatron-to-hf-mode` and confirm default is `bridge`
- [ ] GPU regression: confirm default remains `raw` when `is_npu()` is false

## Related

- Spike / experiment log: [#274](https://github.com/vllm-project/vime/issues/274)
- Reference script already uses bridge: `scripts/run-qwen3-4B-npu.sh`
- Issue #64 / PR #69 (GPU processed_logprobs)
- Issue #210 (NPU reference convergence)
