### PR TITLE
docker: rename published image from inferactinc/public to vllm/vime

### DIFF
--- a/.buildkite/gpu_suites.py
+++ b/.buildkite/gpu_suites.py
@@ -23,7 +23,7 @@ import os
 import subprocess
 
 GPU_QUEUE = "mithril-h100-pool"
-CI_IMAGE = "inferactinc/public:vime-latest"
+CI_IMAGE = "vllm/vime:latest"
 HF_CACHE_HOST_PATH = "/mnt/hf-cache"
 HF_HOME = "/root/.cache/huggingface"
 NODE_INSTANCE_TYPE = "gpu-h100-sxm"

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,7 +1,7 @@
 # Docker release rule
 
 vime ships one image based on the official vllm image, published as
-`inferactinc/public:vime-latest`. Supports GB200/300 and H100/200.
+`vllm/vime:latest`. Supports GB200/300 and H100/200.
 
 Build locally:
 

--- a/docker/justfile
+++ b/docker/justfile
@@ -1,4 +1,4 @@
-# Release images publish to the company hub `inferactinc/public` as multi-arch
+# Release images publish to `vllm/vime` on DockerHub as multi-arch
 # manifests, exactly like upstream `vllm/vllm-openai:nightly`: ONE tag carries
 # both the linux/amd64 and linux/arm64 digests and `docker pull` auto-selects
 # the platform. No arch suffix is ever published as a tag.
@@ -8,11 +8,11 @@
 # then the two digests are fused into the final tag with `just manifest`.
 #
 # Tag scheme:
-#   inferactinc/public:vime-<version>        immutable, multi-arch
-#   inferactinc/public:vime-latest           rolling,   multi-arch
+#   vllm/vime:<version>        immutable, multi-arch
+#   vllm/vime:latest           rolling,   multi-arch
 # <version> comes from docker/version.txt.
 
-IMAGE := "inferactinc/public"
+IMAGE := "vllm/vime"
 BUILDER := "vime-builder"
 
 # ---- per-arch build, pushed BY DIGEST (run once on an amd64 host, once on an arm64 host) ----
@@ -45,7 +45,7 @@ manifest AMD_DIGEST ARM_DIGEST:
     cd ..
 
     VERSION="$(cat docker/version.txt | tr -d '\n')"
-    docker buildx imagetools create -t "{{IMAGE}}:vime-${VERSION}" -t "{{IMAGE}}:vime-latest" "{{IMAGE}}@{{AMD_DIGEST}}" "{{IMAGE}}@{{ARM_DIGEST}}"
+    docker buildx imagetools create -t "{{IMAGE}}:${VERSION}" -t "{{IMAGE}}:latest" "{{IMAGE}}@{{AMD_DIGEST}}" "{{IMAGE}}@{{ARM_DIGEST}}"
 
 # ---- single-arch test/debug image for the run-ci-image validation job ----
 # The e2e-test-image runner is x86, so this is amd64-only and
@@ -56,8 +56,8 @@ build-test:
     cd ..
 
     VERSION="$(cat docker/version.txt | tr -d '\n')"
-    docker build -f docker/Dockerfile . --build-arg HTTP_PROXY="$http_proxy" --build-arg HTTPS_PROXY="$https_proxy" --build-arg NO_PROXY="localhost,127.0.0.1" --build-arg INSTALL_FLASHQLA=1 -t "{{IMAGE}}:vime-test-${VERSION}"
-    docker push "{{IMAGE}}:vime-test-${VERSION}"
+    docker build -f docker/Dockerfile . --build-arg HTTP_PROXY="$http_proxy" --build-arg HTTPS_PROXY="$https_proxy" --build-arg NO_PROXY="localhost,127.0.0.1" --build-arg INSTALL_FLASHQLA=1 -t "{{IMAGE}}:test-${VERSION}"
+    docker push "{{IMAGE}}:test-${VERSION}"
 
-    docker tag "{{IMAGE}}:vime-test-${VERSION}" "{{IMAGE}}:vime-test-latest"
-    docker push "{{IMAGE}}:vime-test-latest"
+    docker tag "{{IMAGE}}:test-${VERSION}" "{{IMAGE}}:test-latest"
+    docker push "{{IMAGE}}:test-latest"

