### PR TITLE
[codex] docs: fix Qwen3-4B download repo

### DIFF
--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -51,7 +51,7 @@ You can download required models and datasets from platforms like Hugging Face, 
 
 ```bash
 # Download model weights (Qwen3-4B)
-hf download zai-org/Qwen3-4B --local-dir /root/Qwen3-4B
+hf download Qwen/Qwen3-4B --local-dir /root/Qwen3-4B
 
 # Download training dataset (dapo-math-17k)
 hf download --repo-type dataset zhuzilin/dapo-math-17k \

--- a/docs/zh/get_started/quick_start.md
+++ b/docs/zh/get_started/quick_start.md
@@ -50,7 +50,7 @@ pip install -e . --no-deps
 
 ```bash
 # 下载模型权重 (Qwen3-4B)
-hf download zai-org/Qwen3-4B --local-dir /root/Qwen3-4B
+hf download Qwen/Qwen3-4B --local-dir /root/Qwen3-4B
 
 # 下载训练数据集 (dapo-math-17k)
 hf download --repo-type dataset zhuzilin/dapo-math-17k \


### PR DESCRIPTION
## Summary
- Update the Qwen3-4B download command in the English quick start from `zai-org/Qwen3-4B` to `Qwen/Qwen3-4B`.
- Apply the same correction to the Chinese quick start.

## Context
This keeps the factual model repository fix from #272 while omitting the unrelated Docker, Ray, and script changes. The commit author is preserved as Liron Kesem, who originally proposed the fix in #272.

## Validation
- Inspected the diff against `origin/main`; only the two quick start model download lines changed.