### PR TITLE
fix(examples/tau-bench): use RunConfig.agent_strategy in TAU_CONFIGS (slime #2101)

### DIFF
--- a/examples/tau-bench/README.md
+++ b/examples/tau-bench/README.md
@@ -42,7 +42,7 @@ You need to configure your litellm API in generate_with_tau.py for user simulati
 
 TAU_CONFIGS = {
     "env": "retail",  # Select between ["retail", "airline"]
-    "agent": "tool-calling",  # Select between ["tool-calling", "act", "react", "few-shot"], only tool-calling implemented for now
+    "agent_strategy": "tool-calling",  # Select between ["tool-calling", "act", "react", "few-shot"], only tool-calling implemented for now
     "user_model": "gemini-2.0-flash-lite",  # Cheap Model for user simulator
     "user_model_provider": "gemini",
     "task_split": "train",  # Select between ["train", "test", "dev"] for retail, ["test"] for airline

--- a/examples/tau-bench/generate_with_tau.py
+++ b/examples/tau-bench/generate_with_tau.py
@@ -22,7 +22,7 @@ _inflight_sem: asyncio.Semaphore | None = None
 # Agent rollout uses vLLM; only user_model / user_model_provider affect the user simulator here.
 TAU_CONFIGS = {
     "env": "retail",  # Select between ["retail", "airline"]
-    "agent": "tool-calling",  # Select between ["tool-calling", "act", "react", "few-shot"]
+    "agent_strategy": "tool-calling",  # Select between ["tool-calling", "act", "react", "few-shot"]
     # Default: local vLLM user sim (no external API). For Gemini API user sim, switch to:
     # "user_model": "gemini-2.5-flash-lite", "user_model_provider": "gemini",
     "user_model": "openai/local-qwen3-4b",
@@ -69,7 +69,7 @@ def resolve_tau_config(args: Any) -> RunConfig:
 
     return RunConfig(
         env=tau_config.env,
-        agent=tau_config.agent,
+        agent_strategy=tau_config.agent_strategy,
         user_model=user_model,
         user_model_provider=user_model_provider,
         task_split=tau_config.task_split,


### PR DESCRIPTION
## Summary

- Fix `TAU_CONFIGS` in the tau-bench example to use `agent_strategy` instead of `agent`.
- Update the README snippet to match.

tau-bench's `RunConfig` defines `agent_strategy`, not `agent`. The previous key was silently ignored by Pydantic, so changing the agent type in `TAU_CONFIGS` had no effect (the default `tool-calling` was always used). `resolve_tau_config()` also accessed `tau_config.agent`, which raises `AttributeError` at rollout time.

Same fix as THUDM/slime#2101.

## Test plan

- [x] `RunConfig(**TAU_CONFIGS)` accepts the config without extra/ignored fields
- [x] Setting `agent_strategy` to a non-default value is reflected on the resulting `RunConfig` object
- [x] Smoke: tau-bench rollout no longer fails with `'RunConfig' object has no attribute 'agent'` (400-step GRPO run on 8×A100)