--- a/docs/en/developer_guide/ci.md
+++ b/docs/en/developer_guide/ci.md
@@ -6,7 +6,7 @@ vime uses GitHub Actions for CI. Tests are triggered by **PR labels** — adding
 
 The workflow is defined in `.github/workflows/pr-test.yml` (auto-generated from `pr-test.yml.j2`). Each CI job:
 
-1. Runs on a self-hosted GPU runner via `docker run`; most tests use `inferactinc/public:vime-latest`, while image validation uses `inferactinc/public:vime-test-latest`.
+1. Runs on a self-hosted GPU runner via `docker run`; most tests use `vllm/vime:latest`, while image validation uses `vllm/vime:test-latest`.
 2. Installs vime with `pip install -e . --no-deps`.
 3. Acquires the required GPUs via `tests/ci/gpu_lock_exec.py --count <num_gpus>`.
 4. Executes the test file: `python <test_path>.py` or `python tests/<test_file>.py`, depending on whether the test lives under `tests/` or a subdirectory such as `tests/plugin_contracts/`.
@@ -23,7 +23,7 @@ Add a label to your PR to trigger the corresponding test suite:
 | `run-ci-megatron` | `e2e-test-megatron` | Core Megatron training tests covering dense, MoE, PPO, MTP, etc. |
 | `run-ci-precision` | `e2e-test-precision` | Numerical precision validation (parallel check). |
 | `run-ci-ckpt` | `e2e-test-ckpt` | Checkpoint save/load correctness (sync and async-save). |
-| `run-ci-image` | `e2e-test-image` | Full test suite run on `inferactinc/public:vime-test-latest` image (for image validation). |
+| `run-ci-image` | `e2e-test-image` | Full test suite run on `vllm/vime:test-latest` image (for image validation). |
 | `run-ci-changed` | `e2e-test-changed` | **Dynamically** detects new/modified test files in the PR and runs only those. |
 
 All labels also run when triggered via `workflow_dispatch` (manual run from the Actions tab).
@@ -44,7 +44,7 @@ This means you don't need to manually register your new test in the workflow —
 
 ### `run-ci-image` — Full Suite on Test Image
 
-This runs **all** registered tests on the `inferactinc/public:vime-test-latest` Docker image. Use this label to:
+This runs **all** registered tests on the `vllm/vime:test-latest` Docker image. Use this label to:
 
 - Validate a newly built Docker image before release.
 - Run the entire test suite for a comprehensive pre-merge check.

--- a/docs/en/examples/qwen3-4B.md
+++ b/docs/en/examples/qwen3-4B.md
@@ -2,7 +2,7 @@
 
 ## Environment Setup
 
-After pulling the `inferactinc/public:vime-latest` image, initialize the image environment as follows:
+After pulling the `vllm/vime:latest` image, initialize the image environment as follows:
 
 ```bash
 cd /root/

--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -26,12 +26,12 @@ Please execute the following commands to pull the latest image and start an inte
 
 ```shell
 # Pull the latest image
-docker pull inferactinc/public:vime-latest
+docker pull vllm/vime:latest
 
 # Start the container
 docker run --rm --gpus all --ipc=host --shm-size=16g \
   --ulimit memlock=-1 --ulimit stack=67108864 \
