### PR TITLE
[NPU] colocate training with TMS, bridge sync, and IPC weight loading

### DIFF
--- a/docker/npu_patch/vllm-ascend.patch
+++ b/docker/npu_patch/vllm-ascend.patch
@@ -37,3 +37,18 @@ index 63ee94c..4e81943 100644
          self.available_kv_cache_memory_bytes = (
              self.requested_memory - profile_result.non_kv_cache_memory - npugraph_memory_estimate_applied
          )
+diff --git a/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py b/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
+index 0000000..0000000 100644
+--- a/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
++++ b/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
+@@ -116,8 +116,8 @@ class NPUIPCWeightTransferEngine(WeightTransferEngine[NPUIPCWeightTransferInitIn
+     init_info_cls = NPUIPCWeightTransferInitInfo
+     update_info_cls = NPUIPCWeightTransferUpdateInfo
+ 
+-    def __init__(self, config: WeightTransferConfig, parallel_config: ParallelConfig) -> None:
+-        super().__init__(config, parallel_config)
++    def __init__(self, config: WeightTransferConfig, parallel_config: ParallelConfig, model: torch.nn.Module = None) -> None:
++        super().__init__(config, parallel_config, model)
+ 
+     def parse_update_info(self, update_dict: dict[str, Any]) -> NPUIPCWeightTransferUpdateInfo:
+         """Parse update dict, deserializing pickled IPC handles if present.

--- a/docker/npu_patch/vllm-ascend.patch
+++ b/docker/npu_patch/vllm-ascend.patch
@@ -2,58 +2,7 @@ diff --git a/vllm_ascend/worker/worker.py b/vllm_ascend/worker/worker.py
 index 63ee94c..4e81943 100644
 --- a/vllm_ascend/worker/worker.py
 +++ b/vllm_ascend/worker/worker.py
-@@ -332,10 +332,46 @@ class NPUWorker(WorkerBase):
-             else:
- 
-                 def load_weights_direct(weights: list[tuple[str, torch.Tensor]]) -> None:
--                    with torch.no_grad():
--                        for name, weight in weights:
--                            param = model.get_parameter(name)
--                            param.copy_(weight)
-+                    from vllm.model_executor.utils import get_packed_modules_mapping
-+
-+                    packed_map = get_packed_modules_mapping(model)
-+                    sub_to_packed = {}
-+                    for packed_name, sub_names in packed_map.items():
-+                        for idx, sub_name in enumerate(sub_names):
-+                            sub_to_packed[sub_name] = (packed_name, idx)
-+                    qkv_shard_ids = {"q_proj": "q", "k_proj": "k", "v_proj": "v"}
-+
-+                    def _remap_and_get_shard_id(hf_name: str) -> tuple[str, object | None]:
-+                        parts = hf_name.split(".")
-+                        shard_id = None
-+                        for i in range(len(parts)):
-+                            if parts[i] in sub_to_packed:
-+                                packed_name, idx = sub_to_packed[parts[i]]
-+                                shard_id = qkv_shard_ids.get(parts[i], idx)
-+                                parts[i] = packed_name
-+                                break
-+                        return ".".join(parts), shard_id
-+
-+                    for name, weight in weights:
-+                        remapped, shard_id = _remap_and_get_shard_id(name)
-+                        try:
-+                            param = model.get_parameter(remapped)
-+                        except AttributeError:
-+                            continue
-+                        weight_loader = getattr(param, "weight_loader", None)
-+                        if weight_loader is not None and shard_id is not None:
-+                            weight_loader(param, weight, loaded_shard_id=shard_id)
-+                        elif weight_loader is not None:
-+                            weight_loader(param, weight)
-+                        elif param.shape == weight.shape:
-+                            param.data.copy_(weight)
-+                        else:
-+                            tp_rank = self.rank % self.parallel_config.tensor_parallel_size
-+                            for dim in range(len(param.shape)):
-+                                if param.shape[dim] != weight.shape[dim]:
-+                                    shard_size = param.shape[dim]
-+                                    param.data.copy_(weight.narrow(dim, tp_rank * shard_size, shard_size))
-+                                    break
- 
-                 self.weight_transfer_engine.receive_weights(
-                     typed_update_info,
-@@ -404,7 +440,7 @@ class NPUWorker(WorkerBase):
+@@ -404,7 +404,7 @@ class NPUWorker(WorkerBase):
          # take current memory snapshot
          self.init_snapshot = MemorySnapshot()
          self.requested_memory = self.init_snapshot.total_memory * self.cache_config.gpu_memory_utilization
@@ -62,7 +11,7 @@ index 63ee94c..4e81943 100644
              GiB = lambda b: round(b / GiB_bytes, 2)
              raise ValueError(
                  f"Free memory on device "
-@@ -535,15 +571,16 @@ class NPUWorker(WorkerBase):
+@@ -535,15 +535,16 @@ class NPUWorker(WorkerBase):
          self.npugraph_memory_estimate = npugraph_memory_estimate
  
          free_gpu_memory = profile_result.after_profile.free_memory

--- a/docker/npu_patch/vllm.patch
+++ b/docker/npu_patch/vllm.patch
@@ -11,3 +11,16 @@ index cb61bcabd..5c076d521 100644
  
          # Cache the new tokens. Preempted requests should be skipped.
          if status_before_update == RequestStatus.RUNNING:
+diff --git a/vllm/model_executor/layers/rotary_embedding/common.py b/vllm/model_executor/layers/rotary_embedding/common.py
+index 0000000..0000000 100644
+--- a/vllm/model_executor/layers/rotary_embedding/common.py
++++ b/vllm/model_executor/layers/rotary_embedding/common.py
+@@ -135,7 +135,9 @@ class ApplyRotaryEmb(CustomOp):
+         self.enable_fp32_compute = enable_fp32_compute
+ 
+         self.apply_rotary_emb_flash_attn = None
+-        if not current_platform.is_cpu() and find_spec("flash_attn") is not None:
++        if not current_platform.is_cpu() and find_spec("flash_attn") is not None and not hasattr(current_platform, "is_npu"):
+             from flash_attn.ops.triton.rotary import apply_rotary
+ 
+             self.apply_rotary_emb_flash_attn = apply_rotary

--- a/vime/backends/megatron_utils/__init__.py
+++ b/vime/backends/megatron_utils/__init__.py
@@ -1,6 +1,12 @@
 import logging
 
 import torch
+
+try:
+    import torch_npu  # noqa: F401
+except ImportError:
+    pass
+
 from vime.utils.common import is_npu
 
 if is_npu():

--- a/vime/backends/megatron_utils/actor.py
+++ b/vime/backends/megatron_utils/actor.py
@@ -8,10 +8,25 @@ import numpy as np
 import ray
 import torch
 import torch.distributed as dist
+
 from vime.utils.common import is_npu
 
 if is_npu():
+    import importlib
+
+    importlib.import_module("vime.backends.megatron_utils.npu_attention_patch")
     from mindspeed.megatron_adaptor import repatch
+
+    _orig_npu_empty_cache = torch.npu.empty_cache
+
+    def _safe_empty_cache():
+        try:
+            _orig_npu_empty_cache()
+        except RuntimeError:
+            pass
+
+    torch.npu.empty_cache = _safe_empty_cache
+    torch.cuda.empty_cache = _safe_empty_cache
 from megatron.core import mpu
 from torch_memory_saver import torch_memory_saver
 from transformers import AutoConfig, AutoTokenizer

--- a/vime/backends/megatron_utils/actor.py
+++ b/vime/backends/megatron_utils/actor.py
@@ -84,9 +84,17 @@ class MegatronTrainRayActor(TrainRayActor):
                 logger.info(f"Set torch_memory_saver.memory_margin_bytes to {x}")
                 torch_memory_saver.memory_margin_bytes = x
 
+        tms_region_ctx = None
+        if args.offload_train and is_npu():
+            tms_region_ctx = torch_memory_saver.region(tag="training", enable_cpu_backup=True)
+            tms_region_ctx.__enter__()
+
         self.model, self.optimizer, self.opt_param_scheduler, loaded_rollout_id = initialize_model_and_optimizer(
             args, role
         )
+
+        if tms_region_ctx is not None:
+            tms_region_ctx.__exit__(None, None, None)
 
         vpp_size = mpu.get_virtual_pipeline_model_parallel_world_size() or 1
         if vpp_size > 1:
@@ -621,7 +629,7 @@ class MegatronTrainRayActor(TrainRayActor):
             if dist.get_rank() == 0:
                 ray.get(self.rollout_manager.clear_updatable_num_new_engines.remote())
 
-        with torch_memory_saver.disable() if self.args.offload_train else nullcontext():
+        with torch_memory_saver.disable() if (self.args.offload_train and not is_npu()) else nullcontext():
             print_memory("before update_weights")
             self.weight_updater.update_weights()
             print_memory("after update_weights")

--- a/vime/backends/megatron_utils/npu_attention_patch.py
+++ b/vime/backends/megatron_utils/npu_attention_patch.py
@@ -1,0 +1,82 @@
+import torch_npu
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.transformer.enums import AttnMaskType
+from torch import Tensor
+
+try:
+    from einops import rearrange
+except ImportError:
+    rearrange = None
+
+
+def npu_dot_product_attention_forward(
+    self,
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    attention_mask: Tensor,
+    attn_mask_type: AttnMaskType = None,
+    attention_bias: Tensor = None,
+    packed_seq_params: PackedSeqParams | None = None,
+):
+    assert attention_bias is None, "Attention bias is not supported for DotProductAttention."
+
+    if packed_seq_params is None:
+        n_head = query.shape[2]
+    else:
+        n_head = query.shape[1]
+
+    sparse_mode = getattr(self.config, "sparse_mode", 0)
+    if attn_mask_type == AttnMaskType.no_mask:
+        sparse_mode = 0
+
+    scale = self.softmax_scale
+
+    pre_tockens = getattr(self.config, "pre_tockens", 65536)
+    next_tockens = getattr(self.config, "next_tockens", 0)
+
+    if packed_seq_params is not None:
+        if isinstance(packed_seq_params.cu_seqlens_q, list):
+            actual_seq_qlen = packed_seq_params.cu_seqlens_q
+            actual_seq_kvlen = packed_seq_params.cu_seqlens_kv
+        else:
+            actual_seq_qlen = packed_seq_params.cu_seqlens_q.tolist()
+            actual_seq_kvlen = packed_seq_params.cu_seqlens_kv.tolist()
+        shape_order = "TND"
+    else:
+        actual_seq_qlen = None
+        actual_seq_kvlen = None
+        if rearrange is not None:
+            query, key, value = [rearrange(x, "s b h d -> s b (h d)") for x in [query, key, value]]
+        else:
+            query = query.reshape(query.shape[0], query.shape[1], -1)
+            key = key.reshape(key.shape[0], key.shape[1], -1)
+            value = value.reshape(value.shape[0], value.shape[1], -1)
+        shape_order = "SBH"
+
+    output = torch_npu.npu_fusion_attention(
+        query,
+        key,
+        value,
+        n_head,
+        shape_order,
+        pse=None,
+        padding_mask=None,
+        atten_mask=attention_mask,
+        scale=scale,
+        pre_tockens=pre_tockens,
+        next_tockens=next_tockens,
+        keep_prob=1 - self.attention_dropout.p,
+        inner_precise=0,
+        sparse_mode=sparse_mode,
+        actual_seq_qlen=actual_seq_qlen,
+        actual_seq_kvlen=actual_seq_kvlen,
+    )[0]
+
+    return output
+
+
+from megatron.core.transformer.dot_product_attention import DotProductAttention
+
+DotProductAttention.forward = npu_dot_product_attention_forward
+print("[NPU PATCH] DotProductAttention.forward replaced with npu_fusion_attention BEFORE mindspeed import", flush=True)

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -62,9 +62,9 @@ def _current_gpu_uuid() -> str:
     if is_npu():
         device_index = torch.npu.current_device()
         props = torch.npu.get_device_properties(device_index)
-    else:
-        device_index = torch.cuda.current_device()
-        props = torch.cuda.get_device_properties(device_index)
+        return str(getattr(props, "uuid", f"npu:{device_index}"))
+    device_index = torch.cuda.current_device()
+    props = torch.cuda.get_device_properties(device_index)
     return str(props.uuid)
 
 
@@ -634,7 +634,8 @@ class vLLMColocateWorkerExtension:
 
         if is_npu():
             device_index = torch.npu.current_device()
-            physical_gpu_id = str(torch.npu.get_device_properties(device_index).uuid)
+            props = torch.npu.get_device_properties(device_index)
+            physical_gpu_id = str(getattr(props, "uuid", f"npu:{device_index}"))
         else:
             device_index = torch.cuda.current_device()
             physical_gpu_id = str(torch.cuda.get_device_properties(device_index).uuid)

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -36,10 +36,84 @@ from .update_weight_from_distributed import (
 )
 
 
+def _patch_npu_colocate_worker() -> None:
+    """Skip layerwise_reload in NPUWorker weight-update hooks (colocate OOM fix)."""
+    try:
+        from vllm_ascend.worker.worker import NPUWorker
+    except ImportError:
+        return
+
+    if getattr(NPUWorker, "_vime_colocate_patched", False):
+        return
+
+    def _patched_start_weight_update(self, is_checkpoint_format: bool = True) -> None:
+        self._weight_update_active = True
+        self._is_checkpoint_format = is_checkpoint_format
+
+    def _patched_finish_weight_update(self) -> None:
+        self._weight_update_active = False
+
+    NPUWorker.start_weight_update = _patched_start_weight_update  # type: ignore[method-assign]
+    NPUWorker.finish_weight_update = _patched_finish_weight_update  # type: ignore[method-assign]
+    NPUWorker._vime_colocate_patched = True  # type: ignore[attr-defined]
+
+
 def _current_gpu_uuid() -> str:
-    device_index = torch.cuda.current_device()
-    props = torch.cuda.get_device_properties(device_index)
+    if is_npu():
+        device_index = torch.npu.current_device()
+        props = torch.npu.get_device_properties(device_index)
+    else:
+        device_index = torch.cuda.current_device()
+        props = torch.cuda.get_device_properties(device_index)
     return str(props.uuid)
+
+
+def _load_colocate_weights_direct(
+    model: torch.nn.Module,
+    weights: list[tuple[str, torch.Tensor]],
+    *,
+    tp_rank: int,
+) -> None:
+    """Load HF-named weights into vLLM packed params (qkv_proj, gate_up_proj, etc.)."""
+    from vllm.model_executor.utils import get_packed_modules_mapping
+
+    packed_map = get_packed_modules_mapping(model)
+    sub_to_packed = {}
+    for packed_name, sub_names in packed_map.items():
+        for idx, sub_name in enumerate(sub_names):
+            sub_to_packed[sub_name] = (packed_name, idx)
+    qkv_shard_ids = {"q_proj": "q", "k_proj": "k", "v_proj": "v"}
+
+    def _remap_and_get_shard_id(hf_name: str) -> tuple[str, object | None]:
+        parts = hf_name.split(".")
+        shard_id = None
+        for i in range(len(parts)):
+            if parts[i] in sub_to_packed:
+                packed_name, idx = sub_to_packed[parts[i]]
+                shard_id = qkv_shard_ids.get(parts[i], idx)
+                parts[i] = packed_name
+                break
+        return ".".join(parts), shard_id
+
+    for name, weight in weights:
+        remapped, shard_id = _remap_and_get_shard_id(name)
+        try:
+            param = model.get_parameter(remapped)
+        except AttributeError:
+            continue
+        weight_loader = getattr(param, "weight_loader", None)
+        if weight_loader is not None and shard_id is not None:
+            weight_loader(param, weight, loaded_shard_id=shard_id)
+        elif weight_loader is not None:
+            weight_loader(param, weight)
+        elif param.shape == weight.shape:
+            param.data.copy_(weight)
+        else:
+            for dim in range(len(param.shape)):
+                if param.shape[dim] != weight.shape[dim]:
+                    shard_size = param.shape[dim]
+                    param.data.copy_(weight.narrow(dim, tp_rank * shard_size, shard_size))
+                    break
 
 
 def _build_ipc_update_info_from_named_tensors(
@@ -283,8 +357,10 @@ class UpdateWeightFromTensor:
         dist.barrier(group=get_gloo_group())
 
         # vLLM #39212: enter weight-update mode on each slot leader.
+        # NPU colocate: direct param loading avoids layerwise_reload + checkpoint remap issues.
+        is_checkpoint_format = not is_npu()
         if self._ipc_engine is not None and rank == self._ipc_gather_src:
-            ray.get(self._ipc_engine.start_weight_update.remote(is_checkpoint_format=True))
+            ray.get(self._ipc_engine.start_weight_update.remote(is_checkpoint_format=is_checkpoint_format))
         dist.barrier(group=get_gloo_group())
 
         megatron_local_weights = self.weights_getter()
@@ -296,12 +372,18 @@ class UpdateWeightFromTensor:
             # then release CUDA IPC cache entries whose consumers (vLLM engines)
             # have already closed their IPC handles.
             del long_lived_tensors, hf_named_tensors
-            torch.cuda.ipc_collect()
+            if is_npu():
+                torch.npu.synchronize()
+            else:
+                torch.cuda.ipc_collect()
 
         dist.barrier(group=get_gloo_group())
         # After the barrier all engines have returned, so every rank's last-chunk
         # IPC handles are now released by the consumers.  Clean them up.
-        torch.cuda.ipc_collect()
+        if is_npu():
+            torch.npu.synchronize()
+        else:
+            torch.cuda.ipc_collect()
 
         # vLLM #39212: exit weight-update mode.
         if self._ipc_engine is not None and rank == self._ipc_gather_src:
@@ -503,7 +585,10 @@ class vLLMColocateWorkerExtension:
     """vLLM ``--worker-extension-cls`` entry for colocated IPC weight sync."""
 
     def __new__(cls, **kwargs):
-        _VLLMHijack.hijack()
+        if is_npu():
+            _patch_npu_colocate_worker()
+        else:
+            _VLLMHijack.hijack()
         return super().__new__(cls)
 
     # ── Three-phase weight update protocol ────────────────────────────────────
@@ -547,8 +632,12 @@ class vLLMColocateWorkerExtension:
         shapes: list[list[int]] = inner["shapes"]
         ipc_handles: list[dict] = inner["ipc_handles"]
 
-        device_index = torch.cuda.current_device()
-        physical_gpu_id = str(torch.cuda.get_device_properties(device_index).uuid)
+        if is_npu():
+            device_index = torch.npu.current_device()
+            physical_gpu_id = str(torch.npu.get_device_properties(device_index).uuid)
+        else:
+            device_index = torch.cuda.current_device()
+            physical_gpu_id = str(torch.cuda.get_device_properties(device_index).uuid)
 
         # Reconstruct weights from per-tensor IPC handles (one handle per
         # parameter — the vLLM IPCWeightTransferEngine.trainer_send_weights
@@ -576,9 +665,11 @@ class vLLMColocateWorkerExtension:
             if self._is_checkpoint_format:
                 model.load_weights(weights=iter(weights))
             else:
-                for name, weight in weights:
-                    param = model.get_parameter(name)
-                    param.copy_(weight)
+                _load_colocate_weights_direct(
+                    model,
+                    weights,
+                    tp_rank=self.rank % self.parallel_config.tensor_parallel_size,
+                )
 
         # Ensure the receiver has finished consuming the IPC tensors before
         # the sender drops its reference on the next barrier.

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -366,7 +366,7 @@ def build_vllm_subprocess_env(server_args: dict[str, Any]) -> dict[str, str]:
         if cann_python_path is not None:
             prepend_pythonpath(env, cann_python_path)
         if getattr(args, "colocate", False):
-            env.pop("PYTORCH_NPU_ALLOC_CONF", None)
+            env["PYTORCH_NPU_ALLOC_CONF"] = "expandable_segments:False"
     else:
         env["CUDA_VISIBLE_DEVICES"] = server_args["visible_devices"]
     env.setdefault("VLLM_SERVER_DEV_MODE", "1")

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -24,7 +24,7 @@ import requests
 
 from vime.backends.vllm_utils.arguments import SKIPPED_DESTS, get_vllm_cli_action_table
 from vime.ray.ray_actor import RayActor
-from vime.utils.common import is_npu
+from vime.utils.common import get_cann_python_site_packages, is_npu, prepend_pythonpath
 from vime.utils.http_utils import get_host_info
 
 logger = logging.getLogger(__name__)
@@ -361,6 +361,12 @@ def build_vllm_subprocess_env(server_args: dict[str, Any]) -> dict[str, str]:
     env.setdefault("NCCL_CUMEM_ENABLE", "0")
     if is_npu():
         env["ASCEND_RT_VISIBLE_DEVICES"] = server_args["visible_devices"]
+        env["VLLM_USE_AOT_COMPILE"] = "0"
+        cann_python_path = get_cann_python_site_packages()
+        if cann_python_path is not None:
+            prepend_pythonpath(env, cann_python_path)
+        if getattr(args, "colocate", False):
+            env.pop("PYTORCH_NPU_ALLOC_CONF", None)
     else:
         env["CUDA_VISIBLE_DEVICES"] = server_args["visible_devices"]
     env.setdefault("VLLM_SERVER_DEV_MODE", "1")

--- a/vime/ray/actor_group.py
+++ b/vime/ray/actor_group.py
@@ -63,34 +63,34 @@ class RayTrainGroup:
         if self.args.offload_train and self.args.train_backend == "megatron":
             import torch_memory_saver
 
-            for path in [
-                "torch_memory_saver_hook_mode_preload_cu12.abi3.so",
-                "torch_memory_saver_hook_mode_preload.abi3.so",
-            ]:
-                dynlib_path = os.path.join(
-                    os.path.dirname(os.path.dirname(torch_memory_saver.__file__)),
-                    path,
-                )
-                if os.path.exists(dynlib_path):
-                    break
-            else:
-                raise FileNotFoundError(
-                    "Cannot find torch_memory_saver dynamic library. Please make sure torch_memory_saver is properly installed."
-                )
-
-            env_vars["LD_PRELOAD"] = dynlib_path
-            env_vars["TMS_INIT_ENABLE"] = "1"
-            env_vars["TMS_INIT_ENABLE_CPU_BACKUP"] = "1"
-
             if is_npu():
                 env_vars["TMS_HOOK_MODE"] = "torch"
                 env_vars["TMS_REGION_TAG"] = "training"
                 env_vars["TMS_ENABLE_CPU_BACKUP"] = "1"
                 if self.args.colocate:
-                    env_vars.pop("PYTORCH_NPU_ALLOC_CONF", None)
+                    env_vars["PYTORCH_NPU_ALLOC_CONF"] = "expandable_segments:False"
                 cann_python_path = get_cann_python_site_packages()
                 if cann_python_path is not None:
                     prepend_pythonpath(env_vars, cann_python_path)
+            else:
+                for path in [
+                    "torch_memory_saver_hook_mode_preload_cu12.abi3.so",
+                    "torch_memory_saver_hook_mode_preload.abi3.so",
+                ]:
+                    dynlib_path = os.path.join(
+                        os.path.dirname(os.path.dirname(torch_memory_saver.__file__)),
+                        path,
+                    )
+                    if os.path.exists(dynlib_path):
+                        break
+                else:
+                    raise FileNotFoundError(
+                        "Cannot find torch_memory_saver dynamic library. Please make sure torch_memory_saver is properly installed."
+                    )
+
+                env_vars["LD_PRELOAD"] = dynlib_path
+                env_vars["TMS_INIT_ENABLE"] = "1"
+                env_vars["TMS_INIT_ENABLE_CPU_BACKUP"] = "1"
 
         # We cannot do routing replay for critic.
         if self.args.use_routing_replay and self.role == "actor":

--- a/vime/ray/actor_group.py
+++ b/vime/ray/actor_group.py
@@ -5,7 +5,7 @@ from ray.util.placement_group import PlacementGroup
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from vime.ray.utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST
-from vime.utils.common import is_npu
+from vime.utils.common import get_cann_python_site_packages, is_npu, prepend_pythonpath
 
 
 class RayTrainGroup:
@@ -81,6 +81,16 @@ class RayTrainGroup:
             env_vars["LD_PRELOAD"] = dynlib_path
             env_vars["TMS_INIT_ENABLE"] = "1"
             env_vars["TMS_INIT_ENABLE_CPU_BACKUP"] = "1"
+
+            if is_npu():
+                env_vars["TMS_HOOK_MODE"] = "torch"
+                env_vars["TMS_REGION_TAG"] = "training"
+                env_vars["TMS_ENABLE_CPU_BACKUP"] = "1"
+                if self.args.colocate:
+                    env_vars.pop("PYTORCH_NPU_ALLOC_CONF", None)
+                cann_python_path = get_cann_python_site_packages()
+                if cann_python_path is not None:
+                    prepend_pythonpath(env_vars, cann_python_path)
 
         # We cannot do routing replay for critic.
         if self.args.use_routing_replay and self.role == "actor":

--- a/vime/ray/placement_group.py
+++ b/vime/ray/placement_group.py
@@ -18,10 +18,26 @@ logger = logging.getLogger(__name__)
 @ray.remote
 class InfoActor:
     def get_ip_and_gpu_id(self):
-        if is_npu():
-            return ray.util.get_node_ip_address(), ray.get_runtime_context().get_accelerator_ids()["NPU"][0]
-        else:
-            return ray.util.get_node_ip_address(), ray.get_gpu_ids()[0]
+        try:
+            import torch_npu  # noqa: F401
+
+            has_npu = True
+        except ImportError:
+            has_npu = False
+
+        if has_npu or is_npu():
+            npu_ids = ray.get_runtime_context().get_accelerator_ids().get("NPU", [])
+            if npu_ids:
+                return ray.util.get_node_ip_address(), npu_ids[0]
+
+        gpu_ids = ray.get_gpu_ids()
+        if gpu_ids:
+            return ray.util.get_node_ip_address(), gpu_ids[0]
+
+        raise RuntimeError(
+            "No GPU/NPU IDs found. "
+            f"Accelerator IDs: {ray.get_runtime_context().get_accelerator_ids()}, GPU IDs: {gpu_ids}"
+        )
 
 
 def sort_key(x):

--- a/vime/ray/rollout.py
+++ b/vime/ray/rollout.py
@@ -21,7 +21,7 @@ GPU_MEMORY_TYPE_WEIGHTS = "weights"
 GPU_MEMORY_TYPE_CUDA_GRAPH = "cuda_graph"
 from vime.rollout.base_types import call_rollout_fn
 from vime.utils import logging_utils
-from vime.utils.common import is_npu
+from vime.utils.common import get_cann_python_site_packages, is_npu, prepend_pythonpath
 from vime.utils.dp_schedule import build_dp_schedule
 from vime.utils.health_monitor import RolloutHealthMonitor
 from vime.utils.http_utils import _wrap_ipv6, find_available_port, get_host_info, init_http_client
@@ -126,6 +126,13 @@ class ServerGroup:
             )
 
             env_vars = {name: "1" for name in NOSET_VISIBLE_DEVICES_ENV_VARS_LIST}
+            if is_npu():
+                cann_python_path = get_cann_python_site_packages()
+                if cann_python_path is not None:
+                    prepend_pythonpath(env_vars, cann_python_path)
+                if self.args.colocate:
+                    env_vars["PYTORCH_NPU_ALLOC_CONF"] = ""
+                env_vars["VLLM_USE_AOT_COMPILE"] = "0"
             rollout_engine = RolloutRayActor.options(
                 num_cpus=num_cpus,
                 scheduling_strategy=scheduling_strategy,

--- a/vime/ray/rollout.py
+++ b/vime/ray/rollout.py
@@ -131,7 +131,7 @@ class ServerGroup:
                 if cann_python_path is not None:
                     prepend_pythonpath(env_vars, cann_python_path)
                 if self.args.colocate:
-                    env_vars["PYTORCH_NPU_ALLOC_CONF"] = ""
+                    env_vars["PYTORCH_NPU_ALLOC_CONF"] = "expandable_segments:False"
                 env_vars["VLLM_USE_AOT_COMPILE"] = "0"
             rollout_engine = RolloutRayActor.options(
                 num_cpus=num_cpus,

--- a/vime/utils/common.py
+++ b/vime/utils/common.py
@@ -1,4 +1,35 @@
+import os
+
 import torch
+
+
+def get_cann_python_site_packages() -> str | None:
+    """Return CANN Python site-packages if ``acl`` is importable from there."""
+    candidates: list[str] = []
+    for env_key in ("ASCEND_TOOLKIT_HOME", "ASCEND_HOME_PATH"):
+        base = os.environ.get(env_key)
+        if not base:
+            continue
+        candidates.extend(
+            [
+                os.path.join(base, "python", "site-packages"),
+                os.path.normpath(os.path.join(base, "..", "python", "site-packages")),
+            ]
+        )
+    candidates.append("/usr/local/Ascend/ascend-toolkit/latest/python/site-packages")
+
+    for path in candidates:
+        if os.path.isdir(os.path.join(path, "acl")):
+            return path
+    return None
+
+
+def prepend_pythonpath(env: dict[str, str], *paths: str) -> None:
+    existing = env.get("PYTHONPATH", os.environ.get("PYTHONPATH", ""))
+    existing_parts = {part for part in existing.split(os.pathsep) if part}
+    prefix_parts = [path for path in paths if path and path not in existing_parts]
+    if prefix_parts:
+        env["PYTHONPATH"] = os.pathsep.join([*prefix_parts, existing] if existing else prefix_parts)
 
 
 def is_npu() -> bool:

--- a/vime/utils/memory_utils.py
+++ b/vime/utils/memory_utils.py
@@ -17,10 +17,16 @@ def clear_memory(clear_host_memory: bool = False):
     gc.collect()
     torch.cuda.empty_cache()
     if is_npu():
-        torch.npu.empty_cache()
+        try:
+            torch.npu.empty_cache()
+        except RuntimeError:
+            pass
     if clear_host_memory:
         if is_npu():
-            torch.npu.empty_cache()
+            try:
+                torch.npu.empty_cache()
+            except RuntimeError:
+                pass
         else:
             torch._C._host_emptyCache()
 

--- a/vime/utils/memory_utils.py
+++ b/vime/utils/memory_utils.py
@@ -15,7 +15,8 @@ def clear_memory(clear_host_memory: bool = False):
     else:
         torch.cuda.synchronize()
     gc.collect()
-    torch.cuda.empty_cache()
+    if not is_npu():
+        torch.cuda.empty_cache()
     if is_npu():
         try:
             torch.npu.empty_cache()


### PR DESCRIPTION
## Summary

- NPU colocate end-to-end: TMS torch mode with NPU/GPU env split, explicit `PYTORCH_NPU_ALLOC_CONF=expandable_segments:False`, CANN `PYTHONPATH`, safe `empty_cache`, and IPC weight sync via `UpdateWeightFromTensor` + bridge mode.
- Docker patches: vllm-ascend colocate init, vllm flash_attn NPU guard, vllm-ascend `NPUIPCWeightTransferEngine` API for vLLM 0.22.
- Trim `vllm-ascend.patch` worker changes to colocate only; remap HF packed modules (QKV, gate_up) in vime IPC path.

## Motivation

New NPU images set `PYTORCH_NPU_ALLOC_CONF=expandable_segments:True` in Dockerfile, which breaks TMS/CaMem colocate. Validated on 8×910B (Qwen3-4B, TP=2, bridge mode, smoke + long run). Code must explicitly override alloc conf; `pop`/`""` is insufficient.

## Key changes

| Area | What |
|------|------|
| `actor_group.py` | NPU: TMS torch only (no `LD_PRELOAD`/`TMS_INIT_ENABLE`); colocate alloc conf override |
| `rollout.py`, `vllm_engine.py` | Colocate `expandable_segments:False` for Ray workers and vLLM subprocess |
| `memory_utils.py`, `actor.py` | Skip/patch `empty_cache` under TMS custom allocator |
| `update_weight_from_tensor.py` | NPU colocate IPC direct param writes |
| `vllm.patch` | Skip flash_attn import on NPU |
| `vllm-ascend.patch` | Colocate init + `npu_ipc_engine` `model` arg |

## TMS .so note

`Dockerfile.npu` builds `torch_memory_saver` from `sgl-kernel-npu@2026.6.0`. The stock wheel `.so` may still be incompatible with NPU TMS torch mode until upstream fixes `TMS_INIT_ENABLE` handling. Validated runs used known-good `.so` MD5 (`03adebff…` / `83181484…`). Track upstream or pin binaries if needed.

## Test plan

- [x] `pre-commit run` on changed files
- [x] Smoke colocate on `vime_pr285_test` (8×910B, num-rollout=1)
- [ ] Rebuild image from `docker/Dockerfile.npu` and verify colocate without manual `.so` swap
- [ ] 100+ step diff vs pr266 baseline
