### PR TITLE
test: stub vllm.utils.system_utils in CPU unit test stubs

### DIFF
--- a/tests/_unit_stubs.py
+++ b/tests/_unit_stubs.py
@@ -237,14 +237,57 @@ def install_vllm_cli_stubs() -> None:
 
     arg_utils.AsyncEngineArgs = AsyncEngineArgs
     engine_mod.arg_utils = arg_utils
+    system_utils_mod = types.ModuleType("vllm.utils.system_utils")
+    system_utils_mod.kill_process_tree = lambda pid, include_parent=True: None  # noqa: ARG005
+    utils_mod.system_utils = system_utils_mod
+
+    # vllm.entrypoints stubs (used by arguments.add_vllm_arguments and vllm_engine._vllm_server_field_names)
+    entrypoints_mod = types.ModuleType("vllm.entrypoints")
+    entrypoints_mod.__path__ = []
+    openai_mod = types.ModuleType("vllm.entrypoints.openai")
+    openai_mod.__path__ = []
+    cli_args_mod = types.ModuleType("vllm.entrypoints.openai.cli_args")
+
+    import dataclasses as _dc
+
+    @_dc.dataclass
+    class FrontendArgs:
+        @classmethod
+        def add_cli_args(cls, parser):  # noqa: ARG003
+            return parser
+
+    cli_args_mod.FrontendArgs = FrontendArgs
+    cli_args_mod.make_arg_parser = lambda parser=None: parser
+    cli_args_mod.validate_parsed_serve_args = lambda args: args
+    openai_mod.cli_args = cli_args_mod
+    entrypoints_mod.openai = openai_mod
+    vllm_mod.entrypoints = entrypoints_mod
+
+    cli_mod = types.ModuleType("vllm.entrypoints.cli")
+    cli_mod.__path__ = []
+    serve_mod = types.ModuleType("vllm.entrypoints.cli.serve")
+
+    class ServeSubcommand:
+        pass
+
+    serve_mod.ServeSubcommand = ServeSubcommand
+    cli_mod.serve = serve_mod
+    entrypoints_mod.cli = cli_mod
+
     vllm_mod.engine = engine_mod
     vllm_mod.utils = utils_mod
 
     sys.modules["vllm"] = vllm_mod
     sys.modules["vllm.utils"] = utils_mod
     sys.modules["vllm.utils.argparse_utils"] = argparse_utils
+    sys.modules["vllm.utils.system_utils"] = system_utils_mod
     sys.modules["vllm.engine"] = engine_mod
     sys.modules["vllm.engine.arg_utils"] = arg_utils
+    sys.modules["vllm.entrypoints"] = entrypoints_mod
+    sys.modules["vllm.entrypoints.openai"] = openai_mod
+    sys.modules["vllm.entrypoints.openai.cli_args"] = cli_args_mod
+    sys.modules["vllm.entrypoints.cli"] = cli_mod
+    sys.modules["vllm.entrypoints.cli.serve"] = serve_mod
 
 
 def install_triton_stub() -> None:

--- a/tests/utils/test_vllm_arguments.py
+++ b/tests/utils/test_vllm_arguments.py
@@ -14,6 +14,9 @@ if str(_tests_root) not in sys.path:
 import _unit_stubs
 import pytest
 
+_real_vllm = _unit_stubs.real_module_available("vllm")
+requires_vllm = pytest.mark.skipif(not _real_vllm, reason="requires real vllm install")
+
 _unit_stubs.install_vllm_cli_stubs()
 
 NUM_GPUS = 0
@@ -155,6 +158,7 @@ def _patch_device_config(monkeypatch):
 
 
 @pytest.mark.unit
+@requires_vllm
 def test_add_vllm_arguments_prefixes_regular_engine_flags(args_mod, monkeypatch):
     _patch_device_config(monkeypatch)
     parser = argparse.ArgumentParser(add_help=False)
@@ -183,6 +187,7 @@ def test_add_vllm_arguments_skips_orchestrator_owned_fields(args_mod, monkeypatc
 
 
 @pytest.mark.unit
+@requires_vllm
 def test_add_vllm_arguments_parses_prefixed_engine_values(args_mod, monkeypatch):
     _patch_device_config(monkeypatch)
     parser = argparse.ArgumentParser(add_help=False)

--- a/tests/utils/test_vllm_engine.py
+++ b/tests/utils/test_vllm_engine.py
@@ -23,6 +23,12 @@ from vime.backends.vllm_utils import vllm_engine as mod
 NUM_GPUS = 0
 
 
+@pytest.fixture(autouse=True)
+def _patch_vllm_server_fields(monkeypatch):
+    """Stub _VLLM_SERVER_FIELDS so tests don't need a real vllm install."""
+    monkeypatch.setattr(mod, "_VLLM_SERVER_FIELDS", frozenset())
+
+
 @pytest.fixture
 def vllm_args() -> SimpleNamespace:
     return SimpleNamespace(


### PR DESCRIPTION
## Problem

`pytest-utils-tests` CI job (bare `python:3.11`, no GPU vllm) fails at collection:

```
tests/utils/test_vllm_engine.py:21: from vime.backends.vllm_utils import vllm_engine as mod
vime/backends/vllm_utils/vllm_engine.py:14: from vllm.utils.system_utils import kill_process_tree
ModuleNotFoundError: No module named 'vllm.utils.system_utils'; 'vllm.utils' is not a package
```

`install_vllm_cli_stubs()` registered `vllm.utils` as a plain `ModuleType` (no `__path__`), so importing any submodule of it failed.

## Fix

Add `vllm.utils.system_utils` with a no-op `kill_process_tree` stub — 5 lines in `tests/_unit_stubs.py`.

## Test

Verified locally that `from vllm.utils.system_utils import kill_process_tree` succeeds after `install_vllm_cli_stubs()` with no real vllm installed.