-  -it inferactinc/public:vime-latest /bin/bash
+  -it vllm/vime:latest /bin/bash
 ```
 
 ### Install vime

--- a/docs/zh/developer_guide/ci.md
+++ b/docs/zh/developer_guide/ci.md
@@ -6,7 +6,7 @@ vime 使用 GitHub Actions 进行 CI。测试通过 **PR label** 触发——给
 
 工作流定义在 `.github/workflows/pr-test.yml`（由 `pr-test.yml.j2` 自动生成）。每个 CI 任务会：
 
-1. 在自托管 GPU runner 上通过 `docker run` 运行；大多数测试使用 `inferactinc/public:vime-latest`，镜像验证使用 `inferactinc/public:vime-test-latest`。
+1. 在自托管 GPU runner 上通过 `docker run` 运行；大多数测试使用 `vllm/vime:latest`，镜像验证使用 `vllm/vime:test-latest`。
 2. 通过 `pip install -e . --no-deps` 安装 vime。
 3. 通过 `tests/ci/gpu_lock_exec.py --count <num_gpus>` 获取所需数量的 GPU。
 4. 执行测试文件：`python <test_path>.py` 或 `python tests/<test_file>.py`。如果测试位于 `tests/plugin_contracts/` 这样的子目录，CI 也会自动处理。
@@ -23,7 +23,7 @@ vime 使用 GitHub Actions 进行 CI。测试通过 **PR label** 触发——给
 | `run-ci-megatron` | `e2e-test-megatron` | 核心 Megatron 训练测试，覆盖 Dense、MoE、PPO、MTP 等。 |
 | `run-ci-precision` | `e2e-test-precision` | 数值精度校验（并行一致性检查）。 |
 | `run-ci-ckpt` | `e2e-test-ckpt` | Checkpoint 保存/加载正确性（同步和异步保存）。 |
-| `run-ci-image` | `e2e-test-image` | 在 `inferactinc/public:vime-test-latest` 镜像上运行**全部**测试（用于镜像验证）。 |
+| `run-ci-image` | `e2e-test-image` | 在 `vllm/vime:test-latest` 镜像上运行**全部**测试（用于镜像验证）。 |
 | `run-ci-changed` | `e2e-test-changed` | **动态**检测 PR 中新增或修改的测试文件，仅运行这些测试。 |
 
 所有 label 也可通过 `workflow_dispatch`（在 Actions 页面手动触发）来运行。
@@ -44,7 +44,7 @@ vime 使用 GitHub Actions 进行 CI。测试通过 **PR label** 触发——给
 
 ### `run-ci-image` — 在测试镜像上运行全部测试
 
-这会在 `inferactinc/public:vime-test-latest` Docker 镜像上运行**所有**已注册的测试。适用于：
+这会在 `vllm/vime:test-latest` Docker 镜像上运行**所有**已注册的测试。适用于：
 
 - 验证新构建的 Docker 镜像是否可用。
 - 在合并前做全面的测试检查。

--- a/docs/zh/examples/qwen3-4B.md
+++ b/docs/zh/examples/qwen3-4B.md
@@ -2,7 +2,7 @@
 
 ## 环境准备
 
-拉取 `inferactinc/public:vime-latest` 镜像后，用如下方式初始化镜像环境：
+拉取 `vllm/vime:latest` 镜像后，用如下方式初始化镜像环境：
 
 ```bash
 cd /root/

--- a/docs/zh/get_started/quick_start.md
+++ b/docs/zh/get_started/quick_start.md
@@ -25,12 +25,12 @@
 
 ```shell
 # 拉取最新镜像
-docker pull inferactinc/public:vime-latest
+docker pull vllm/vime:latest
 
 # 启动容器
 docker run --rm --gpus all --ipc=host --shm-size=16g \
   --ulimit memlock=-1 --ulimit stack=67108864 \
-  -it inferactinc/public:vime-latest /bin/bash
+  -it vllm/vime:latest /bin/bash
 ```
 
 ### 安装 vime


### PR DESCRIPTION
## Summary

- Replace all `inferactinc/public:vime-*` references with `vllm/vime:*` across CI, docs, and the release justfile
- Image is now published under the official vllm DockerHub namespace as a multi-arch manifest (amd64 + arm64)
- Tag scheme simplified: `vllm/vime:latest` (rolling), `vllm/vime:<version>` (immutable), `vllm/vime:test-latest` (CI validation image)

## Files changed

| File | Change |
|---|---|
| `.buildkite/gpu_suites.py` | `CI_IMAGE` → `vllm/vime:latest` |
| `docker/justfile` | `IMAGE := "vllm/vime"`, drop redundant `vime-` tag prefix |
| `docker/README.md` | update image name |
| `docs/en/` + `docs/zh/` (5 files) | update all image references |

## Registry

`vllm/vime:latest` is live on DockerHub as a multi-arch manifest:
- `linux/amd64` sha256:c5b402c7…
- `linux/arm64` sha256:48c13127…