### PR TITLE
sync: delta weight sync (slime #1806/#1991)

### DIFF
--- a/docs/en/advanced/delta-weight-sync.md
+++ b/docs/en/advanced/delta-weight-sync.md
@@ -1,0 +1,82 @@
+# Delta Weight Sync
+
+- [Why](#why)
+- [Quick Start](#quick-start)
+- [How It Works](#how-it-works)
+- [Encoding Choice](#encoding-choice)
+- [Why Not Colocated](#why-not-colocated)
+
+## Why
+
+Slime's default sync broadcasts every parameter every step. The cost scales linearly with model size and dominates the sync phase, even though only a few percent of weights change between consecutive RL steps. Delta sync keeps a pinned-CPU snapshot of the last broadcast and ships only the positions whose bytes differ.
+
+The motivating use case is **training/inference disaggregation** — running the trainer and the rollout engines in *different datacenters* over a shared filesystem with bandwidth on the order of 100s of MB/s, where a full broadcast is infeasible but a sparse delta (~3% density, ~5 GB for a 355B model) is. The same delta machinery also runs over NCCL inside a single datacenter, where it serves as the validation baseline that proves the wire encoding and apply logic are correct.
+
+Prior art: selective overwrite is inspired by [arXiv:2509.19128](https://arxiv.org/abs/2509.19128); the cross-DC disaggregation motivation is from [Fireworks AI — Frontier RL Is Cheaper Than You Think](https://fireworks.ai/blog/frontier-rl-is-cheaper-than-you-think).
+
+## Quick Start
+
+Disk transport (training/inference disaggregation — the main use case):
+
+```bash
+--update-weight-mode delta
+--update-weight-transport disk
+--update-weight-encoding deltas_zstd                 # best for ≤ 300 MB/s shared FS
+--update-weight-delta-dir /shared/fs/delta-updates
+```
+
+NCCL transport (intra-datacenter validation baseline):
+
+```bash
+--update-weight-mode delta
+--update-weight-transport nccl
+--update-weight-encoding indices                     # lowest compute, no compression
+```
+
+Receiver-side tuning (applies to both transports):
+
+```bash
+--vllm-update-weight-delta-chunk-bytes $((2 * 1024 * 1024 * 1024))  # byte cap per load_weights call
+--vllm-update-weight-delta-read-workers 4                           # parallel I/O threads (disk only)
+```
+
+See [examples/delta_weight_sync/run-glm4.7-355B-A32B-delta.sh](../../../examples/delta_weight_sync/run-glm4.7-355B-A32B-delta.sh) for a complete launcher.
+
+## How It Works
+
+Both transports share one sender pipeline, one wire layout, and one receiver-side decoder; only the per-flush carrier differs.
+
+**Sender (per sync, PP-source rank only):**
+
+1. **Diff** the current weights against the pinned-CPU snapshot via bytewise compare (`current.view(int_dtype) != snapshot.view(int_dtype)`) — lossless, dtype-agnostic, no arithmetic.
+2. **Encode** changed (position, value) pairs into a packed `__positions__` byte blob + `__values__` tensor + per-param decoding manifest. The encoding (`indices`, `deltas`, `deltas_zstd`) governs only how positions are packed; values are sent verbatim in the param's dtype.
+3. **Bucket** per-chunk encodes up to `--update-weight-buffer-size` bytes, then flush:
+   - NCCL: broadcast `(__positions__, __values__)` to the rollout engines with a `DeltaSpec` (encoding + per-param manifest) carried in the Ray RPC.
+   - Disk: write one safetensors file per flush under `weight_v{N:06d}/`. Async background thread does the I/O + optional zstd compression off the critical path.
+4. **Snapshot the just-sent values** via a D2H copy on a side stream so it overlaps with the next chunk's encode.
+
+**End-of-sync (disk only):** write a `DONE` marker, then rank 0 fires one HTTP push per engine and removes the directory after every engine acknowledges.
+
+**Receiver:**
+
+For both transports, the receiver ends up calling the same `_apply_delta_payload(encoding, params, positions, values)` helper. It decodes each param's slice into a full-shape tensor with NaN at unchanged positions, then routes it through `model.load_weights(...)` under a `_delta_apply_context` that patches `Tensor.copy_` / `Tensor.fill_` to perform NaN-masked overwrite. Auxiliary writes (scratch buffers, fp8 scales, MoE biases via `post_load_weights`) keep their normal semantics.
+
+Selective overwrite has no arithmetic — the receiver writes the trainer's exact bytes at changed positions — so it's lossless by construction and there's no notion of drift to fight with periodic base re-syncs.
+
+## Encoding Choice
+
+`--update-weight-encoding` picks how positions are packed. All three share the same on-wire layout (`__positions__` uint8 blob + `__values__` tensor + per-param manifest); decoder dispatches on the metadata.
+
+| value | positions | when to pick |
+|---|---|---|
+| `indices` | int32 absolute positions (4 bytes / nnz) | NCCL or fast intra-cluster FS (≥ ~600 MB/s) |
+| `deltas` | uint16 gap-deltas with uint32 fallback (~2 bytes / nnz at 2% density) | medium FS bandwidth (~300-500 MB/s) |
+| `deltas_zstd` | `deltas` wrapped in zstd L1 on disk | cross-DC / cross-region shared FS (≤ ~300 MB/s) |
+
+**Why gap-encoded positions are smaller**: positions come out of `mask.nonzero()` already sorted ascending. At density `p`, the expected gap between consecutive nonzero positions is `1/p`, and `P(gap > 65535) ≈ exp(-p · 65535)`. At p = 2% that's effectively zero, so uint16 fits with a uint32 per-param fallback for pathological inputs. Half the position bytes of `indices`, lossless.
+
+**Break-even with `indices`** at our density (~2%): `deltas` halves the positions blob (which dominates the wire); `zstd` shaves another ~35-40% on top by compressing the gap byte stream, at the cost of ~250ms/file compress + ~150ms/file decompress. The crossover with `indices` is where compress/decompress compute exceeds the bandwidth savings — empirically around 500 MB/s for `deltas` and 300 MB/s for `deltas_zstd`.
+
+## Why Not Colocated
+
+Colocated weight sync uses CUDA IPC: only a memory handle (~64 B) crosses processes. Delta encoding's "bytes saved on the wire" benefit is zero, while the bookkeeping (snapshot + diff + sparse encode) is pure overhead. Slime rejects `--update-weight-mode delta --colocate` at argparse time.

--- a/docs/en/advanced/delta-weight-sync.md
+++ b/docs/en/advanced/delta-weight-sync.md
@@ -8,7 +8,7 @@
 
 ## Why
 
-Slime's default sync broadcasts every parameter every step. The cost scales linearly with model size and dominates the sync phase, even though only a few percent of weights change between consecutive RL steps. Delta sync keeps a pinned-CPU snapshot of the last broadcast and ships only the positions whose bytes differ.
+Vime's default sync broadcasts every parameter every step. The cost scales linearly with model size and dominates the sync phase, even though only a few percent of weights change between consecutive RL steps. Delta sync keeps a pinned-CPU snapshot of the last broadcast and ships only the positions whose bytes differ.
 
 The motivating use case is **training/inference disaggregation** — running the trainer and the rollout engines in *different datacenters* over a shared filesystem with bandwidth on the order of 100s of MB/s, where a full broadcast is infeasible but a sparse delta (~3% density, ~5 GB for a 355B model) is. The same delta machinery also runs over NCCL inside a single datacenter, where it serves as the validation baseline that proves the wire encoding and apply logic are correct.
 
@@ -79,4 +79,4 @@ Selective overwrite has no arithmetic — the receiver writes the trainer's exac
 
 ## Why Not Colocated
 
-Colocated weight sync uses CUDA IPC: only a memory handle (~64 B) crosses processes. Delta encoding's "bytes saved on the wire" benefit is zero, while the bookkeeping (snapshot + diff + sparse encode) is pure overhead. Slime rejects `--update-weight-mode delta --colocate` at argparse time.
+Colocated weight sync uses CUDA IPC: only a memory handle (~64 B) crosses processes. Delta encoding's "bytes saved on the wire" benefit is zero, while the bookkeeping (snapshot + diff + sparse encode) is pure overhead. Vime rejects `--update-weight-mode delta --colocate` at argparse time.

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -44,6 +44,7 @@ vime is built on `slime <https://github.com/THUDM/slime>`_, the RL framework beh
    advanced/vllm-config.md
    advanced/megatron-config.md
    advanced/arch-support-beyond-megatron.md
+   advanced/delta-weight-sync.md
 
 .. toctree::
    :maxdepth: 1

--- a/docs/zh/advanced/delta-weight-sync.md
+++ b/docs/zh/advanced/delta-weight-sync.md
@@ -1,0 +1,80 @@
+# Delta 权重同步
+
+- [背景](#背景)
+- [快速开始](#快速开始)
+- [工作原理](#工作原理)
+- [编码选择](#编码选择)
+- [为何不支持 colocated](#为何不支持-colocated)
+
+## 背景
+
+vime 默认的权重同步会在每一步广播全部参数，开销随模型规模线性增长，即使每步真正变化的权重只有几个百分点。Delta 同步在内存中保留上一次同步后的参数快照（pinned CPU），只发送字节发生变化的位置。
+
+最主要的应用场景是 **训练 / 推理跨数据中心解耦** —— 训练器和推理引擎运行在不同数据中心，通过共享文件系统通信（带宽通常在百 MB/s 级别）。在这种环境下，全量广播不可行，而 ~3% 密度的稀疏 delta（355B 模型约 5 GB）是可行的。同一套 delta 机制在数据中心内部跑 NCCL，作为验证基线，确认 wire 编码和 apply 逻辑正确。
+
+参考资料：选择性覆写借鉴自 [arXiv:2509.19128](https://arxiv.org/abs/2509.19128)，跨数据中心的动机来自 [Fireworks AI — Frontier RL Is Cheaper Than You Think](https://fireworks.ai/blog/frontier-rl-is-cheaper-than-you-think)。
+
+## 快速开始
+
+磁盘传输（跨数据中心训推解耦，主要场景）：
+
+```bash
+--update-weight-mode delta
+--update-weight-transport disk
+--update-weight-encoding deltas_zstd                 # ≤ 300 MB/s 共享 FS 推荐
+--update-weight-delta-dir /shared/fs/delta-updates
+```
+
+NCCL 传输（数据中心内部验证基线）：
+
+```bash
+--update-weight-mode delta
+--update-weight-transport nccl
+--update-weight-encoding indices                     # 计算最少，无压缩
+```
+
+接收端调优（两种传输都适用）：
+
+```bash
+--vllm-update-weight-delta-chunk-bytes $((2 * 1024 * 1024 * 1024))  # 每次 load_weights 字节上限
+--vllm-update-weight-delta-read-workers 4                           # 并行 I/O 线程数（仅磁盘传输）
+```
+
+完整启动脚本见 [examples/delta_weight_sync/run-glm4.7-355B-A32B-delta.sh](../../../examples/delta_weight_sync/run-glm4.7-355B-A32B-delta.sh)。
+
+## 工作原理
+
+两种传输共用同一条发送管线、同一种 wire 布局以及同一套接收端解码器；只有每个 bucket 的承载层不同。
+
+**发送端（每次同步，仅 PP 源 rank）：**
+
+1. **求差**：通过逐字节比较 `current.view(int_dtype) != snapshot.view(int_dtype)` 检测变化。无算术、无损、与 dtype 无关。
+2. **编码**：将变化的 (位置, 值) 对打包成 `__positions__` 字节块 + `__values__` 张量 + per-param 解码 manifest。编码方式（`indices` / `deltas` / `deltas_zstd`）只影响位置如何打包，值始终按参数本身的 dtype 原样发送。
+3. **打包并发送**：每个 chunk 编码后累积至 `--update-weight-buffer-size` 字节再 flush：
+   - NCCL：广播 `(__positions__, __values__)`，Ray RPC 同时携带 `DeltaSpec`（编码 + per-param manifest）。
+   - 磁盘：每个 flush 写一个 safetensors 文件到 `weight_v{N:06d}/` 目录，后台线程负责 I/O 和可选的 zstd 压缩，不阻塞关键路径。
+4. **更新快照**：刚发送的值在 side stream 上 D2H 拷贝，与下一个 chunk 的编码重叠。
+
+**同步结束（仅磁盘）：** 写 `DONE` 标记，rank 0 对每个引擎触发一次 HTTP push，所有引擎确认后清理目录。
+
+**接收端：** 两种传输最终都进入同一个 `_apply_delta_payload(encoding, params, positions, values)` 帮助函数。它把每个参数的切片解码成全形状张量，未变化位置填 NaN，然后通过 `model.load_weights(...)` 应用；过程中 `_delta_apply_context` 替换 `Tensor.copy_` / `Tensor.fill_`，对参数存储执行 NaN 掩码覆写。辅助写入（scratch buffer、fp8 scale、MoE bias 等通过 `post_load_weights` 写入的派生张量）保留正常语义。
+
+选择性覆写没有任何算术运算 —— 接收端在变化位置直接写入训练端的精确字节 —— 因此天然无损，也不存在数值漂移问题，无需周期性 base 同步。
+
+## 编码选择
+
+`--update-weight-encoding` 决定位置如何打包。三种编码共用同一种 wire 布局（`__positions__` uint8 块 + `__values__` 张量 + per-param manifest），解码端根据 metadata 分派。
+
+| 取值 | 位置编码 | 推荐场景 |
+|---|---|---|
+| `indices` | int32 绝对位置（4 字节 / nnz） | NCCL 或高速集群内 FS（≥ ~600 MB/s） |
+| `deltas` | uint16 增量（异常时 uint32 兜底，2% 密度下约 2 字节 / nnz） | 中等带宽 FS（~300-500 MB/s） |
+| `deltas_zstd` | `deltas` 文件再用 zstd L1 压缩 | 跨数据中心 / 跨区共享 FS（≤ ~300 MB/s） |
+
+**为何 gap 编码更省**：`mask.nonzero()` 返回的位置已经升序排列。密度 `p` 时连续非零位置的期望间隔为 `1/p`，且 `P(gap > 65535) ≈ exp(-p · 65535)`，p = 2% 时这个概率实际上为零，所以 uint16 完全够用，uint32 仅作 per-param 兜底。位置开销比 `indices` 减半，且无损。
+
+**`deltas_zstd` 的额外收益**：在 gap 字节流上做 zstd L1 还能再减少 ~35-40%，代价是每文件约 250ms 压缩 + 150ms 解压。当共享 FS 带宽 ≤ 300 MB/s 时，带宽节省超过额外计算开销。
+
+## 为何不支持 colocated
+
+Colocated 同步通过 CUDA IPC：进程间传递的只是一个内存句柄（~64 B）。Delta 编码的"wire 节省"在此为零，而其簿记开销（快照 + 求差 + 稀疏编码）反而是纯损失。vime 在参数校验阶段拒绝 `--update-weight-mode delta --colocate`。

--- a/docs/zh/index.rst
+++ b/docs/zh/index.rst
@@ -44,6 +44,7 @@ vime 构建于 `slime <https://github.com/THUDM/slime>`_ 之上，slime 正是 G
    advanced/vllm-config.md
    advanced/megatron-config.md
    advanced/arch-support-beyond-megatron.md
+   advanced/delta-weight-sync.md
 
 .. toctree::
    :maxdepth: 1

--- a/examples/delta_weight_sync/README.md
+++ b/examples/delta_weight_sync/README.md
@@ -1,0 +1,67 @@
+# Delta Weight Sync
+
+Non-colocated weight sync that ships only changed positions + values instead of every parameter. Two transports over one wire format and one receiver-side decoder:
+
+- **Disk** (the point) — write per-flush safetensors to a shared filesystem; one HTTP push per sync. Designed for **training/inference disaggregation** across datacenters where bandwidth between trainer and rollout is on the order of 100s of MB/s.
+- **NCCL** (the baseline) — broadcast each per-flush bucket directly. Used intra-datacenter to validate that the wire encoding and apply logic are correct, separate from any shared-FS variable.
+
+Both modes are lossless by construction (selective overwrite via NaN sentinel; no arithmetic).
+
+## Files
+
+- `run-glm4.7-355B-A32B-delta.sh`: 16-node (8 actor + 8 rollout) GLM-4.7-355B-A32B launcher. Disk transport active by default; NCCL block commented below it.
+
+## Usage
+
+```bash
+bash examples/delta_weight_sync/run-glm4.7-355B-A32B-delta.sh
+```
+
+**Disk (default):**
+
+```bash
+DELTA_ARGS=(
+   --update-weight-mode delta
+   --update-weight-transport disk
+   --update-weight-encoding deltas_zstd
+   --update-weight-delta-dir /shared/fs/delta-updates
+)
+```
+
+**NCCL (baseline):**
+
+```bash
+DELTA_ARGS=(
+   --update-weight-mode delta
+   --update-weight-transport nccl
+   --update-weight-encoding indices
+)
+```
+
+Receiver-side byte cap (both transports):
+
+```bash
+--vllm-update-weight-delta-chunk-bytes $((2 * 1024 * 1024 * 1024))
+```
+
+See [docs/en/advanced/delta-weight-sync.md](../../docs/en/advanced/delta-weight-sync.md) for the wire protocol, encoding choice, and design.
+
+## Results
+
+W&B traces comparing delta sync against the full-sync baseline on GLM-4.7-355B-A32B / DAPO-Math-17k.
+
+![Raw reward](./raw_reward.png)
+
+![Train/rollout logprob abs diff](./train_rollout_logprob_abs_diff.png)
+
+![Update weights time](./update_weights_time.png)
+
+> **Note on the small curve-to-curve gap.** RL training is inherently non-deterministic (cuBLAS reductions, FlashAttention split-K, NCCL all-reduce ordering, dynamic-batch token assignment). Two identically-configured *full*-sync runs would diverge the same way. Delta sync's selective overwrite is bit-exact with full sync per step (no arithmetic, no drift); the trajectory matches, the bits don't.
+
+![Update weights density](./update_weights_density.png)
+
+*Per-sync change density (`perf/update_weights_density`) — fraction of weight positions that moved between consecutive syncs. Sync 0 is omitted: it's the snapshot-seeding pass with density = 1.0, which would compress the y-axis.*
+
+## Why these encoding defaults
+
+Per-sync change density during RL fine-tuning at conservative LRs sits around **2-3%** ([arXiv:2602.03839](https://arxiv.org/pdf/2602.03839) reports ~1% on a related setup; we measured ~2-3% on this run). Below the 3.125% break-even point, gap-encoded positions are smaller than absolute indices — the disk default `deltas_zstd` adds zstd L1 on top to squeeze the gap byte stream further (~35-40%), which is the right tradeoff when shared-FS bandwidth is ≤ 300 MB/s. Intra-datacenter NCCL has no bandwidth pressure, so `indices` (lowest compute, biggest payload) is the cleaner default there.

--- a/examples/delta_weight_sync/run-glm4.7-355B-A32B-delta.sh
+++ b/examples/delta_weight_sync/run-glm4.7-355B-A32B-delta.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+# Non-colocated GLM-4.7-355B-A32B with delta weight sync.
+# 8 actor nodes (TP=8, PP=4, EP=16) + 64 rollout GPUs (8 H100 nodes worth), 16 nodes total.
+# Disk transport is active by default; the NCCL block below it is commented out.
+
+pkill -9 vllm
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python
+
+set -ex
+
+export PYTHONUNBUFFERED=1
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "$NVLINK_COUNT" -gt 0 ]; then
+    HAS_NVLINK=1
+else
+    HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+source "/root/vime/scripts/models/glm4.5-355B-A32B.sh"
+
+CKPT_ARGS=(
+   --hf-checkpoint /root/GLM-4.7-355B-A32B
+   --ref-load /root/GLM-4.7-355B-A32B_torch_dist/
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data /root/dapo-math-17k/dapo-math-17k.jsonl
+   --input-key prompt
+   --label-key label
+   --apply-chat-template
+   --rollout-shuffle
+   --rm-type deepscaler
+   --num-rollout 3000
+   --rollout-batch-size 64
+   --n-samples-per-prompt 8
+   --rollout-max-response-len 8192
+   --rollout-temperature 1
+
+   --num-steps-per-rollout 4
+   --balance-data
+   --rollout-stop-token-ids 151329 151336 151338
+)
+
+EVAL_ARGS=(
+   --eval-interval 20
+   --eval-prompt-data aime /root/aime-2024/aime-2024.jsonl
+   --n-samples-per-eval-prompt 8
+   --eval-max-response-len 8192
+   --eval-top-p 1
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 8
+   --sequence-parallel
+   --pipeline-model-parallel-size 4
+   --context-parallel-size 2
+   --expert-model-parallel-size 16
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 16384
+)
+
+GRPO_ARGS=(
+   --advantage-estimator gspo
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --kl-coef 0.00
+   --entropy-coef 0.00
+   --eps-clip 1e-4
+   --eps-clip-high 2e-4
+   --use-tis
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+WANDB_ARGS=(
+   # --use-wandb
+   # --wandb-project vime-delta
+   # --wandb-group glm4.7-355B-delta
+)
+
+VLLM_ARGS=(
+   --rollout-num-gpus-per-engine 32
+   --vllm-mem-fraction-static 0.7
+   --vllm-enable-dp-attention
+   --vllm-dp-size 4
+   --vllm-ep-size 32
+   --vllm-enable-dp-lm-head
+   --vllm-moe-dense-tp-size 1
+
+   # Receiver batches up to this many bytes per model.load_weights call. Bigger
+   # amortizes per-call cost (name resolution, MoE expert remap) but raises peak HBM.
+   --vllm-update-weight-delta-chunk-bytes $((2 * 1024 * 1024 * 1024))
+
+   # Max parallel I/O threads for reading delta files from disk (disk transport only).
+   --vllm-update-weight-delta-read-workers 4
+
+   # mtp
+   --vllm-speculative-algorithm EAGLE
+   --vllm-speculative-num-steps 3
+   --vllm-speculative-eagle-topk 1
+   --vllm-speculative-num-draft-tokens 4
+)
+
+# Delta weight sync. Pick one of the two blocks below.
+
+# ── Disk (default) — for training/inference disaggregation across datacenters ────
+# `deltas_zstd` is the right pick when shared-FS bandwidth is ≤ ~300 MB/s.
+DELTA_ARGS=(
+   --update-weight-mode delta
+   --update-weight-transport disk
+   --update-weight-encoding deltas_zstd
+   --update-weight-delta-dir /shared/fs/delta-updates
+)
+
+# ── NCCL (baseline) — intra-datacenter, no shared FS ────────────────────────────
+# DELTA_ARGS=(
+#    --update-weight-mode delta
+#    --update-weight-transport nccl
+#    --update-weight-encoding indices
+# )
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+   --moe-token-dispatcher-type flex
+   --moe-enable-deepep
+   --update-weight-buffer-size $((2 * 1024 * 1024 * 1024))
+)
+
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+RUNTIME_ENV_JSON=$(cat <<EOF_JSON
+{
+  "env_vars": {
+    "no_proxy": "localhost,127.0.0.1,0.0.0.0,${MASTER_ADDR}",
+    "MASTER_ADDR": "${MASTER_ADDR}",
+    "PYTHONPATH": "/root/Megatron-LM/",
+    "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+    "NCCL_NVLS_ENABLE": "${HAS_NVLINK}"
+  }
+}
+EOF_JSON
+)
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 train.py \
+   --actor-num-nodes 8 \
+   --actor-num-gpus-per-node 8 \
+   --rollout-num-gpus 64 \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${VLLM_ARGS[@]} \
+   ${DELTA_ARGS[@]} \
+   ${MISC_ARGS[@]}

--- a/tests/test_delta_weight_update.py
+++ b/tests/test_delta_weight_update.py
@@ -1,0 +1,143 @@
+"""E2E smoke test for disk-backed delta weight updates.
+
+Runs a tiny Qwen3.5-0.8B job so the first weight update seeds the delta
+snapshot and the post-train update publishes sparse delta files through
+``update_weights_from_disk(load_format="delta", files=...)``.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+import vime.utils.external_utils.command_utils as U
+
+
+MODEL_NAME = "Qwen3.5-0.8B"
+MODEL_TYPE = "qwen3.5-0.8B"
+NUM_GPUS = 4
+TORCH_DIST_CKPT = f"/dev/shm/{MODEL_NAME}_torch_dist"
+
+
+def prepare():
+    U.exec_command("mkdir -p /root/models /root/datasets")
+    U.exec_command(f"hf download Qwen/{MODEL_NAME} --local-dir /root/models/{MODEL_NAME}")
+    U.hf_download_dataset("zhuzilin/gsm8k")
+    U.convert_checkpoint(
+        model_name=MODEL_NAME,
+        megatron_model_type=MODEL_TYPE,
+        num_gpus_per_node=NUM_GPUS,
+        dir_dst="/dev/shm",
+    )
+
+
+def execute():
+    with tempfile.TemporaryDirectory(prefix="vime_delta_weight_update_") as delta_dir:
+        ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}/ " f"--ref-load {TORCH_DIST_CKPT} "
+
+        rollout_args = (
+            "--prompt-data /root/datasets/gsm8k/train.parquet "
+            "--input-key messages "
+            "--label-key label "
+            "--apply-chat-template "
+            "--rollout-shuffle "
+            "--rm-type math "
+            "--num-rollout 1 "
+            "--rollout-batch-size 4 "
+            "--n-samples-per-prompt 4 "
+            "--rollout-max-response-len 1024 "
+            "--rollout-temperature 0.8 "
+            "--over-sampling-batch-size 8 "
+            "--dynamic-sampling-filter-path vime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std "
+            "--global-batch-size 16 "
+        )
+
+        perf_args = (
+            "--tensor-model-parallel-size 1 "
+            "--sequence-parallel "
+            "--pipeline-model-parallel-size 1 "
+            "--context-parallel-size 1 "
+            "--expert-model-parallel-size 1 "
+            "--expert-tensor-parallel-size 1 "
+            "--use-dynamic-batch-size "
+            "--max-tokens-per-gpu 9216 "
+        )
+
+        grpo_args = (
+            "--advantage-estimator grpo "
+            "--use-kl-loss "
+            "--kl-loss-coef 0.00 "
+            "--kl-loss-type low_var_kl "
+            # Nonzero entropy coef guarantees a nonzero gradient even when all
+            # rewards in a group tie (advantages=0), so the delta sync writes
+            # real sparse files instead of an empty no-op.
+            "--entropy-coef 0.01 "
+            "--eps-clip 0.2 "
+            "--eps-clip-high 0.28 "
+        )
+
+        optimizer_args = (
+            "--optimizer adam "
+            "--lr 1e-6 "
+            "--lr-decay-style constant "
+            "--weight-decay 0.1 "
+            "--adam-beta1 0.9 "
+            "--adam-beta2 0.98 "
+        )
+
+        vllm_args = (
+            "--rollout-num-gpus-per-engine 1 "
+            "--rollout-num-gpus 3 "
+            "--vllm-mem-fraction-static 0.7 "
+            "--vllm-cuda-graph-max-bs 32 "
+            "--vllm-enable-metrics "
+        )
+
+        delta_args = (
+            "--update-weight-mode delta "
+            "--update-weight-transport disk "
+            "--update-weight-encoding deltas "
+            f"--update-weight-delta-dir {delta_dir} "
+            "--update-weight-delta-keep-files "
+        )
+
+        ci_args = "--ci-test "
+
+        misc_args = (
+            "--attention-dropout 0.0 "
+            "--hidden-dropout 0.0 "
+            "--accumulate-allreduce-grads-in-fp32 "
+            "--attention-softmax-in-fp32 "
+            "--attention-backend flash "
+            "--loss-mask-type qwen3_5 "
+            "--actor-num-nodes 1 "
+            "--actor-num-gpus-per-node 1 "
+        )
+
+        train_args = (
+            f"{ckpt_args} "
+            f"{rollout_args} "
+            f"{optimizer_args} "
+            f"{grpo_args} "
+            f"{U.get_default_wandb_args(__file__)} "
+            f"{perf_args} "
+            f"{vllm_args} "
+            f"{delta_args} "
+            f"{ci_args} "
+            f"{misc_args} "
+        )
+
+        U.execute_train(
+            train_args=train_args,
+            num_gpus_per_node=NUM_GPUS,
+            megatron_model_type=MODEL_TYPE,
+        )
+
+        delta_files = list(Path(delta_dir).glob("weight_v*/*.safetensors"))
+        assert delta_files, f"No disk delta safetensors were written under {delta_dir}"
+
+
+if __name__ == "__main__":
+    prepare()
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    execute()

--- a/vime/backends/megatron_utils/actor.py
+++ b/vime/backends/megatron_utils/actor.py
@@ -136,6 +136,10 @@ class MegatronTrainRayActor(TrainRayActor):
 
         if self.args.colocate:
             update_weight_cls = UpdateWeightFromTensor
+        elif self.args.update_weight_mode == "delta":
+            from .update_weight.update_weight_from_distributed_delta import UpdateWeightFromDistributedDelta
+
+            update_weight_cls = UpdateWeightFromDistributedDelta
         else:
             update_weight_cls = UpdateWeightFromDistributed
         self.weight_updater = update_weight_cls(
@@ -555,7 +559,8 @@ class MegatronTrainRayActor(TrainRayActor):
                     logger.info(f"Updating ref model at rollout_id {rollout_id}")
                 self.weights_backuper.backup("ref")
 
-        log_perf_data(rollout_id, self.args)
+        pop_metrics = getattr(self.weight_updater, "pop_metrics", None)
+        log_perf_data(rollout_id, self.args, extra_metrics=pop_metrics() if pop_metrics else None)
 
     @timer
     def save_model(self, rollout_id: int, force_sync: bool = False) -> None:

--- a/vime/backends/megatron_utils/data.py
+++ b/vime/backends/megatron_utils/data.py
@@ -508,7 +508,7 @@ def log_passrate(rollout_id: int, args: Namespace, rollout_data: RolloutBatch) -
         gather_log_data("passrate", args, rollout_id, log_dict)
 
 
-def log_perf_data(rollout_id: int, args: Namespace) -> None:
+def log_perf_data(rollout_id: int, args: Namespace, extra_metrics: dict | None = None) -> None:
     train_metric_utils.log_perf_data_raw(
         rollout_id=rollout_id,
         args=args,
@@ -520,6 +520,7 @@ def log_perf_data(rollout_id: int, args: Namespace) -> None:
         compute_total_fwd_flops=lambda seq_lens: calculate_fwd_flops(seqlens=seq_lens, args=args)
         / dist.get_world_size()
         / 1e12,
+        extra_metrics=extra_metrics,
     )
 
 

--- a/vime/backends/megatron_utils/update_weight/delta_io.py
+++ b/vime/backends/megatron_utils/update_weight/delta_io.py
@@ -1,0 +1,55 @@
+"""Wire structs for delta weight sync.
+
+Ported from slime, which defines these in the sglang ``io_struct`` module (and
+ships them via ``docker/patch/.../sglang.patch``). vime has no sglang dependency,
+so the structs live here and are shared by both ends of the wire:
+
+  - the trainer encoder (``update_weight_from_distributed_delta.py``), and
+  - the receiver decoder (``delta_receiver.py``, mixed into the vLLM worker via
+    ``vLLMColocateWorkerExtension``).
+
+Three ``DeltaEncoding`` variants differ only in how the changed-position blob is
+packed; ``DeltaParam`` slices the shared (positions, values) bucket per param;
+``DeltaSpec`` is the per-bucket decoding manifest that travels as JSON alongside
+the NCCL broadcast / disk safetensors payload.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class DeltaEncoding(str, Enum):
+    """Position encoding for delta weight updates."""
+
+    # int32 absolute nonzero offsets.
+    INDICES = "indices"
+    # uint16 gap-deltas between consecutive sorted positions; uint32 per-param fallback.
+    DELTAS = "deltas"
+    # ``deltas`` wrapped in zstd L1.
+    DELTAS_ZSTD = "deltas_zstd"
+
+
+@dataclass
+class DeltaParam:
+    """Per-param slice into the shared (positions, values) bucket. ``pos_*`` index
+    into the uint8 byte blob; ``val_*`` index into the param-dtype value tensor."""
+
+    name: str
+    dtype: str
+    shape: list[int]
+    pos_start: int
+    pos_end: int
+    pos_width: int  # 2 or 4
+    val_start: int
+    val_end: int
+
+
+@dataclass
+class DeltaSpec:
+    """Decoding manifest for one delta bucket. ``checksum`` is verified on apply."""
+
+    encoding: DeltaEncoding
+    params: list[DeltaParam] = field(default_factory=list)
+    checksum: int = 0

--- a/vime/backends/megatron_utils/update_weight/delta_io.py
+++ b/vime/backends/megatron_utils/update_weight/delta_io.py
@@ -1,13 +1,5 @@
 """Wire structs for delta weight sync.
 
-Ported from slime, which defines these in the sglang ``io_struct`` module (and
-ships them via ``docker/patch/.../sglang.patch``). vime has no sglang dependency,
-so the structs live here and are shared by both ends of the wire:
-
-  - the trainer encoder (``update_weight_from_distributed_delta.py``), and
-  - the receiver decoder (``delta_receiver.py``, mixed into the vLLM worker via
-    ``vLLMColocateWorkerExtension``).
-
 Three ``DeltaEncoding`` variants differ only in how the changed-position blob is
 packed; ``DeltaParam`` slices the shared (positions, values) bucket per param;
 ``DeltaSpec`` is the per-bucket decoding manifest that travels as JSON alongside

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_distributed_delta.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_distributed_delta.py
@@ -1,0 +1,870 @@
+"""
+Delta weight sync.
+
+For each sync, the sender bytewise-diffs the current weights against a
+pinned-CPU snapshot of the last broadcast, packs the changed positions
+and values, and ships them via one of two transports:
+
+  - "nccl": each bucket flush goes out via NCCL broadcast (low-latency,
+    high-bandwidth, intra-datacenter).
+  - "disk": each bucket flush is written to a versioned shared-FS directory
+    as one safetensors file; one HTTP push per sync wakes the rollout
+    engines to read+apply (cross-datacenter, bandwidth-limited).
+
+Both transports share one wire layout (``__positions__`` uint8 byte blob +
+``__values__`` param-dtype tensor + per-param decoding manifest) and one
+receiver-side decoder. Three encodings differ only in how positions are
+packed:
+
+  indices     : int32 absolute positions
+  deltas      : uint16 gap-deltas (uint32 fallback per param)
+  deltas_zstd : ``deltas`` with the safetensors blob wrapped in zstd L1
+
+The receiver overwrites changed positions with the trainer's exact bytes
+(no arithmetic), so the apply is lossless and there is no drift to fight
+with periodic re-syncs. The first ``update_weights`` call seeds the
+snapshot without contacting the rollout engines — they're assumed to have
+loaded the same HF checkpoint at init.
+"""
+
+import itertools
+import json
+import logging
+import os
+import shutil
+import threading
+from argparse import Namespace
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass, field, replace
+from queue import Queue
+
+import numpy as np
+import ray
+import torch
+import torch.distributed as dist
+from megatron.core import mpu
+from ray.actor import ActorHandle
+from safetensors.torch import save as st_save_bytes
+from tqdm import tqdm
+
+from vime.utils.distributed_utils import get_gloo_group
+from vime.utils.timer import Timer, timer
+
+from .delta_io import DeltaEncoding, DeltaParam, DeltaSpec
+from .update_weight_from_distributed import UpdateWeightFromDistributed
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------- compute + encode -----------------------------------------------
+
+
+@dataclass
+class ParamDiff:
+    """
+    One per-param compute output. ``values`` is a reference to the full-shape
+    current tensor (no copy); ``mask`` is a same-shape bool marking the
+    positions whose bytes differ from the snapshot.
+    """
+
+    name: str
+    values: torch.Tensor
+    mask: torch.Tensor
+
+
+@dataclass
+class EncodedChunk:
+    """
+    One HF chunk after position+value encoding, before bucket merging.
+
+    ``pos_bytes`` and ``val_tensor`` are the chunk-local concatenations across
+    all params; per-param byte/element offsets live on ``params``.
+    """
+
+    pos_bytes: bytes
+    val_tensor: torch.Tensor
+    params: list[DeltaParam]
+    nnz: int
+
+    @classmethod
+    def empty(cls) -> "EncodedChunk":
+        return cls(pos_bytes=b"", val_tensor=torch.empty(0, dtype=torch.bfloat16), params=[], nnz=0)
+
+
+def _checksum(positions: torch.Tensor, values: torch.Tensor) -> int:
+    """
+    Wire-corruption check via ``torch.hash_tensor`` (XOR-reduce over uint64 bitcast).
+    Sender computes pre-flush, receiver computes post-recv; mismatch indicates
+    corruption between encode and apply. One reduction + one ``.item()`` sync per arg.
+    """
+    p = int(torch.hash_tensor(positions).item()) if positions.numel() else 0
+    v = int(torch.hash_tensor(values).item()) if values.numel() else 0
+    return p ^ (v << 1)
+
+
+def _bytewise_diff_mask(current: torch.Tensor, snapshot: torch.Tensor) -> torch.Tensor:
+    """
+    Per-element bool mask: True where current and snapshot bytes differ. Dtype-agnostic via view-as-integer.
+    """
+    es = current.element_size()
+    int_dtype = {1: torch.uint8, 2: torch.int16, 4: torch.int32, 8: torch.int64}.get(es)
+    if int_dtype is None:
+        raise ValueError(f"unsupported element size {es}")
+    return current.view(int_dtype) != snapshot.view(int_dtype)
+
+
+def _sparse_boundaries(
+    diffs: list[ParamDiff],
+) -> tuple[torch.Tensor, list[int], torch.Tensor, list[int]]:
+    """
+    One concat → one nonzero → one searchsorted → one ``tolist()``: collapses
+    per-param host syncs to one per chunk. Returns ``(big_val, bounds, big_idx, cum)``.
+    """
+    device = diffs[0].values.device
+    sizes = [d.values.numel() for d in diffs]
+    cum = list(itertools.accumulate(sizes))
+    cum_t = torch.tensor(cum, dtype=torch.int64, device=device)
+
+    big_values = torch.cat([d.values.contiguous().view(-1) for d in diffs], dim=0)
+    big_mask = torch.cat([d.mask.contiguous().view(-1) for d in diffs], dim=0)
+    big_idx = big_mask.nonzero(as_tuple=False).view(-1)
+    big_val = big_values[big_idx]
+    bounds = torch.searchsorted(big_idx, cum_t).tolist()
+    return big_val, bounds, big_idx, cum
+
+
+def encode_indices(diffs: list[ParamDiff]) -> EncodedChunk:
+    """
+    int32 absolute positions, per-param. Position blob is uint8 bytes; pos_width=4 for all params.
+    """
+    if not diffs:
+        return EncodedChunk.empty()
+    big_val, bounds, big_idx, cum = _sparse_boundaries(diffs)
+    pos_pieces: list[torch.Tensor] = []
+    val_pieces: list[torch.Tensor] = []
+    params: list[DeltaParam] = []
+    pos_byte_off = val_off = 0
+    prev_b = 0
+    prev_param_start = 0
+    for i, d in enumerate(diffs):
+        b = bounds[i]
+        nnz = b - prev_b
+        if nnz > 0:
+            local_idx = (big_idx[prev_b:b] - prev_param_start).to(torch.int32)
+            pos_pieces.append(local_idx)
+            val_pieces.append(big_val[prev_b:b])
+            params.append(
+                DeltaParam(
+                    name=d.name,
+                    dtype=str(d.values.dtype).replace("torch.", ""),
+                    shape=list(d.values.shape),
+                    pos_start=pos_byte_off,
+                    pos_end=pos_byte_off + nnz * 4,
+                    pos_width=4,
+                    val_start=val_off,
+                    val_end=val_off + nnz,
+                )
+            )
+            pos_byte_off += nnz * 4
+            val_off += nnz
+        prev_b = b
+        prev_param_start = cum[i]
+    if not params:
+        return EncodedChunk.empty()
+    positions = torch.cat(pos_pieces, dim=0)
+    values = torch.cat(val_pieces, dim=0)
+    return EncodedChunk(
+        pos_bytes=positions.cpu().numpy().tobytes(),
+        val_tensor=values,
+        params=params,
+        nnz=val_off,
+    )
+
+
+def encode_deltas(diffs: list[ParamDiff]) -> EncodedChunk:
+    """
+    Gap-encode sorted positions: store ``idx[k] - idx[k-1] - 1`` with idx[-1] := -1
+    so the first delta equals the first index. Per-param downcast to uint16 if the max
+    gap fits, otherwise uint32. At ~2% Bernoulli density on bf16 weights, max gap ≈ 300
+    — uint16 fits; the fallback covers pathological inputs without correctness risk.
+    Receiver inverts: ``idx = cumsum(delta + 1) - 1``.
+    """
+    if not diffs:
+        return EncodedChunk.empty()
+    big_val, bounds, big_idx, cum = _sparse_boundaries(diffs)
+
+    kept: list[tuple[ParamDiff, int]] = []  # (diff, nnz) for non-empty params
+    per_param_deltas: list[torch.Tensor] = []
+    val_pieces: list[torch.Tensor] = []
+    prev_b = 0
+    prev_param_start = 0
+    for i, d in enumerate(diffs):
+        b = bounds[i]
+        nnz = b - prev_b
+        if nnz > 0:
+            local_idx = big_idx[prev_b:b] - prev_param_start  # int64, sorted
+            prev = torch.cat(
+                [
+                    torch.tensor([-1], dtype=local_idx.dtype, device=local_idx.device),
+                    local_idx[:-1],
+                ]
+            )
+            per_param_deltas.append(local_idx - prev - 1)
+            val_pieces.append(big_val[prev_b:b])
+            kept.append((d, nnz))
+        prev_b = b
+        prev_param_start = cum[i]
+
+    if not kept:
+        return EncodedChunk.empty()
+
+    # One CPU sync for per-param width selection.
+    max_per_param = torch.stack([d.max() for d in per_param_deltas]).cpu().tolist()
+    pos_byte_pieces: list[bytes] = []
+    pos_byte_off = val_off = 0
+    params: list[DeltaParam] = []
+    for (d, nnz), deltas, max_d in zip(kept, per_param_deltas, max_per_param, strict=True):
+        width = 2 if int(max_d) <= 65535 else 4
+        np_dtype = np.uint16 if width == 2 else np.uint32
+        b_chunk = deltas.cpu().numpy().astype(np_dtype, copy=False).tobytes()
+        pos_byte_pieces.append(b_chunk)
+        params.append(
+            DeltaParam(
+                name=d.name,
+                dtype=str(d.values.dtype).replace("torch.", ""),
+                shape=list(d.values.shape),
+                pos_start=pos_byte_off,
+                pos_end=pos_byte_off + len(b_chunk),
+                pos_width=width,
+                val_start=val_off,
+                val_end=val_off + nnz,
+            )
+        )
+        pos_byte_off += len(b_chunk)
+        val_off += nnz
+
+    values = torch.cat(val_pieces, dim=0)
+    return EncodedChunk(
+        pos_bytes=b"".join(pos_byte_pieces),
+        val_tensor=values,
+        params=params,
+        nnz=val_off,
+    )
+
+
+# ---------- snapshot state -------------------------------------------------
+
+
+class DeltaState:
+    """
+    Pinned-CPU snapshot of every HF tensor we've broadcast, plus the H2D/D2H
+    side streams that pipeline next-chunk snapshot transfer behind the current
+    chunk's compute.
+    """
+
+    def __init__(self) -> None:
+        self.snapshot: dict[str, torch.Tensor] = {}
+        self.d2h_stream: torch.cuda.Stream | None = None
+        self.h2d_stream: torch.cuda.Stream | None = None
+        self.snapshot_dirty = False
+
+    def prefetch_snapshot(
+        self, named_tensors: list[tuple[str, torch.Tensor]]
+    ) -> tuple[list[torch.Tensor], torch.cuda.Event]:
+        """
+        Start an async H2D copy of the snapshot tensors for ``named_tensors`` on a side stream.
+        """
+        if self.h2d_stream is None:
+            self.h2d_stream = torch.cuda.Stream()
+        prev_gpu: list[torch.Tensor] = []
+        with torch.cuda.stream(self.h2d_stream):
+            for name, tensor in named_tensors:
+                if name not in self.snapshot:
+                    raise KeyError(f"missing snapshot for {name!r}; first update_weights call seeds the snapshot")
+                prev_gpu.append(self.snapshot[name].to(device=tensor.device, non_blocking=True))
+            event = self.h2d_stream.record_event()
+        return prev_gpu, event
+
+    def compute_diffs(
+        self,
+        named_tensors: list[tuple[str, torch.Tensor]],
+        prefetched: tuple[list[torch.Tensor], torch.cuda.Event],
+    ) -> list[ParamDiff]:
+        """
+        Wait for the prefetched H2D copy, then per-param bytewise diff against the snapshot.
+        """
+        prev_gpu, event = prefetched
+        event.wait()
+        return [
+            ParamDiff(name=name, values=current, mask=_bytewise_diff_mask(current, prev))
+            for (name, current), prev in zip(named_tensors, prev_gpu, strict=True)
+        ]
+
+    def update_snapshot_async(self, named_tensors: list[tuple[str, torch.Tensor]]) -> None:
+        """
+        Enqueue a D2H copy of ``named_tensors`` into the pinned-CPU snapshot on a
+        side stream. Non-blocking; call ``flush_snapshot`` before the next sync.
+        """
+        if self.d2h_stream is None:
+            self.d2h_stream = torch.cuda.Stream()
+        event = torch.cuda.current_stream().record_event()
+        with torch.cuda.stream(self.d2h_stream):
+            self.d2h_stream.wait_event(event)
+            for name, tensor in named_tensors:
+                if name not in self.snapshot:
+                    self.snapshot[name] = torch.empty_like(tensor, device=torch.device("cpu"), pin_memory=True)
+                self.snapshot[name].copy_(tensor.detach(), non_blocking=True)
+        self.snapshot_dirty = True
+
+    def flush_snapshot(self) -> None:
+        """
+        Block until all enqueued D2H snapshot copies have landed.
+        """
+        if self.snapshot_dirty:
+            if self.d2h_stream is not None:
+                self.d2h_stream.synchronize()
+            else:
+                torch.cuda.synchronize()
+            self.snapshot_dirty = False
+
+
+# ---------- bucket ---------------------------------------------------------
+
+
+@dataclass
+class DeltaBucket:
+    """
+    Accumulates encoded chunks for one flush. Per-param offsets are rebased
+    into the bucket's growing position blob + value tensor on ``add``.
+    """
+
+    pos_pieces: list[bytes] = field(default_factory=list)
+    val_pieces: list[torch.Tensor] = field(default_factory=list)
+    params: list[DeltaParam] = field(default_factory=list)
+    pos_total: int = 0
+    val_total: int = 0
+    byte_size: int = 0
+
+    @property
+    def has_updates(self) -> bool:
+        return bool(self.pos_pieces)
+
+    def should_flush_before_add(self, chunk: EncodedChunk, byte_limit: int) -> bool:
+        """True iff adding ``chunk`` would push the bucket past ``byte_limit``."""
+        chunk_bytes = len(chunk.pos_bytes) + chunk.val_tensor.numel() * chunk.val_tensor.element_size()
+        return self.has_updates and self.byte_size + chunk_bytes > byte_limit
+
+    def add(self, chunk: EncodedChunk) -> None:
+        """Append ``chunk``, rebasing each param's byte/element offsets into the bucket."""
+        for p in chunk.params:
+            self.params.append(
+                replace(
+                    p,
+                    pos_start=p.pos_start + self.pos_total,
+                    pos_end=p.pos_end + self.pos_total,
+                    val_start=p.val_start + self.val_total,
+                    val_end=p.val_end + self.val_total,
+                )
+            )
+        self.pos_pieces.append(chunk.pos_bytes)
+        self.val_pieces.append(chunk.val_tensor)
+        self.pos_total += len(chunk.pos_bytes)
+        self.val_total += chunk.val_tensor.numel()
+        self.byte_size += len(chunk.pos_bytes) + chunk.val_tensor.numel() * chunk.val_tensor.element_size()
+
+    def merged_positions_cpu(self) -> torch.Tensor:
+        """One CPU uint8 tensor with the bucket's positions blob."""
+        merged = b"".join(self.pos_pieces)
+        if not merged:
+            return torch.empty(0, dtype=torch.uint8)
+        return torch.from_numpy(np.frombuffer(merged, dtype=np.uint8).copy())
+
+    def merged_values(self) -> torch.Tensor:
+        """One GPU tensor with the bucket's values, concatenated across chunks."""
+        if not self.val_pieces:
+            return torch.empty(0, dtype=torch.bfloat16)
+        return torch.cat(self.val_pieces, dim=0)
+
+    def clear(self) -> None:
+        """Reset to empty so the bucket can be reused for the next flush."""
+        self.pos_pieces.clear()
+        self.val_pieces.clear()
+        self.params.clear()
+        self.pos_total = 0
+        self.val_total = 0
+        self.byte_size = 0
+
+
+# ---------- async safetensors writer (disk transport only) -----------------
+
+
+class AsyncSafetensorsWriter:
+    """
+    Background thread that drains a queue of file writes. Producers do GPU→CPU
+    on the default stream and enqueue; the writer does the slow disk I/O
+    (and optional zstd compress) off the critical path. End-of-sync ``drain()``
+    blocks until all enqueued writes have landed.
+    """
+
+    def __init__(self, compress_with_zstd: bool, zstd_level: int = 1) -> None:
+        self._queue: Queue = Queue()
+        self._error: BaseException | None = None
+        self._compress_with_zstd = compress_with_zstd
+        self._zstd_level = zstd_level
+        if compress_with_zstd:
+            # Lazy import — non-disk users don't pay the dep.
+            import zstandard
+
+            self._zstd = zstandard
+        self._lock = threading.Lock()
+        self.bytes_pre_compress = 0
+        self.bytes_post_compress = 0
+        self._thread = threading.Thread(target=self._run, name="delta-disk-writer", daemon=True)
+        self._thread.start()
+
+    def enqueue(
+        self,
+        path: str,
+        tensors: dict[str, torch.Tensor],
+        metadata: dict[str, str],
+    ) -> None:
+        """Hand a (path, tensors, metadata) tuple to the writer thread."""
+        if self._error is not None:
+            raise RuntimeError(f"writer thread already failed: {self._error!r}")
+        self._queue.put((path, tensors, metadata))
+
+    def drain(self) -> None:
+        """Block until every queued write has landed; re-raise any writer-thread error."""
+        self._queue.join()
+        if self._error is not None:
+            raise RuntimeError(f"writer thread failed: {self._error!r}") from self._error
+
+    def reset_counters(self) -> None:
+        """Zero the byte counters at the start of a sync."""
+        with self._lock:
+            self.bytes_pre_compress = 0
+            self.bytes_post_compress = 0
+
+    def _run(self) -> None:
+        """Writer-thread loop: safetensors-encode → (optional zstd) → atomic replace."""
+        cctx = self._zstd.ZstdCompressor(level=self._zstd_level, threads=-1) if self._compress_with_zstd else None
+        while True:
+            path, tensors, metadata = self._queue.get()
+            try:
+                if self._error is None:
+                    blob = st_save_bytes(tensors, metadata=metadata)
+                    pre = len(blob)
+                    if cctx is not None:
+                        blob = cctx.compress(blob)
+                    post = len(blob)
+                    tmp = path + ".tmp"
+                    with open(tmp, "wb") as f:
+                        f.write(blob)
+                        f.flush()
+                        os.fsync(f.fileno())
+                    os.replace(tmp, path)
+                    with self._lock:
+                        self.bytes_pre_compress += pre
+                        self.bytes_post_compress += post
+            except BaseException as e:  # noqa: BLE001
+                self._error = e
+            finally:
+                self._queue.task_done()
+
+
+# ---------- main class -----------------------------------------------------
+
+
+class UpdateWeightFromDistributedDelta(UpdateWeightFromDistributed):
+    """
+    Selective delta sync. ``--update-weight-transport`` picks the per-flush carrier:
+    "nccl" broadcasts each bucket; "disk" writes each bucket as a safetensors file under
+    ``--update-weight-delta-dir`` and pushes once at end-of-sync.
+    """
+
+    def __init__(
+        self,
+        args: Namespace,
+        model: Sequence[torch.nn.Module],
+        weights_getter: Callable[[], Mapping[str, torch.Tensor]],
+        *,
+        model_name: str,
+        quantization_config: dict[str, int | str | list[str]] | None,
+    ) -> None:
+        super().__init__(
+            args,
+            model,
+            weights_getter,
+            model_name=model_name,
+            quantization_config=quantization_config,
+        )
+        self.transport = args.update_weight_transport
+        self.encoding = DeltaEncoding(args.update_weight_encoding)
+        self.delta_state = DeltaState()
+        self._snapshot_seeded = False
+        # DELTAS_ZSTD shares the gap encoder; zstd is applied at file-write time.
+        self._encode = encode_indices if self.encoding is DeltaEncoding.INDICES else encode_deltas
+
+        self.writer: AsyncSafetensorsWriter | None = None
+        self.delta_dir: str | None = None
+        self._pre_push_hook: Callable | None = None
+        # Disk transport: each pass boundary publishes its accumulated files
+        # (the only globally-synced flush points, since ``_publish_batch``
+        # contains collectives). ``_pre_push_hook`` may return a Future, in
+        # which case the receiver RPC is deferred behind it via
+        # ``_rpc_executor`` so the main encode thread continues immediately.
+        # ``_pending_publishes`` holds the resulting Future[list[ObjectRef]]
+        # on rank 0; ``_finalize_sync`` awaits them at end of sync.
+        self._pending_files: list[str] = []
+        self._pending_publishes: list = []
+        self._published_any: bool = False
+        self._rpc_executor: ThreadPoolExecutor | None = None
+        if self.transport == "disk":
+            self.delta_dir = args.update_weight_delta_dir
+            os.makedirs(self.delta_dir, exist_ok=True)
+            self.writer = AsyncSafetensorsWriter(
+                compress_with_zstd=(self.encoding == DeltaEncoding.DELTAS_ZSTD),
+            )
+            self._rpc_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="delta-publish-rpc")
+            if getattr(args, "custom_delta_pre_push_path", None):
+                from vime.utils.misc import load_function
+
+                self._pre_push_hook = load_function(args.custom_delta_pre_push_path)
+
+    def connect_rollout_engines(
+        self,
+        rollout_engines: Sequence[ActorHandle],
+        rollout_engine_lock: ActorHandle,
+        engine_gpu_counts: Sequence[int] | None = None,
+        engine_gpu_offsets: Sequence[int] | None = None,
+    ) -> None:
+        """
+        NCCL transport: delegate to parent (group creation). Disk transport: just
+        record the engines + PP-src flag (no NCCL group needed).
+        """
+        if self.transport == "nccl":
+            super().connect_rollout_engines(
+                rollout_engines,
+                rollout_engine_lock,
+                engine_gpu_counts=engine_gpu_counts,
+                engine_gpu_offsets=engine_gpu_offsets,
+            )
+            return
+        self.rollout_engines = rollout_engines
+        self.rollout_engine_lock = rollout_engine_lock
+        self._engine_gpu_counts = engine_gpu_counts
+        self._is_pp_src_rank = (
+            mpu.get_data_parallel_rank(with_context_parallel=True) == 0 and mpu.get_tensor_model_parallel_rank() == 0
+        )
+        pp_rank = mpu.get_pipeline_model_parallel_rank()
+        self._group_name = f"vime-pp_{pp_rank}"
+
+    def disconnect_rollout_engines(self) -> None:
+        if self.transport == "nccl":
+            super().disconnect_rollout_engines()
+
+    @torch.no_grad()
+    def update_weights(self) -> None:
+        """
+        First call: seed the CPU snapshot from current model state, no engine RPCs.
+        Subsequent calls: pause → diff/encode → finalize → resume. ``delta_encode``
+        covers the sender's per-param TP/EP gather + diff + sparse encode + per-publish
+        commit/RPC handoff; ``delta_finalize`` covers the tail wait for the last
+        batch's receiver-apply. Their sum is the sync latency the user observes.
+        """
+        if not self._snapshot_seeded:
+            self._seed_snapshot()
+            self._snapshot_seeded = True
+            # Pin the engine's recorded version to ours (0) on the seed call so the
+            # CI version-equality check holds before any real sync has happened.
+            if dist.get_rank() == 0 and self.transport == "disk" and self.rollout_engines:
+                weight_version = str(self.weight_version)
+                ray.get([engine.set_weight_version.remote(weight_version) for engine in self.rollout_engines])
+            return
+
+        self.weight_version += 1
+        if self.transport == "disk":
+            self._version_dir = os.path.join(self.delta_dir, f"weight_v{self.weight_version:06d}")
+            if self._is_pp_src_rank:
+                os.makedirs(self._version_dir, exist_ok=True)
+
+        if dist.get_rank() == 0:
+            ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
+            ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
+        dist.barrier(group=get_gloo_group())
+
+        self.density_nnz = self.density_numel = self.wire_bytes = self._flush_idx = 0
+        self._pending_files.clear()
+        self._pending_publishes.clear()
+        self._published_any = False
+        if self.writer is not None:
+            self.writer.reset_counters()
+        pbar = tqdm(desc=f"[{self._group_name}] Update weights", total=0) if self._is_pp_src_rank else None
+
+        with timer("delta_encode"):
+            self._send_weights(pbar)
+            if self.writer is not None:
+                self.writer.drain()
+            self.delta_state.flush_snapshot()
+            dist.barrier(group=get_gloo_group())
+
+        with timer("delta_finalize"):
+            self._finalize_sync()
+
+        self._record_metrics()
+
+    def _seed_snapshot(self) -> None:
+        """
+        Populate the snapshot from current model state (TP/EP gather + HF
+        convert on PP-src ranks, D2H pinned copy). Cost is one full pass over
+        params — ~50s blocking on 355B at init.
+        """
+        for chunk_iter in (self._iter_non_expert_chunks(), self._iter_expert_chunks()):
+            for hf_chunk in chunk_iter:
+                if hf_chunk:
+                    self.delta_state.update_snapshot_async(hf_chunk)
+            dist.barrier(group=get_gloo_group())
+        self.delta_state.flush_snapshot()
+
+    def _send_weights(self, pbar: tqdm | None) -> None:
+        """
+        Non-expert pass then expert pass, each followed by a barrier + (disk-only)
+        publish. The expert pass is split into ``_EXPERT_SUBPASSES`` sub-passes so
+        receiver apply for an earlier batch overlaps with later expert encoding,
+        instead of bottlenecking at end-of-sync. Megatron splits MoE layers
+        uniformly across PP ranks, so a per-rank slice of the expert param list
+        keeps the publish count identical on every rank (no barrier desync).
+        """
+        from .common import named_params_and_buffers
+
+        bucket = DeltaBucket()
+        self._pipeline_pass(self._iter_non_expert_chunks(), bucket, pbar)
+        self._flush_and_publish(bucket, pbar)
+
+        expert_params = [(n, p) for n, p in named_params_and_buffers(self.args, self.model) if ".experts." in n]
+        n = len(expert_params)
+        for i in range(self._EXPERT_SUBPASSES):
+            lo = i * n // self._EXPERT_SUBPASSES
+            hi = (i + 1) * n // self._EXPERT_SUBPASSES
+            self._pipeline_pass(self._iter_expert_chunks(iter(expert_params[lo:hi])), bucket, pbar)
+            self._flush_and_publish(bucket, pbar)
+
+    _EXPERT_SUBPASSES = 4
+
+    def _flush_and_publish(self, bucket: DeltaBucket, pbar: tqdm | None) -> None:
+        """
+        End-of-sub-pass: drain the in-flight bucket, barrier all PP ranks, then
+        (disk-only) fire one publish RPC for everything since the last call.
+        """
+        if bucket.has_updates:
+            self._flush_bucket(bucket, pbar)
+        dist.barrier(group=get_gloo_group())
+        if self.transport == "disk":
+            self._publish_batch()
+
+    def _pipeline_pass(
+        self,
+        chunk_iter: Iterator[list[tuple[str, torch.Tensor]]],
+        bucket: DeltaBucket,
+        pbar: tqdm | None,
+    ) -> None:
+        """
+        1-step H2D snapshot prefetch lookahead: chunk N+1's snapshot transfer
+        overlaps chunk N's compute+encode on the default stream.
+        """
+        pending_chunk: list[tuple[str, torch.Tensor]] | None = None
+        pending_prefetch: tuple[list[torch.Tensor], torch.cuda.Event] | None = None
+        for hf_chunk in chunk_iter:
+            if not hf_chunk:
+                continue
+            next_prefetch = self.delta_state.prefetch_snapshot(hf_chunk)
+            if pending_prefetch is not None:
+                self._enqueue_chunk(pending_chunk, pending_prefetch, bucket, pbar)
+            pending_chunk, pending_prefetch = hf_chunk, next_prefetch
+        if pending_prefetch is not None:
+            self._enqueue_chunk(pending_chunk, pending_prefetch, bucket, pbar)
+
+    def _enqueue_chunk(
+        self,
+        hf_chunk: list[tuple[str, torch.Tensor]],
+        prefetched: tuple[list[torch.Tensor], torch.cuda.Event],
+        bucket: DeltaBucket,
+        pbar: tqdm | None,
+    ) -> None:
+        """
+        compute diffs → snapshot new prev → encode → bucket.add (flushing if full).
+        """
+        diffs = self.delta_state.compute_diffs(hf_chunk, prefetched=prefetched)
+        self.delta_state.update_snapshot_async(hf_chunk)
+        chunk = self._encode(diffs)
+        self.density_numel += sum(d.values.numel() for d in diffs)
+        self.density_nnz += chunk.nnz
+        self.wire_bytes += len(chunk.pos_bytes) + chunk.val_tensor.numel() * chunk.val_tensor.element_size()
+        if not chunk.params:
+            return
+        if bucket.should_flush_before_add(chunk, self.args.update_weight_buffer_size):
+            self._flush_bucket(bucket, pbar)
+        bucket.add(chunk)
+
+    def _flush_bucket(self, bucket: DeltaBucket, pbar: tqdm | None) -> None:
+        """
+        NCCL: broadcast (__positions__, __values__) with a DeltaSpec.
+        Disk: enqueue one safetensors file with the same payload + metadata.
+        Both paths embed a checksum the receiver verifies before apply.
+        """
+        if not bucket.has_updates:
+            return
+        positions_cpu = bucket.merged_positions_cpu()
+        values_gpu = bucket.merged_values()
+        params = list(bucket.params)
+        bucket.clear()
+
+        # GPU-resident checksum: positions go to the device the values already live on
+        # (NCCL needs the same move anyway; disk gets it for free at the reduction).
+        positions_gpu = positions_cpu.to(values_gpu.device, non_blocking=True)
+        checksum = _checksum(positions_gpu, values_gpu)
+
+        if self.transport == "nccl":
+            spec = DeltaSpec(encoding=self.encoding, params=params, checksum=checksum)
+            self._update_bucket_weights_from_distributed(
+                [("__positions__", positions_gpu), ("__values__", values_gpu)],
+                pbar=pbar,
+                load_format="delta",
+                delta=spec,
+            )
+        else:  # disk
+            tensors = {"__positions__": positions_cpu, "__values__": values_gpu.cpu()}
+            metadata = {
+                "encoding": self.encoding.value,
+                "params": json.dumps([asdict(p) for p in params]),
+                "current_version": str(self.weight_version),
+                "checksum": str(checksum),
+            }
+            filename = f"rank{dist.get_rank():04d}_flush{self._flush_idx:06d}.safetensors"
+            path = os.path.join(self._version_dir, filename)
+            self.writer.enqueue(path, tensors, metadata)
+            self._pending_files.append(filename)
+            if pbar is not None:
+                pbar.update(1)
+        self._flush_idx += 1
+
+    def _publish_batch(self) -> None:
+        """
+        Drain pending fsyncs, invoke the pre-push hook (may return a Future for an
+        async durability step on shared FS), then defer rank 0's
+        ``update_weights_from_disk`` RPC behind that Future via ``_rpc_executor``.
+        Each deferred dispatch lands in ``_pending_publishes`` as a
+        Future[list[ObjectRef]]; ``_finalize_sync`` awaits both layers. Safe to call
+        with empty ``_pending_files``: the all_gather still synchronizes and rank 0
+        skips the dispatch when no rank produced files.
+        """
+        self.writer.drain()
+        dist.barrier(group=get_gloo_group())
+
+        commit_future = None
+        if self._pre_push_hook is not None:
+            commit_future = self._pre_push_hook(self.args, self._version_dir, list(self.rollout_engines))
+        dist.barrier(group=get_gloo_group())
+
+        # Collect every rank's batch filenames at rank 0; payload is ~KB, gather is cheap.
+        all_files: list[list[str]] = [None] * dist.get_world_size()  # type: ignore[list-item]
+        dist.all_gather_object(all_files, list(self._pending_files), group=get_gloo_group())
+        flat = [f for sub in all_files for f in sub]
+        self._pending_files.clear()
+
+        if dist.get_rank() == 0 and flat:
+            version_dir = self._version_dir
+            engines = list(self.rollout_engines)
+            weight_version = str(self.weight_version)
+            self._published_any = True
+
+            def _fire_when_committed() -> list:
+                if commit_future is not None:
+                    commit_future.result()
+                return [
+                    engine.update_weights_from_disk.remote(
+                        model_path=version_dir,
+                        files=flat,
+                        load_format="delta",
+                        weight_version=weight_version,
+                    )
+                    for engine in engines
+                ]
+
+            self._pending_publishes.append(self._rpc_executor.submit(_fire_when_committed))
+
+    def _finalize_sync(self) -> None:
+        """
+        Per-transport end-of-sync. NCCL: each flush already broadcasted; just resume.
+        Disk: publish the trailing files, wait for all streamed applies to land, then
+        cleanup + resume.
+        """
+        if self.transport == "nccl":
+            if dist.get_rank() == 0:
+                ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
+            dist.barrier(group=get_gloo_group())
+            return
+
+        if self._pending_files:
+            self._publish_batch()
+        if dist.get_rank() == 0:
+            # Each entry is a Future returning a list of ObjectRefs. Awaiting the
+            # Futures unblocks the (commit-then-RPC) chain; ray.get waits for the
+            # receivers' apply to finish.
+            object_refs = [ref for fut in self._pending_publishes for ref in fut.result()]
+            ray.get(object_refs)
+            self._pending_publishes.clear()
+            if not self._published_any:
+                # No delta files needed publishing this sync (e.g. all-zero diff).
+                # Engines never saw the new version via update_weights_from_disk, so
+                # bump it explicitly to keep their recorded version in sync with ours.
+                weight_version = str(self.weight_version)
+                ray.get([engine.set_weight_version.remote(weight_version) for engine in self.rollout_engines])
+            if not self.args.update_weight_delta_keep_files:
+                shutil.rmtree(self._version_dir, ignore_errors=True)
+            ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
+        dist.barrier(group=get_gloo_group())
+
+    def _record_metrics(self) -> None:
+        """
+        Allreduce density/byte counters across PP-src ranks; stash on
+        ``update_weight_metrics`` for the actor to drain into the next step log.
+        Wall-clock timings come from the vime ``Timer`` (``delta_encode`` /
+        ``delta_finalize`` blocks above + the outer ``update_weights`` decorator).
+        """
+        pre_bytes = self.writer.bytes_pre_compress if self.writer is not None else 0
+        post_bytes = self.writer.bytes_post_compress if self.writer is not None else 0
+        counts = torch.tensor(
+            [self.density_nnz, self.density_numel, self.wire_bytes, pre_bytes, post_bytes],
+            dtype=torch.int64,
+            device=torch.cuda.current_device(),
+        )
+        dist.all_reduce(counts)
+        nnz, numel, wire_bytes, pre_bytes, post_bytes = counts.tolist()
+
+        density = nnz / max(numel, 1)
+        compression_ratio = (pre_bytes / post_bytes) if post_bytes > 0 else 1.0
+
+        m = self.update_weight_metrics
+        m["perf/update_weights_density"] = density
+        m["perf/update_weights_wire_bytes"] = wire_bytes
+        m["perf/update_weights_flushes_per_rank"] = float(self._flush_idx)
+        if self.transport == "disk":
+            m["perf/update_weights_disk_bytes_pre_compress"] = pre_bytes
+            m["perf/update_weights_disk_bytes_post_compress"] = post_bytes
+            m["perf/update_weights_compression_ratio"] = compression_ratio
+
+        if dist.get_rank() == 0:
+            t = Timer().log_dict()
+            logger.info(
+                "[delta sync v=%s] transport=%s enc=%s density=%.3f%% " "encode=%.2fs finalize=%.2fs flushes/rank=%d",
+                self.weight_version,
+                self.transport,
+                self.encoding.value,
+                100.0 * density,
+                t.get("delta_encode", 0.0),
+                t.get("delta_finalize", 0.0),
+                self._flush_idx,
+            )

--- a/vime/utils/arguments.py
+++ b/vime/utils/arguments.py
@@ -137,6 +137,67 @@ def get_vime_extra_args_provider(add_custom_arguments=None):
                 default="raw",
                 help="The method to convert megatron weights to hugging face weights for vLLM.",
             )
+            # Delta weight sync.
+            parser.add_argument(
+                "--update-weight-mode",
+                choices=["full", "delta"],
+                default="full",
+                help=(
+                    "Weight sync strategy. 'full' (default) broadcasts every parameter "
+                    "every sync. 'delta' detects byte-level changes against a pinned-CPU "
+                    "snapshot of the previous broadcast and ships only the changed positions + values."
+                ),
+            )
+            parser.add_argument(
+                "--update-weight-transport",
+                choices=["nccl", "disk"],
+                default="nccl",
+                help=(
+                    "Per-flush carrier for --update-weight-mode=delta. 'nccl' broadcasts each "
+                    "bucket; 'disk' writes each bucket as a safetensors file under "
+                    "--update-weight-delta-dir and pushes once at end-of-sync."
+                ),
+            )
+            parser.add_argument(
+                "--update-weight-encoding",
+                choices=["indices", "deltas", "deltas_zstd"],
+                default="indices",
+                help=(
+                    "Position encoding for partial flushes. 'indices': int32 absolute "
+                    "positions (largest, lowest compute). 'deltas': uint16 gap-deltas "
+                    "with uint32 fallback (smaller). 'deltas_zstd': 'deltas' with the "
+                    "safetensors blob wrapped in zstd L1 (smallest, heaviest compute — "
+                    "best for shared-FS bandwidth <= ~300 MB/s)."
+                ),
+            )
+            parser.add_argument(
+                "--update-weight-delta-dir",
+                type=str,
+                default=None,
+                help=(
+                    "Filesystem directory for per-sync delta safetensors. Writable by the "
+                    "trainer, readable by every rollout engine. Required when "
+                    "--update-weight-transport=disk. One subdirectory per sync "
+                    "(``weight_v{N:06d}``), removed after every engine has acknowledged."
+                ),
+            )
+            parser.add_argument(
+                "--update-weight-delta-keep-files",
+                action="store_true",
+                default=False,
+                help="Skip post-apply cleanup of per-sync version directories. Useful for debugging.",
+            )
+            parser.add_argument(
+                "--custom-delta-pre-push-path",
+                type=str,
+                default=None,
+                help=(
+                    "Path to a custom function called by --update-weight-transport=disk after each "
+                    "trainer rank's files are durably on local disk, before rank 0 fires the engine "
+                    "RPCs. Signature: ``def hook(args, version_dir: str, rollout_engines) -> None``. "
+                    "Called from every trainer rank; the hook gates itself."
+                ),
+            )
             parser.add_argument(
                 "--custom-model-provider-path",
                 type=str,
@@ -1649,6 +1710,14 @@ def vime_validate_args(args):
         # If OPD is not enabled, opd_teacher_load should not be set
         if args.opd_teacher_load is not None:
             raise ValueError("--opd-teacher-load is set but --use-opd is not enabled. Please add --use-opd flag.")
+
+    if args.update_weight_mode == "delta":
+        if args.colocate:
+            raise ValueError(
+                "--update-weight-mode=delta is not supported with --colocate. Colocate transfers "
+                "weights via CUDA IPC (only a handle crosses processes), so the delta bookkeeping "
+                "(snapshot + diff + sparse encode) is pure overhead."
+            )
 
     if args.megatron_to_hf_mode == "bridge":
         if (

--- a/vime/utils/arguments.py
+++ b/vime/utils/arguments.py
@@ -1718,6 +1718,11 @@ def vime_validate_args(args):
                 "weights via CUDA IPC (only a handle crosses processes), so the delta bookkeeping "
                 "(snapshot + diff + sparse encode) is pure overhead."
             )
+        if args.update_weight_transport == "disk" and not args.update_weight_delta_dir:
+            raise ValueError(
+                "--update-weight-transport=disk requires --update-weight-delta-dir to point at "
+                "a filesystem shared between the trainer and the rollout engines."
+            )
 
     if args.megatron_to_hf_mode == "bridge":
         if (

--- a/vime/utils/train_metric_utils.py
+++ b/vime/utils/train_metric_utils.py
@@ -11,7 +11,11 @@ logger = logging.getLogger(__name__)
 
 
 def log_perf_data_raw(
-    rollout_id: int, args: Namespace, is_primary_rank: bool, compute_total_fwd_flops: Callable
+    rollout_id: int,
+    args: Namespace,
+    is_primary_rank: bool,
+    compute_total_fwd_flops: Callable,
+    extra_metrics: dict | None = None,
 ) -> None:
     timer_instance = Timer()
     log_dict_raw = deepcopy(timer_instance.log_dict())
@@ -21,6 +25,8 @@ def log_perf_data_raw(
         return
 
     log_dict = {f"perf/{key}_time": val for key, val in log_dict_raw.items()}
+    if extra_metrics:
+        log_dict.update(extra_metrics)
 
     if ("perf/actor_train_time" in log_dict) and (compute_total_fwd_flops is not None):
         total_fwd_flops = compute_total_fwd_flops(seq_lens=timer_instance.seq_lens)

--- a/vime/utils/types.py
+++ b/vime/utils/types.py
@@ -53,6 +53,8 @@ class Sample:
     # metadata used during training, e.g., what loss to use for this sample.
     train_metadata: dict | None = None
 
+    rollout_id: int | None = None
+
     # Session ID for consistent hashing routing (used when router policy is consistent_hashing)
     session_id: str | None = None
 


### PR DESCRIPTION
## Summary

Port delta weight sync from slime #1806 (core) and #1991 (CI test + zero-delta version bump).

Bandwidth-optimized weight sync for non-colocate: trainer bytewise-diffs weights against a pinned-CPU snapshot, ships only changed positions+values via nccl broadcast or shared-FS safetensors. Three position encodings (indices/deltas/deltas_zstd). Receiver overwrites changed bytes losslessly.

### New files (5)
- `update_weight/delta_io.py`: DeltaEncoding/DeltaParam/DeltaSpec dataclasses
- `update_weight/update_weight_from_distributed_delta.py`: 870-line trainer encoder
- `tests/test_delta_weight_update.py`: 4-GPU e2e test (disk transport)
- `docs/{en,zh}/advanced/delta-weight-sync.md`
- `examples/delta_weight_sync/`: README + GLM4.7-355B script

### Modified files (5)
- `actor.py`: lazy import delta updater + pop_metrics() perf plumbing
- `data.py`, `train_metric_utils.py`: extra_metrics parameter
- `arguments.py`: 7 new CLI args + colocate validation
- `types.py`: add Sample.rollout_id field

### Fidelity
- Replaces closed PR #150 (was stacked on mega-A, now standalone from main)
- Slime file copied verbatim from slime@44d29ee with mechanical slime->vime rename
- DeltaEncoding/DeltaParam/DeltaSpec defined in delta_io.py (slime imports from sglang.srt)
- set_weight_version already on main (no vllm_engine change needed)

## Test plan
- [x] pre-commit passed
- [ ] CPU unit tests
- [ ] GPU e2e: test_delta_weight_update.py (4-GPU non-colocate)