### PR TITLE
[Example] Add MemAgent long-context RL example (mem_agent)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ These examples provide concrete examples to leverage vime in your own RL workflo
 - **[geo3k_vlm](./geo3k_vlm)**: Training VLMs on a single-turn reasoning task using GRPO on the GEO3K dataset.
 - **[geo3k_vlm_multi_turn](./geo3k_vlm_multi_turn)**: VLM multi-turn training on Geo3k dataset.
 - **[low_precision](./low_precision)**: Examples of FP8 training and inference for improved throughput and stability.
+- **[mem_agent](./mem_agent)**: MemAgent long-context RL — chunk-wise memory update, HotpotQA GRPO training, and RULER-HQA evaluation.
 - **[multi_agent](./multi_agent)**: Example of running multi-agent RL with `vime`.
 - **[tau-bench](./tau-bench)**: Multi-turn tool-use agent training in tau-bench environments.
 - **[train_infer_mismatch_helper](./train_infer_mismatch_helper)**: Algorithmic methods for rollout correction (e.g., TIS, MIS).

--- a/examples/mem_agent/README.md
+++ b/examples/mem_agent/README.md
@@ -1,0 +1,113 @@
+# MemAgent on vime
+
+[MemAgent](https://arxiv.org/abs/2507.02259) (*Reshaping Long-Context LLM with Multi-Conv RL-based Memory Agent*) is an **RL-based memory agent** workflow for very long documents. It splits a document into chunks, reads them sequentially, and compresses key information into a **fixed-size memory** (overwrite policy). After all chunks are processed, the model answers using only the problem statement and the memory, with the final answer in `\boxed{}`. Because memory size stays constant, inference scales **linearly** \(O(N)\) with document length—without changing model architecture or positional encodings.
+
+The paper trains end-to-end with **Multi-Conv DAPO** (this example uses **GRPO**) on multi-turn, context-independent trajectories with verifiable rewards on HotpotQA and RULER. Qwen2.5-7B trained on 32K documents generalizes to million-token QA with near-lossless performance on RULER-HQA.
+
+This example reproduces that pipeline on vime: HotpotQA multi-turn rollout, GRPO training, and RULER-HQA evaluation, with vLLM as the inference backend.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `rollout.py` | Multi-turn MemAgent rollout + HotpotQA reward |
+| `rollout_client.py` | vLLM router client for multi-turn turns |
+| `custom_convert.py` | Unroll trajectories for GRPO training |
+| `prepare_data.py` | HotpotQA parquet/HF → JSONL |
+| `eval_ruler_hqa.py` | RULER-HQA evaluation script |
+
+## Launch scripts
+
+Run from **vime repo root** (`cd vime`):
+
+| Script | Purpose |
+|--------|---------|
+| `run-qwen3-4b-train.sh` | GRPO training (default 100 steps) |
+| `run-eval.sh` | RULER-HQA eval (vLLM serve + `eval_ruler_hqa.py`) |
+| `convert-to-hf.sh` | Megatron `iter_*` → HuggingFace |
+| `prepare-eval-data.sh` | Check/download `eval_{length}.json` |
+
+Shared setup lives in `_common.sh` (paths, MemAgent env vars, Ray launch).
+
+### Quick start
+
+#### Data download
+
+Training and evaluation data come from the MemAgent HuggingFace dataset **[BytedTsinghua-SIA/hotpotqa](https://huggingface.co/datasets/BytedTsinghua-SIA/hotpotqa)**.
+
+**Training set** — download the `train` split and convert to vime JSONL:
+
+```bash
+pip install datasets huggingface_hub pandas pyarrow
+
+# Optional: use a mirror if huggingface.co is slow
+export HF_ENDPOINT=https://hf-mirror.com
+
+mkdir -p /data/datasets/hotpotqa_slime
+
+python examples/mem_agent/prepare_data.py \
+  --hf-dataset BytedTsinghua-SIA/hotpotqa \
+  --hf-split train \
+  --output /data/datasets/hotpotqa_slime/train.jsonl
+```
+
+If you already have a local `hotpotqa_train.parquet`, pass `--input` instead of `--hf-dataset`.
+
+**Eval set (RULER-HQA)** — `eval_{50,100,200,...}.json` files under `DATA_ROOT` (default `/data/datasets/hotpotqa_hf`):
+
+```bash
+mkdir -p /data/datasets/hotpotqa_hf
+
+# Download all default lengths (50 … 6400)
+bash examples/mem_agent/prepare-eval-data.sh --download
+
+# Or only the lengths you need
+LENGTHS="50 200 800" bash examples/mem_agent/prepare-eval-data.sh --download
+```
+
+To check which files are present without downloading:
+
+```bash
+LENGTHS="50 200 800" bash examples/mem_agent/prepare-eval-data.sh
+```
+
+#### Run pipeline
+
+```bash
+cd vime
+
+# 1. Training (100 steps by default; set TRAIN_DATA if you used a different path)
+bash examples/mem_agent/run-qwen3-4b-train.sh
+
+# 2. Eval (after convert to HF)
+CONVERT=1 SINGLE_ITER=iter_0000099 bash examples/mem_agent/run-eval.sh
+
+# Baseline (untrained Qwen3-4B)
+MODEL_PATH=/data/models/Qwen3-4B SAVE_FILE=Qwen3-4B-base bash examples/mem_agent/run-eval.sh
+```
+
+### Environment variables
+
+Paths (override for your cluster):
+
+- `HF_CKPT`, `TORCH_DIST`, `TRAIN_DATA`, `SAVE_PATH`, `DATA_ROOT`
+
+Training:
+
+- `NUM_ROLLOUT`, `MEM_CHUNK_TOKENS`, `MEM_MAX_MEMORY`, `MEM_MAX_FINAL`, `MEM_MAX_CHUNKS`
+
+Eval:
+
+- `MODEL_PATH`, `LENGTH` (e.g. `"50 200 800"`), `CONVERT`, `SINGLE_ITER`, `SAVE_FILE`
+
+### Example paths
+
+```bash
+export HF_CKPT=/data/models/Qwen3-4B
+export TORCH_DIST=/data/models/Qwen3-4B_torch_dist
+export TRAIN_DATA=/data/datasets/hotpotqa_slime/train.jsonl
+export SAVE_PATH=/data/models/MemAgent_Qwen3-4B-RL
+export DATA_ROOT=/data/datasets/hotpotqa_hf
+
+bash examples/mem_agent/run-qwen3-4b-train.sh
+```

--- a/examples/mem_agent/_common.sh
+++ b/examples/mem_agent/_common.sh
@@ -154,7 +154,7 @@ mem_agent_launch_train() {
   if [[ "${RUN_TRAIN_DIRECT:-0}" == "1" && -n "${RUN_TRAIN_DIRECT_PY:-}" && -f "${RUN_TRAIN_DIRECT_PY}" ]]; then
     export VIME_ROOT NCCL_NVLS_ENABLE MEM_CHUNK_TOKENS MEM_MAX_MEMORY MEM_MAX_FINAL MEM_MAX_CHUNKS
     python3 "${RUN_TRAIN_DIRECT_PY}" \
-      ${MODEL_ARGS[@]} \
+      "${MODEL_ARGS[@]}" \
       "${CKPT_ARGS[@]}" \
       "${ROLLOUT_ARGS[@]}" \
       "${OPTIMIZER_ARGS[@]}" \
@@ -192,7 +192,7 @@ mem_agent_launch_train() {
     --runtime-env-json="${runtime_env}" \
     -- python3 train.py \
       --train-backend megatron \
-      ${MODEL_ARGS[@]} \
+      "${MODEL_ARGS[@]}" \
       "${CKPT_ARGS[@]}" \
       "${ROLLOUT_ARGS[@]}" \
       "${OPTIMIZER_ARGS[@]}" \

--- a/examples/mem_agent/_common.sh
+++ b/examples/mem_agent/_common.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Shared setup for MemAgent example scripts (sourced, not executed directly).
+set -euo pipefail
+
+MEM_AGENT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+VIME_ROOT="$(cd -- "${MEM_AGENT_DIR}/../.." &>/dev/null && pwd)"
+
+export VIME_ROOT
+export PYTHONBUFFERED="${PYTHONBUFFERED:-16}"
+export WANDB_MODE="${WANDB_MODE:-disabled}"
+export MASTER_ADDR="${MASTER_ADDR:-127.0.0.1}"
+export no_proxy="127.0.0.1,${MASTER_ADDR},localhost"
+export NO_PROXY="${no_proxy}"
+
+# Override via env for your cluster (H800 example in README).
+export HF_CKPT="${HF_CKPT:-/data/models/Qwen3-4B}"
+export TORCH_DIST="${TORCH_DIST:-/data/models/Qwen3-4B_torch_dist}"
+export TRAIN_DATA="${TRAIN_DATA:-/data/datasets/hotpotqa_slime/train.jsonl}"
+export SAVE_PATH="${SAVE_PATH:-/data/models/MemAgent_Qwen3-4B-RL}"
+export DATA_ROOT="${DATA_ROOT:-/data/datasets/hotpotqa_hf}"
+export ORIGIN_HF_DIR="${ORIGIN_HF_DIR:-${HF_CKPT}}"
+
+export MEM_CHUNK_TOKENS="${MEM_CHUNK_TOKENS:-2048}"
+export MEM_MAX_MEMORY="${MEM_MAX_MEMORY:-1024}"
+export MEM_MAX_FINAL="${MEM_MAX_FINAL:-256}"
+export MEM_MAX_CHUNKS="${MEM_MAX_CHUNKS:-64}"
+
+mem_agent_detect_nvlink() {
+  local count
+  count=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+  export NCCL_NVLS_ENABLE=$([[ "${count}" -gt 0 ]] && echo 1 || echo 0)
+}
+
+mem_agent_detect_gpus() {
+  local detected=0
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    detected=$(nvidia-smi -L 2>/dev/null | wc -l | tr -d ' ')
+  fi
+  export NUM_GPUS="${NUM_GPUS:-${detected:-8}}"
+  if [[ -z "${NUM_GPUS}" || "${NUM_GPUS}" -le 0 ]]; then
+    export NUM_GPUS=8
+  fi
+}
+
+mem_agent_cleanup() {
+  pkill -9 -f '[v]llm serve|VLLM::' 2>/dev/null || true
+  sleep 2
+  ray stop --force 2>/dev/null || true
+  pkill -9 -f '[r]ay::' 2>/dev/null || true
+  pkill -9 -f '[t]rain.py' 2>/dev/null || true
+  pkill -9 redis 2>/dev/null || true
+  rm -rf /tmp/ray /tmp/ray_session_* "${HOME}/.ray" 2>/dev/null || true
+  sleep 2
+}
+
+mem_agent_rollout_args() {
+  ROLLOUT_ARGS=(
+    --custom-generate-function-path examples.mem_agent.rollout.generate
+    --custom-rm-path examples.mem_agent.rollout.reward_func
+    --custom-convert-samples-to-train-data-path examples.mem_agent.custom_convert.custom_convert
+    --prompt-data "${TRAIN_DATA}"
+    --input-key prompt
+    --label-key label
+    --rollout-shuffle
+    --reward-key score
+    --num-rollout "${NUM_ROLLOUT}"
+    --rollout-batch-size "${ROLLOUT_BATCH_SIZE}"
+    --n-samples-per-prompt "${N_SAMPLES_PER_PROMPT}"
+    --rollout-max-response-len 8192
+    --rollout-max-context-len 32768
+    --rollout-temperature 1.0
+    --rollout-top-p 1.0
+    --global-batch-size "${GLOBAL_BATCH_SIZE}"
+    --balance-data
+    --rollout-function-path vime.rollout.vllm_rollout.generate_rollout
+  )
+}
+
+mem_agent_train_args() {
+  CKPT_ARGS=(
+    --hf-checkpoint "${HF_CKPT}"
+    --ref-load "${TORCH_DIST}"
+  )
+  if [[ -n "${SAVE_PATH:-}" ]]; then
+    CKPT_ARGS+=(--save "${SAVE_PATH}")
+    if [[ -n "${SAVE_INTERVAL:-}" ]]; then
+      CKPT_ARGS+=(--save-interval "${SAVE_INTERVAL}")
+    fi
+  fi
+
+  EVAL_ARGS=(--skip-eval-before-train)
+
+  PERF_ARGS=(
+    --tensor-model-parallel-size 2
+    --sequence-parallel
+    --pipeline-model-parallel-size 1
+    --context-parallel-size 1
+    --expert-model-parallel-size 1
+    --expert-tensor-parallel-size 1
+    --recompute-granularity full
+    --recompute-method uniform
+    --recompute-num-layers 1
+    --use-dynamic-batch-size
+    --max-tokens-per-gpu 9216
+  )
+
+  GRPO_ARGS=(
+    --advantage-estimator grpo
+    --use-kl-loss
+    --kl-loss-coef 0.001
+    --kl-loss-type low_var_kl
+    --eps-clip 0.2
+    --eps-clip-high 0.3
+  )
+
+  OPTIMIZER_ARGS=(
+    --optimizer adam
+    --lr 1e-6
+    --lr-decay-style constant
+    --weight-decay 0.1
+    --adam-beta1 0.9
+    --adam-beta2 0.98
+  )
+
+  VLLM_ARGS=(
+    --rollout-num-gpus-per-engine 2
+    --vllm-gpu-memory-utilization 0.7
+    --vllm-max-model-len 32768
+    --router-policy consistent_hash
+  )
+
+  MISC_ARGS=(
+    --attention-dropout 0.0
+    --hidden-dropout 0.0
+    --accumulate-allreduce-grads-in-fp32
+    --attention-softmax-in-fp32
+    --attention-backend flash
+    --train-memory-margin-bytes 2147483648
+    --actor-num-nodes 1
+    --actor-num-gpus-per-node "${NUM_GPUS}"
+    --colocate
+  )
+}
+
+mem_agent_launch_train() {
+  cd "${VIME_ROOT}"
+  source "${VIME_ROOT}/scripts/models/qwen3-4B.sh"
+  mem_agent_rollout_args
+  mem_agent_train_args
+
+  export RAY_DISABLE_DOCKER_CPU_WARNING=1
+  export PYTHONPATH="/root/Megatron-LM:${VIME_ROOT}:${PYTHONPATH:-}"
+
+  if [[ "${RUN_TRAIN_DIRECT:-0}" == "1" && -n "${RUN_TRAIN_DIRECT_PY:-}" && -f "${RUN_TRAIN_DIRECT_PY}" ]]; then
+    export VIME_ROOT NCCL_NVLS_ENABLE MEM_CHUNK_TOKENS MEM_MAX_MEMORY MEM_MAX_FINAL MEM_MAX_CHUNKS
+    python3 "${RUN_TRAIN_DIRECT_PY}" \
+      ${MODEL_ARGS[@]} \
+      "${CKPT_ARGS[@]}" \
+      "${ROLLOUT_ARGS[@]}" \
+      "${OPTIMIZER_ARGS[@]}" \
+      "${GRPO_ARGS[@]}" \
+      "${PERF_ARGS[@]}" \
+      "${EVAL_ARGS[@]}" \
+      "${VLLM_ARGS[@]}" \
+      "${MISC_ARGS[@]}"
+    return
+  fi
+
+  ray start --head --node-ip-address "${MASTER_ADDR}" \
+    --num-gpus "${NUM_GPUS}" --disable-usage-stats \
+    --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+  local runtime_env
+  runtime_env="{
+    \"env_vars\": {
+      \"PYTHONPATH\": \"${VIME_ROOT}:/root/Megatron-LM/\",
+      \"VIME_ROOT\": \"${VIME_ROOT}\",
+      \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+      \"NCCL_NVLS_ENABLE\": \"${NCCL_NVLS_ENABLE}\",
+      \"PYTHONBUFFERED\": \"16\",
+      \"MASTER_ADDR\": \"${MASTER_ADDR}\",
+      \"no_proxy\": \"${no_proxy}\",
+      \"NO_PROXY\": \"${NO_PROXY}\",
+      \"MEM_CHUNK_TOKENS\": \"${MEM_CHUNK_TOKENS}\",
+      \"MEM_MAX_MEMORY\": \"${MEM_MAX_MEMORY}\",
+      \"MEM_MAX_FINAL\": \"${MEM_MAX_FINAL}\",
+      \"MEM_MAX_CHUNKS\": \"${MEM_MAX_CHUNKS}\"
+    }
+  }"
+
+  ray job submit --address="http://127.0.0.1:8265" \
+    --runtime-env-json="${runtime_env}" \
+    -- python3 train.py \
+      --train-backend megatron \
+      ${MODEL_ARGS[@]} \
+      "${CKPT_ARGS[@]}" \
+      "${ROLLOUT_ARGS[@]}" \
+      "${OPTIMIZER_ARGS[@]}" \
+      "${GRPO_ARGS[@]}" \
+      "${PERF_ARGS[@]}" \
+      "${EVAL_ARGS[@]}" \
+      "${VLLM_ARGS[@]}" \
+      "${MISC_ARGS[@]}"
+}

--- a/examples/mem_agent/convert-to-hf.sh
+++ b/examples/mem_agent/convert-to-hf.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Convert MemAgent Megatron checkpoints to HuggingFace format.
+#
+# Usage:
+#   bash examples/mem_agent/convert-to-hf.sh
+#   CHECKPOINT_DIR=/path/to/ckpt SINGLE_ITER=iter_0000199 bash examples/mem_agent/convert-to-hf.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# shellcheck source=_common.sh
+source "${SCRIPT_DIR}/_common.sh"
+
+CHECKPOINT_DIR="${CHECKPOINT_DIR:-${SAVE_PATH}}"
+OUTPUT_BASE="${OUTPUT_BASE:-${CHECKPOINT_DIR}-HF}"
+MEGATRON_LM_DIR="${MEGATRON_LM_DIR:-/root/Megatron-LM}"
+CONVERT_SCRIPT="${CONVERT_SCRIPT:-${VIME_ROOT}/tools/convert_torch_dist_to_hf.py}"
+
+mkdir -p "${OUTPUT_BASE}"
+export PYTHONPATH="${MEGATRON_LM_DIR}:${VIME_ROOT}:${PYTHONPATH:-}"
+
+if [[ -n "${SINGLE_ITER:-}" ]]; then
+  ITERS=("${CHECKPOINT_DIR}/${SINGLE_ITER}")
+else
+  mapfile -t ITERS < <(ls -d "${CHECKPOINT_DIR}"/iter_* 2>/dev/null | sort)
+fi
+
+if [[ ${#ITERS[@]} -eq 0 ]]; then
+  echo "ERROR: no iter_* checkpoints in ${CHECKPOINT_DIR}"
+  exit 1
+fi
+
+echo "Converting ${#ITERS[@]} checkpoint(s) -> ${OUTPUT_BASE}"
+FAILED=()
+
+for iter_path in "${ITERS[@]}"; do
+  iter_name="$(basename "${iter_path}")"
+  output_dir="${OUTPUT_BASE}/${iter_name}"
+
+  if [[ -d "${output_dir}" && -f "${output_dir}/config.json" ]]; then
+    echo "[SKIP] ${iter_name} already at ${output_dir}"
+    continue
+  fi
+
+  echo "[CONVERT] ${iter_name} -> ${output_dir}"
+  if python3 "${CONVERT_SCRIPT}" \
+      --input-dir "${iter_path}" \
+      --output-dir "${output_dir}" \
+      --origin-hf-dir "${ORIGIN_HF_DIR}"; then
+    echo "[DONE] ${iter_name}"
+  else
+    echo "[FAILED] ${iter_name}"
+    FAILED+=("${iter_name}")
+  fi
+done
+
+echo "===== Summary: total=${#ITERS[@]} failed=${#FAILED[@]} ====="
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  printf '  %s\n' "${FAILED[@]}"
+  exit 1
+fi
+echo "Output: ${OUTPUT_BASE}"

--- a/examples/mem_agent/custom_convert.py
+++ b/examples/mem_agent/custom_convert.py
@@ -9,6 +9,13 @@ import torch
 logger = logging.getLogger(__name__)
 
 
+def _sample_has_rollout_log_probs(sample) -> bool:
+    meta = sample.train_metadata
+    if meta and "turns" in meta:
+        return any(t.get("rollout_log_probs") is not None for t in meta["turns"])
+    return sample.rollout_log_probs is not None
+
+
 def custom_convert(args, samples):
     raw_rewards = [s.get_reward_value(args) for s in samples]
     rewards_tensor = torch.tensor(raw_rewards, dtype=torch.float)
@@ -41,11 +48,18 @@ def custom_convert(args, samples):
     truncated_list = []
     sample_indices = []
     rollout_log_probs_list = []
-    has_rollout_log_probs = False
+    has_rollout_log_probs = any(
+        _sample_has_rollout_log_probs(s) for s in samples if s.status not in (s.Status.FAILED, s.Status.ABORTED)
+    )
 
     for i, sample in enumerate(samples):
+        if sample.status in (sample.Status.FAILED, sample.Status.ABORTED):
+            continue
+
         meta = sample.train_metadata
         if meta is None or "turns" not in meta:
+            if not sample.tokens:
+                continue
             tokens_list.append(sample.tokens)
             response_lengths.append(sample.response_length)
             lm = sample.loss_mask if sample.loss_mask is not None else [1] * sample.response_length
@@ -56,12 +70,16 @@ def custom_convert(args, samples):
             raw_reward_list.append(raw_rewards[i])
             truncated_list.append(1 if sample.status == sample.Status.TRUNCATED else 0)
             sample_indices.append(sample.index)
-            if sample.rollout_log_probs is not None:
-                rollout_log_probs_list.append(sample.rollout_log_probs)
-                has_rollout_log_probs = True
+            if has_rollout_log_probs:
+                lp = sample.rollout_log_probs
+                if lp is None:
+                    lp = [0.0] * sample.response_length
+                rollout_log_probs_list.append(lp)
             continue
 
         turns = meta["turns"]
+        if not turns:
+            continue
         norm_reward = normalized_rewards[i] / len(turns)
         is_truncated = 1 if sample.status == sample.Status.TRUNCATED else 0
 
@@ -76,9 +94,11 @@ def custom_convert(args, samples):
             raw_reward_list.append(raw_rewards[i])
             truncated_list.append(is_truncated)
             sample_indices.append(sample.index)
-            if turn.get("rollout_log_probs"):
-                rollout_log_probs_list.append(turn["rollout_log_probs"])
-                has_rollout_log_probs = True
+            if has_rollout_log_probs:
+                lp = turn.get("rollout_log_probs")
+                if lp is None:
+                    lp = [0.0] * turn["response_length"]
+                rollout_log_probs_list.append(lp)
 
     gbs = args.global_batch_size
     total = len(tokens_list)

--- a/examples/mem_agent/custom_convert.py
+++ b/examples/mem_agent/custom_convert.py
@@ -1,0 +1,117 @@
+"""MemAgent multi-turn custom convert — unroll turns into independent training samples."""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def custom_convert(args, samples):
+    raw_rewards = [s.get_reward_value(args) for s in samples]
+    rewards_tensor = torch.tensor(raw_rewards, dtype=torch.float)
+
+    if getattr(args, "advantage_estimator", None) in ["grpo", "gspo", "reinforce_plus_plus_baseline"] and getattr(
+        args, "rewards_normalization", False
+    ):
+        n = getattr(args, "n_samples_per_prompt", 1)
+        if rewards_tensor.shape[-1] == n * getattr(args, "rollout_batch_size", 1):
+            rewards_tensor = rewards_tensor.reshape(-1, n)
+        else:
+            rewards_tensor = rewards_tensor.view(-1, rewards_tensor.shape[-1])
+
+        mean = rewards_tensor.mean(dim=-1, keepdim=True)
+        rewards_tensor = rewards_tensor - mean
+
+        if getattr(args, "advantage_estimator", None) in ["grpo", "gspo"] and getattr(
+            args, "grpo_std_normalization", False
+        ):
+            std = rewards_tensor.std(dim=-1, keepdim=True)
+            rewards_tensor = rewards_tensor / (std + 1e-6)
+
+    normalized_rewards = rewards_tensor.flatten().tolist()
+
+    tokens_list = []
+    response_lengths = []
+    loss_masks = []
+    rewards = []
+    raw_reward_list = []
+    truncated_list = []
+    sample_indices = []
+    rollout_log_probs_list = []
+    has_rollout_log_probs = False
+
+    for i, sample in enumerate(samples):
+        meta = sample.train_metadata
+        if meta is None or "turns" not in meta:
+            tokens_list.append(sample.tokens)
+            response_lengths.append(sample.response_length)
+            lm = sample.loss_mask if sample.loss_mask is not None else [1] * sample.response_length
+            if sample.remove_sample:
+                lm = [0] * sample.response_length
+            loss_masks.append(lm)
+            rewards.append(normalized_rewards[i])
+            raw_reward_list.append(raw_rewards[i])
+            truncated_list.append(1 if sample.status == sample.Status.TRUNCATED else 0)
+            sample_indices.append(sample.index)
+            if sample.rollout_log_probs is not None:
+                rollout_log_probs_list.append(sample.rollout_log_probs)
+                has_rollout_log_probs = True
+            continue
+
+        turns = meta["turns"]
+        norm_reward = normalized_rewards[i] / len(turns)
+        is_truncated = 1 if sample.status == sample.Status.TRUNCATED else 0
+
+        for turn in turns:
+            tokens_list.append(turn["tokens"])
+            response_lengths.append(turn["response_length"])
+            lm = list(turn["loss_mask"])
+            if sample.remove_sample:
+                lm = [0] * turn["response_length"]
+            loss_masks.append(lm)
+            rewards.append(norm_reward)
+            raw_reward_list.append(raw_rewards[i])
+            truncated_list.append(is_truncated)
+            sample_indices.append(sample.index)
+            if turn.get("rollout_log_probs"):
+                rollout_log_probs_list.append(turn["rollout_log_probs"])
+                has_rollout_log_probs = True
+
+    gbs = args.global_batch_size
+    total = len(tokens_list)
+    trim_to = (total // gbs) * gbs
+    if trim_to == 0:
+        trim_to = total
+    if trim_to < total:
+        logger.info(
+            "custom_convert: trimming expanded samples from %d to %d (global_batch_size=%d)",
+            total,
+            trim_to,
+            gbs,
+        )
+        tokens_list = tokens_list[:trim_to]
+        response_lengths = response_lengths[:trim_to]
+        loss_masks = loss_masks[:trim_to]
+        rewards = rewards[:trim_to]
+        raw_reward_list = raw_reward_list[:trim_to]
+        truncated_list = truncated_list[:trim_to]
+        sample_indices = sample_indices[:trim_to]
+        if has_rollout_log_probs:
+            rollout_log_probs_list = rollout_log_probs_list[:trim_to]
+
+    train_data = {
+        "tokens": tokens_list,
+        "response_lengths": response_lengths,
+        "loss_masks": loss_masks,
+        "rewards": rewards,
+        "raw_reward": raw_reward_list,
+        "truncated": truncated_list,
+        "sample_indices": sample_indices,
+    }
+    if has_rollout_log_probs:
+        train_data["rollout_log_probs"] = rollout_log_probs_list
+
+    return train_data

--- a/examples/mem_agent/eval_ruler_hqa.py
+++ b/examples/mem_agent/eval_ruler_hqa.py
@@ -1,0 +1,542 @@
+"""
+eval_ruler_hqa.py — MemAgent HotpotQA evaluation (vime / vLLM version)
+======================================================================
+Core logic aligned with slime-agentic eval_ruler_hqa.py and MemAgent ruler_hqa.py.
+Inference uses vLLM OpenAI-compatible ``/v1/chat/completions``.
+
+Evaluation data: MemAgent-format eval_{length}.json
+    Fields: input, answers, context, num_docs
+
+Metrics: F1, EM, sub_EM
+
+Usage (vLLM server must be running, e.g. via examples/mem_agent/run-eval.sh):
+    python eval_ruler_hqa.py \\
+        --model  /path/to/hf_ckpt \\
+        --tokenizer /path/to/hf_ckpt \\
+        --length 200 \\
+        --data-root /data/hotpotqa \\
+        --save-dir results/ruler_hqa_200 \\
+        --save-file iter_0000200
+
+Environment variables:
+    VLLM_SERVE_HOST / SERVE_HOST   vLLM server host (default: 127.0.0.1)
+    VLLM_SERVE_PORT / SERVE_PORT   vLLM server port (default: 8000)
+    MEM_CHUNK_TOKENS               tokens per chunk (default: 2048)
+    MEM_MAX_MEMORY                 max tokens for memory update (default: 1024)
+    MEM_MAX_FINAL                  max tokens for final answer (default: 256)
+    MEM_MAX_CHUNKS                 max number of chunks (default: 512)
+    DATAROOT                       directory with eval_*.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import copy
+import json
+import os
+import re
+import string
+from collections import Counter
+from pathlib import Path
+
+import aiohttp
+from tqdm import tqdm
+from transformers import AutoTokenizer
+
+SERVE_HOST = os.getenv("VLLM_SERVE_HOST", os.getenv("SERVE_HOST", "127.0.0.1"))
+SERVE_PORT = os.getenv("VLLM_SERVE_PORT", os.getenv("SERVE_PORT", "8000"))
+CHUNK_TOKENS = int(os.getenv("MEM_CHUNK_TOKENS", "2048"))
+MAX_MEMORY_TOKS = int(os.getenv("MEM_MAX_MEMORY", "1024"))
+MAX_FINAL_TOKS = int(os.getenv("MEM_MAX_FINAL", "256"))
+MAX_CHUNKS = int(os.getenv("MEM_MAX_CHUNKS", "512"))
+MAX_CTX_TOKENS = int(os.getenv("MEM_MAX_CTX_TOKENS", str(10**12)))
+BASE_URL = f"http://{SERVE_HOST}:{SERVE_PORT}/v1"
+API_KEY = os.getenv("SERVE_API_KEY", "EMPTY")
+DATAROOT = os.getenv("DATAROOT", "/data/hotpotqa")
+
+_MEMORY_TEMPLATE = """You are presented with a problem, a section of an article that may contain the answer to the problem, and a previous memory. Please read the provided section carefully and update the memory with the new information that helps to answer the problem. Be sure to retain all relevant details from the previous memory while adding any new, useful information.
+
+<problem>
+{prompt}
+</problem>
+
+<memory>
+{memory}
+</memory>
+
+<section>
+{chunk}
+</section>
+
+Updated memory:
+"""
+
+_FINAL_TEMPLATE = """You are presented with a problem and a previous memory. Please answer the problem based on the previous memory and put the answer in \\boxed{{}}.
+
+<problem>
+{prompt}
+</problem>
+
+<memory>
+{memory}
+</memory>
+
+Your answer:
+"""
+
+_NO_MEMORY = "No previous memory"
+_STOP_TOKEN_STRINGS = ["<|im_end|>", "<|endoftext|>"]
+
+
+def _strip_stop_tokens(text: str) -> str:
+    for tok in _STOP_TOKEN_STRINGS:
+        text = text.replace(tok, "")
+    return text.strip()
+
+
+def _last_boxed_only_string(s: str) -> str | None:
+    if "\\boxed " in s:
+        return "\\boxed " + s.split("\\boxed ")[-1].split("$")[0]
+    idx = s.rfind("\\boxed")
+    if idx < 0:
+        idx = s.rfind("\\fbox")
+        if idx < 0:
+            return None
+    i, right_brace_idx, opens = idx, None, 0
+    while i < len(s):
+        if s[i] == "{":
+            opens += 1
+        if s[i] == "}":
+            opens -= 1
+            if opens == 0:
+                right_brace_idx = i
+                break
+        i += 1
+    return s[idx : right_brace_idx + 1] if right_brace_idx is not None else None
+
+
+def _remove_boxed(s: str) -> str:
+    if s.startswith("\\boxed "):
+        return s[len("\\boxed ") :]
+    left = "\\boxed{"
+    assert s.startswith(left) and s.endswith("}")
+    return s[len(left) : -1]
+
+
+def _extract_boxed(text: str) -> str:
+    s = _last_boxed_only_string(text)
+    if s is None:
+        return ""
+    try:
+        return _remove_boxed(s).strip()
+    except Exception:
+        return ""
+
+
+def _normalize_answer(s: str) -> str:
+    def remove_articles(t):
+        return re.sub(r"\b(a|an|the)\b", " ", t)
+
+    def white_space_fix(t):
+        return " ".join(t.split())
+
+    def remove_punc(t):
+        exclude = set(string.punctuation)
+        return "".join(ch for ch in t if ch not in exclude)
+
+    return white_space_fix(remove_articles(remove_punc(s.lower())))
+
+
+def _f1_score(prediction: str, ground_truth: str) -> tuple[float, float, float]:
+    p = _normalize_answer(prediction).split()
+    g = _normalize_answer(ground_truth).split()
+    if not p or not g:
+        return 0.0, 0.0, 0.0
+    common = Counter(p) & Counter(g)
+    num_same = sum(common.values())
+    if num_same == 0:
+        return 0.0, 0.0, 0.0
+    prec = num_same / len(p)
+    recall = num_same / len(g)
+    f1 = 2 * prec * recall / (prec + recall)
+    return f1, prec, recall
+
+
+def _exact_match(prediction: str, ground_truth: str) -> float:
+    p = _normalize_answer(prediction)
+    g = _normalize_answer(ground_truth)
+    if p in ("yes", "no", "noanswer") and p != g:
+        return 0.0
+    if g in ("yes", "no", "noanswer") and p != g:
+        return 0.0
+    return float(p == g)
+
+
+def _sub_exact_match(prediction: str, ground_truth: str) -> float:
+    p = _normalize_answer(prediction)
+    g = _normalize_answer(ground_truth)
+    return float((g in p) or (p in g))
+
+
+def _agg_metrics(records: list[dict]) -> dict:
+    keys = ("judge_f1", "judge_em", "judge_sub_em")
+    totals = {k: 0.0 for k in keys}
+    n = len(records)
+    for r in records:
+        for k in keys:
+            totals[k] += r[k]
+    return {
+        "f1": round(totals["judge_f1"] / n, 4) if n else 0.0,
+        "em": round(totals["judge_em"] / n, 4) if n else 0.0,
+        "sub_em": round(totals["judge_sub_em"] / n, 4) if n else 0.0,
+        "total": n,
+    }
+
+
+async def _chat_once(
+    session: aiohttp.ClientSession,
+    model: str,
+    messages: list[dict],
+    temperature: float,
+    top_p: float,
+    max_tokens: int,
+) -> str:
+    payload = dict(
+        model=model,
+        messages=messages,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
+    )
+    async with session.post(
+        f"{BASE_URL}/chat/completions",
+        headers={"Authorization": f"Bearer {API_KEY}"},
+        json=payload,
+    ) as resp:
+        if resp.status != 200:
+            body = await resp.text()
+            raise RuntimeError(f"HTTP {resp.status}: {body[:300]}")
+        data = await resp.json()
+    return data["choices"][0]["message"]["content"]
+
+
+async def _recurrent_infer(
+    item: dict,
+    model: str,
+    tokenizer,
+    temperature: float,
+    top_p: float,
+    sem: asyncio.Semaphore,
+) -> str:
+    question = item["input"].strip()
+    context = item["context"].strip()
+
+    ctx_ids = tokenizer.encode(context, add_special_tokens=False)
+    if len(ctx_ids) > MAX_CTX_TOKENS:
+        half = MAX_CTX_TOKENS // 2
+        ctx_ids = ctx_ids[:half] + ctx_ids[-half:]
+
+    chunks = [ctx_ids[i : i + CHUNK_TOKENS] for i in range(0, len(ctx_ids), CHUNK_TOKENS)][:MAX_CHUNKS]
+
+    async with sem:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=86400)) as session:
+            memory = _NO_MEMORY
+            for chunk_ids in chunks:
+                chunk_text = tokenizer.decode(chunk_ids, skip_special_tokens=True)
+                msg = _MEMORY_TEMPLATE.format(prompt=question, memory=memory, chunk=chunk_text)
+                raw = await _chat_once(
+                    session,
+                    model,
+                    [{"role": "user", "content": msg}],
+                    temperature,
+                    top_p,
+                    MAX_MEMORY_TOKS,
+                )
+                memory = _strip_stop_tokens(raw) or memory
+
+            final_msg = _FINAL_TEMPLATE.format(prompt=question, memory=memory)
+            response = await _chat_once(
+                session,
+                model,
+                [{"role": "user", "content": final_msg}],
+                temperature,
+                top_p,
+                MAX_FINAL_TOKS,
+            )
+    return response.strip()
+
+
+async def _openai_infer(
+    item: dict,
+    model: str,
+    tokenizer,
+    temperature: float,
+    top_p: float,
+    max_input_len: int,
+    max_output_len: int,
+    sem: asyncio.Semaphore,
+) -> str:
+    question = item["input"].strip()
+    context = item["context"].strip()
+    prompt = f"{context}\n\n" f"Question: {question}\n" "Please put the answer in \\boxed{}.\n\n" "Answer:"
+    ids = tokenizer.encode(prompt, add_special_tokens=False)
+    if len(ids) > max_input_len:
+        prompt = tokenizer.decode(ids[:max_input_len], skip_special_tokens=True)
+
+    async with sem:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=86400)) as session:
+            response = await _chat_once(
+                session,
+                model,
+                [{"role": "user", "content": prompt}],
+                temperature,
+                top_p,
+                max_output_len,
+            )
+    return response.strip()
+
+
+async def run_eval(data: list[dict], args: argparse.Namespace, tokenizer) -> None:
+    out_path = Path(args.save_dir) / f"{args.save_file}.jsonl"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    cached_ids: set[int] = set()
+    if out_path.exists() and not args.force:
+        with open(out_path, encoding="utf-8") as f:
+            for line in f:
+                try:
+                    cached_ids.add(json.loads(line)["_id"])
+                except Exception:
+                    pass
+
+    todo = [item for item in data if item["_id"] not in cached_ids]
+    print(f"Data: {len(data)}  Cached: {len(cached_ids)}  " f"Todo: {len(todo)}  Concurrency: {args.n_proc}")
+    if not todo:
+        print("All done (cached).")
+        _print_existing_stats(out_path)
+        return
+
+    sem = asyncio.Semaphore(args.n_proc)
+
+    async def process_one(item: dict) -> dict | None:
+        try:
+            if args.api == "recurrent":
+                response = await _recurrent_infer(item, args.model, tokenizer, args.temperature, args.top_p, sem)
+            else:
+                response = await _openai_infer(
+                    item,
+                    args.model,
+                    tokenizer,
+                    args.temperature,
+                    args.top_p,
+                    args.max_input_len,
+                    args.max_output_len,
+                    sem,
+                )
+        except Exception:
+            import traceback
+
+            traceback.print_exc()
+            return None
+
+        gold = item["answers"][0] if item.get("answers") else ""
+        pred = _extract_boxed(response[-300:].lower()) or ""
+
+        result = {
+            "_id": item["_id"],
+            "answer": gold,
+            "pred": pred,
+            "judge_f1": _f1_score(pred, gold)[0],
+            "judge_em": _exact_match(pred, gold),
+            "judge_sub_em": _sub_exact_match(pred, gold),
+            "response": response,
+        }
+        for k, v in item.items():
+            if k not in ("context", "response") and k not in result:
+                result[k] = v
+        return result
+
+    tasks = [process_one(item) for item in todo]
+    records: list[dict] = []
+    n_err = 0
+    first_shown = False
+    fout = open(out_path, "a", encoding="utf-8")
+    pbar = tqdm(total=len(tasks), desc=f"ruler_hqa[{args.length}]", dynamic_ncols=True)
+    PRINT_INTERVAL = 10
+
+    for coro in asyncio.as_completed(tasks):
+        result = await coro
+        pbar.update(1)
+        if result is None:
+            n_err += 1
+            pbar.set_postfix(err=n_err, done=len(records))
+            continue
+
+        fout.write(json.dumps(result, ensure_ascii=False) + "\n")
+        fout.flush()
+        records.append(result)
+
+        n = len(records)
+        rolling_f1 = sum(r["judge_f1"] for r in records) / n
+        rolling_sub_em = sum(r["judge_sub_em"] for r in records) / n
+        pbar.set_postfix(
+            done=n,
+            err=n_err,
+            f1=f"{rolling_f1 * 100:.1f}",
+            sub_em=f"{rolling_sub_em * 100:.1f}",
+        )
+
+        if not first_shown:
+            first_shown = True
+            _print_sample(result)
+
+        if n % PRINT_INTERVAL == 0:
+            tqdm.write(
+                f"[interim {n}/{len(tasks)}]  "
+                f"F1={rolling_f1 * 100:.2f}  "
+                f"sub_EM={rolling_sub_em * 100:.2f}  "
+                f"err={n_err}"
+            )
+
+    pbar.close()
+    fout.close()
+
+    all_records = records[:]
+    if cached_ids:
+        with open(out_path, encoding="utf-8") as f:
+            all_records = [json.loads(line) for line in f if line.strip()]
+
+    stats = _agg_metrics(all_records)
+    print(f"\n=== ruler_hqa [n_docs={args.length}]  " f"total={stats['total']}  errors={n_err} ===")
+    for k in ("f1", "em", "sub_em"):
+        print(f"  {k}: {round(stats[k] * 100, 2)}")
+
+
+def _print_sample(result: dict) -> None:
+    sep = "=" * 40
+    print(f"\n{sep} Sample {result['_id']} {sep}")
+    print(f"[response]  {result['response'][:500]}")
+    print(f"[pred]      {result['pred']}")
+    print(f"[answer]    {result['answer']}")
+    print(f"[sub_em]    {result['judge_sub_em']}")
+    print(sep)
+
+
+def _print_existing_stats(out_path: Path) -> None:
+    records = []
+    with open(out_path, encoding="utf-8") as f:
+        for line in f:
+            try:
+                records.append(json.loads(line))
+            except Exception:
+                pass
+    if not records:
+        return
+    stats = _agg_metrics(records)
+    print(f"Existing results ({stats['total']} samples):")
+    for k in ("f1", "em", "sub_em"):
+        print(f"  {k}: {round(stats[k] * 100, 2)}")
+
+
+def load_data(data_root: str, length: int) -> list[dict]:
+    candidates = [
+        Path(data_root) / f"eval_{length}.json",
+        Path(data_root) / f"eval_{length}.jsonl",
+    ]
+    data_path = next((p for p in candidates if p.exists()), None)
+    if data_path is None:
+        raise FileNotFoundError(
+            f"Cannot find eval data for length={length} in {data_root!r}. " f"Tried: {[str(p) for p in candidates]}"
+        )
+
+    suffix = data_path.suffix.lower()
+    if suffix == ".json":
+        with open(data_path, encoding="utf-8") as f:
+            raw = json.load(f)
+        if isinstance(raw, dict):
+            raw = list(raw.values())
+    else:
+        with open(data_path, encoding="utf-8") as f:
+            raw = [json.loads(line) for line in f if line.strip()]
+
+    data = []
+    for idx, item in enumerate(raw):
+        if "input" in item:
+            item = dict(item)
+            item.setdefault("_id", idx)
+            data.append(item)
+        elif "prompt" in item:
+            meta = item.get("metadata") or {}
+            data.append(
+                {
+                    "_id": idx,
+                    "input": item["prompt"],
+                    "answers": meta.get("ground_truth", [item.get("label", "")]),
+                    "context": meta.get("context", ""),
+                    "num_docs": meta.get("num_docs", 0),
+                }
+            )
+        else:
+            print(f"[warn] skipping row {idx}: unrecognized format (keys={list(item.keys())[:5]})")
+
+    return data
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="MemAgent HotpotQA eval — vime/vLLM version")
+    parser.add_argument(
+        "--length",
+        type=int,
+        default=200,
+        choices=[50, 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600],
+        help="Number of distractive documents (controls context length)",
+    )
+    parser.add_argument(
+        "--data-root",
+        default=DATAROOT,
+        help="Directory containing eval_{length}.json files",
+    )
+    parser.add_argument("--save-dir", "-s", default="results/ruler_hqa", help="Output directory")
+    parser.add_argument("--save-file", "-f", default="model", help="Output filename stem")
+    parser.add_argument("--model", "-m", required=True, help="Model id registered in vLLM server")
+    parser.add_argument("--tokenizer", "-t", required=True, help="HuggingFace tokenizer path (for chunking)")
+    parser.add_argument(
+        "--api",
+        default="recurrent",
+        choices=["recurrent", "openai"],
+        help="recurrent: chunk-by-chunk memory update (default); openai: single-turn baseline",
+    )
+    parser.add_argument("--n-proc", "-n", type=int, default=32, help="Max concurrent requests")
+    parser.add_argument("--temperature", type=float, default=0.7)
+    parser.add_argument("--top-p", type=float, default=0.95)
+    parser.add_argument("--max-input-len", type=int, default=120000)
+    parser.add_argument("--max-output-len", type=int, default=10000)
+    parser.add_argument("--sampling", type=int, default=1)
+    parser.add_argument("--force", action="store_true", help="Ignore cache and re-evaluate")
+    args = parser.parse_args()
+
+    print(f"[config] vLLM={SERVE_HOST}:{SERVE_PORT}  api={args.api}")
+    print(
+        f"[config] CHUNK_TOKENS={CHUNK_TOKENS}  MAX_MEMORY={MAX_MEMORY_TOKS}  "
+        f"MAX_FINAL={MAX_FINAL_TOKS}  MAX_CHUNKS={MAX_CHUNKS}"
+    )
+
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer, trust_remote_code=True)
+    data = load_data(args.data_root, args.length)
+
+    if args.sampling > 1:
+        base = data[:]
+        data = []
+        for s in range(args.sampling):
+            for item in base:
+                new_item = copy.deepcopy(item)
+                new_item["_id"] = item["_id"] * args.sampling + s
+                data.append(new_item)
+
+    print(f"[data] {len(data)} samples  (n_docs={args.length})")
+    asyncio.run(run_eval(data, args, tokenizer))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mem_agent/eval_ruler_hqa.py
+++ b/examples/mem_agent/eval_ruler_hqa.py
@@ -341,7 +341,7 @@ async def run_eval(data: list[dict], args: argparse.Namespace, tokenizer) -> Non
             return None
 
         gold = item["answers"][0] if item.get("answers") else ""
-        pred = _extract_boxed(response[-300:].lower()) or ""
+        pred = _extract_boxed(response[-300:]) or ""
 
         result = {
             "_id": item["_id"],

--- a/examples/mem_agent/prepare-eval-data.sh
+++ b/examples/mem_agent/prepare-eval-data.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Prepare RULER-HQA eval JSON (eval_{50,100,200,...}.json).
+#
+# Usage:
+#   bash examples/mem_agent/prepare-eval-data.sh
+#   LENGTHS="50 200 800" bash examples/mem_agent/prepare-eval-data.sh
+#   bash examples/mem_agent/prepare-eval-data.sh --download
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# shellcheck source=_common.sh
+source "${SCRIPT_DIR}/_common.sh"
+
+DATA_DIR="${DATA_DIR:-${DATA_ROOT}}"
+HF_DATASET="${HF_DATASET:-BytedTsinghua-SIA/hotpotqa}"
+LENGTHS="${LENGTHS:-50 100 200 400 800 1600 3200 6400}"
+
+mkdir -p "${DATA_DIR}"
+export PYTHONPATH="/root/Megatron-LM:${VIME_ROOT}:${PYTHONPATH:-}"
+
+download_one() {
+  local length="$1"
+  local fname="eval_${length}.json"
+  local dest="${DATA_DIR}/${fname}"
+  if [[ -f "${dest}" ]]; then
+    echo "[SKIP] ${fname}"
+    return 0
+  fi
+  echo "[DOWNLOAD] ${fname}"
+  python3 - <<PY
+from huggingface_hub import hf_hub_download
+import shutil
+path = hf_hub_download(repo_id="${HF_DATASET}", filename="${fname}", repo_type="dataset")
+shutil.copy2(path, "${dest}")
+print("Saved:", "${dest}")
+PY
+}
+
+if [[ "${1:-}" == "--download" ]]; then
+  for length in ${LENGTHS}; do
+    download_one "${length}"
+  done
+else
+  missing=0
+  for length in ${LENGTHS}; do
+    if [[ ! -f "${DATA_DIR}/eval_${length}.json" ]]; then
+      echo "MISSING: ${DATA_DIR}/eval_${length}.json"
+      missing=$((missing + 1))
+    fi
+  done
+  if [[ "${missing}" -gt 0 ]]; then
+    echo ""
+    echo "Place eval_*.json under ${DATA_DIR}, or run:"
+    echo "  bash examples/mem_agent/prepare-eval-data.sh --download"
+    exit 1
+  fi
+  echo "All eval files present in ${DATA_DIR}"
+  ls -lh "${DATA_DIR}"/eval_*.json 2>/dev/null | head -20
+fi

--- a/examples/mem_agent/prepare_data.py
+++ b/examples/mem_agent/prepare_data.py
@@ -1,0 +1,253 @@
+"""
+Convert MemAgent hotpotqa parquet data to slime-compatible JSONL format.
+
+MemAgent parquet fields:
+    prompt        : [{"role": "user", "content": question}]
+    context       : "Document 1:\n...\n\nDocument 2:\n..."
+    reward_model  : {"style": "rule", "ground_truth": ["answer1", ...]}
+    extra_info    : {"index": 0, "question": ..., "num_docs": 200}
+    data_source   : "hotpotqa"
+    ability       : "memory"
+
+Output JSONL fields (slime convention):
+    prompt    : question string            (--input-key prompt)
+    label     : first answer string        (--label-key label)
+    metadata  : {
+        "context"      : long document text,
+        "ground_truth" : [all acceptable answers],  # used by reward_func for multi-answer matching
+        "num_docs"     : int,
+        "data_source"  : str,
+    }
+
+Usage:
+    python prepare_data.py \\
+        --input  /path/to/hotpotqa_train.parquet \\
+        --output /path/to/hotpotqa_train.jsonl
+
+    # Can also pull directly from HuggingFace
+    python prepare_data.py \\
+        --hf-dataset BytedTsinghua-SIA/hotpotqa \\
+        --hf-split  train \\
+        --output /path/to/hotpotqa_train.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _to_json_safe(obj):
+    try:
+        import numpy as np
+    except ImportError:
+        np = None
+
+    if np is not None:
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if isinstance(obj, (np.integer, np.floating, np.bool_)):
+            return obj.item()
+    if isinstance(obj, dict):
+        return {k: _to_json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_to_json_safe(v) for v in obj]
+    return obj
+
+
+def convert_row(row: dict) -> dict | None:
+    """Convert one row from MemAgent format to slime JSONL format.
+
+    Compatible with two formats:
+      Training set format (parquet): prompt(list) / reward_model / extra_info / context
+      Evaluation set format (eval_*.json): input / answers / num_docs / context
+    """
+    context = row.get("context", "")
+    if not context:
+        return None
+
+    # ── Evaluation set format: input + answers ───────────────────────────────
+    if "input" in row:
+        question = row["input"]
+        answers = row.get("answers", [])
+        if isinstance(answers, str):
+            answers = [answers]
+        label = answers[0] if answers else ""
+        if not question or not label:
+            return None
+        return {
+            "prompt": question,
+            "label": label,
+            "metadata": {
+                "context": context,
+                "ground_truth": answers,
+                "num_docs": row.get("num_docs", 0),
+                "data_source": "hotpotqa",
+            },
+        }
+
+    # ── Training set format: prompt(list) + reward_model ────────────────────
+    prompt_field = row.get("prompt", [])
+    if isinstance(prompt_field, list) and prompt_field:
+        question = prompt_field[0].get("content", "") if isinstance(prompt_field[0], dict) else str(prompt_field[0])
+    elif isinstance(prompt_field, str):
+        question = prompt_field
+    else:
+        question = row.get("extra_info", {}).get("question", "")
+
+    if not question:
+        return None
+
+    reward_model = row.get("reward_model", {})
+    if isinstance(reward_model, str):
+        try:
+            reward_model = json.loads(reward_model)
+        except Exception:
+            reward_model = {}
+    ground_truth = reward_model.get("ground_truth", [])
+    if isinstance(ground_truth, str):
+        ground_truth = [ground_truth]
+    label = ground_truth[0] if ground_truth else ""
+    if not label:
+        return None
+
+    extra_info = row.get("extra_info", {}) or {}
+
+    return {
+        "prompt": question,
+        "label": label,
+        "metadata": {
+            "context": context,
+            "ground_truth": ground_truth,
+            "num_docs": extra_info.get("num_docs", 0),
+            "data_source": row.get("data_source", "hotpotqa"),
+        },
+    }
+
+
+def convert_parquet(input_path: str, output_path: str) -> int:
+    try:
+        import pandas as pd
+    except ImportError:
+        print("ERROR: pandas is required. pip install pandas pyarrow", file=sys.stderr)
+        sys.exit(1)
+
+    df = pd.read_parquet(input_path)
+    rows = df.to_dict(orient="records")
+    return _write_jsonl(rows, output_path)
+
+
+def convert_hf(dataset_name: str, split: str, output_path: str) -> int:
+    try:
+        from datasets import load_dataset
+    except ImportError:
+        print("ERROR: datasets is required. pip install datasets", file=sys.stderr)
+        sys.exit(1)
+
+    # Prefer the HF_ENDPOINT environment variable; otherwise automatically try the mirror
+    import os
+
+    if not os.environ.get("HF_ENDPOINT"):
+        os.environ["HF_ENDPOINT"] = "https://hf-mirror.com"
+
+    # Use list_repo_files to precisely list files for the target split
+    from huggingface_hub import list_repo_files
+
+    exts = (".parquet", ".json", ".jsonl", ".csv")
+
+    # list_repo_files is more reliable than glob and lists all files
+    all_files = list(list_repo_files(dataset_name, repo_type="dataset"))
+    split_files = [
+        f"hf://datasets/{dataset_name}/{p}" for p in all_files if split in Path(p).name and Path(p).suffix in exts
+    ]
+    if split_files:
+        fmt = "parquet" if split_files[0].endswith(".parquet") else "json"
+        ds = load_dataset(fmt, data_files={split: split_files}, split=split)
+    else:
+        # Last fallback: the split name may be nested inside a directory (e.g. data/split/xxx.parquet)
+        split_files = [
+            f"hf://datasets/{dataset_name}/{p}"
+            for p in all_files
+            if (f"/{split}/" in p or f"/{split}-" in p) and Path(p).suffix in exts
+        ]
+        if not split_files:
+            raise FileNotFoundError(
+                f"Cannot find files for split '{split}' in dataset '{dataset_name}'. "
+                f"Available files: {all_files[:20]}"
+            )
+        fmt = "parquet" if split_files[0].endswith(".parquet") else "json"
+        ds = load_dataset(fmt, data_files={split: split_files}, split=split)
+    rows = [dict(r) for r in ds]
+    return _write_jsonl(rows, output_path)
+
+
+def _write_jsonl(rows: list[dict], output_path: str) -> int:
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    written = 0
+    skipped = 0
+    with open(output_path, "w", encoding="utf-8") as f:
+        for row in rows:
+            out = convert_row(row)
+            if out is None:
+                skipped += 1
+                continue
+            f.write(json.dumps(_to_json_safe(out), ensure_ascii=False) + "\n")
+            written += 1
+
+    print(f"Written: {written}  Skipped: {skipped}  → {output_path}")
+    return written
+
+
+def convert_hf_file(dataset_name: str, filename: str, output_path: str) -> int:
+    """Directly download and convert a specified file from an HF repo; used for non-standard split files such as eval_*.json."""
+    import os
+
+    if not os.environ.get("HF_ENDPOINT"):
+        os.environ["HF_ENDPOINT"] = "https://hf-mirror.com"
+
+    from huggingface_hub import hf_hub_download
+
+    local_path = hf_hub_download(
+        repo_id=dataset_name,
+        filename=filename,
+        repo_type="dataset",
+    )
+    suffix = Path(local_path).suffix.lower()
+    if suffix == ".parquet":
+        return convert_parquet(local_path, output_path)
+    else:
+        with open(local_path, encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            rows = list(data.values()) if all(isinstance(v, dict) for v in data.values()) else [data]
+        else:
+            rows = data
+        return _write_jsonl(rows, output_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert MemAgent parquet to slime JSONL")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--input", help="Local parquet file path")
+    group.add_argument("--hf-dataset", help="HuggingFace dataset name, e.g. BytedTsinghua-SIA/hotpotqa")
+    parser.add_argument("--hf-split", default="train", help="HF split (default: train)")
+    parser.add_argument(
+        "--hf-file",
+        default=None,
+        help="Directly specify a filename in the HF repo, e.g. eval_1600.json (for non-standard splits)",
+    )
+    parser.add_argument("--output", required=True, help="Output JSONL file path")
+    args = parser.parse_args()
+
+    if args.input:
+        convert_parquet(args.input, args.output)
+    elif args.hf_file:
+        convert_hf_file(args.hf_dataset, args.hf_file, args.output)
+    else:
+        convert_hf(args.hf_dataset, args.hf_split, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mem_agent/prepare_data.py
+++ b/examples/mem_agent/prepare_data.py
@@ -38,13 +38,13 @@ import json
 import sys
 from pathlib import Path
 
+try:
+    import numpy as np
+except ImportError:
+    np = None
+
 
 def _to_json_safe(obj):
-    try:
-        import numpy as np
-    except ImportError:
-        np = None
-
     if np is not None:
         if isinstance(obj, np.ndarray):
             return obj.tolist()

--- a/examples/mem_agent/rollout.py
+++ b/examples/mem_agent/rollout.py
@@ -1,0 +1,263 @@
+"""
+MemAgent rollout for vime (migrated from slime-agentic).
+
+Chunk-by-chunk memory update pipeline:
+    for chunk in split(context):
+        memory = LLM(problem, memory, chunk)
+    answer = LLM(problem, memory)  # final turn with \\boxed{}
+"""
+
+from __future__ import annotations
+
+import os
+import traceback
+from typing import Any
+
+from examples.mem_agent.rollout_client import MemAgentRolloutClient
+
+from vime.rollout.vllm_rollout import GenerateState
+from vime.utils.types import Sample
+
+CHUNK_TOKENS = int(os.environ.get("MEM_CHUNK_TOKENS", "2048"))
+MAX_MEMORY_TOKENS = int(os.environ.get("MEM_MAX_MEMORY", "1024"))
+MAX_FINAL_TOKENS = int(os.environ.get("MEM_MAX_FINAL", "256"))
+MAX_CHUNKS = int(os.environ.get("MEM_MAX_CHUNKS", "512"))
+
+_MEMORY_TEMPLATE = """You are presented with a problem, a section of an article that may contain the answer to the problem, and a previous memory. Please read the provided section carefully and update the memory with the new information that helps to answer the problem. Be sure to retain all relevant details from the previous memory while adding any new, useful information.
+
+<problem> 
+{prompt}
+</problem>
+
+<memory>
+{memory}
+</memory>
+
+<section>
+{chunk}
+</section>
+
+Updated memory:
+"""
+
+_FINAL_TEMPLATE = """You are presented with a problem and a previous memory. Please answer the problem based on the previous memory and put the answer in \\boxed{{}}.
+
+<problem> 
+{prompt}
+</problem>
+
+<memory>
+{memory}
+</memory>
+
+Your answer:
+"""
+
+_NO_MEMORY = "No previous memory"
+_STOP_TOKEN_STRINGS = ["", "<|endoftext|>"]
+
+
+def _strip_stop_tokens(text: str) -> str:
+    for tok in _STOP_TOKEN_STRINGS:
+        text = text.replace(tok, "")
+    return text.strip()
+
+
+async def generate(
+    args: Any,
+    sample: Sample,
+    sampling_params: dict[str, Any],
+    evaluation: bool = False,
+) -> Sample:
+    state = GenerateState(args)
+    client = MemAgentRolloutClient(args, state.tokenizer, sampling_params)
+
+    if not isinstance(sample.metadata, dict):
+        sample.metadata = {}
+
+    question = sample.prompt if isinstance(sample.prompt, str) else sample.prompt[-1]["content"]
+    context = sample.metadata.get("context", "")
+    if not context:
+        sample.status = Sample.Status.ABORTED
+        sample.rollout_log_probs = []
+        return sample
+
+    try:
+        context_ids = state.tokenizer.encode(context, add_special_tokens=False)
+        chunks_ids = [context_ids[i : i + CHUNK_TOKENS] for i in range(0, len(context_ids), CHUNK_TOKENS)][:MAX_CHUNKS]
+
+        turns: list[dict] = []
+        memory = _NO_MEMORY
+        mem_params = {**sampling_params, "max_new_tokens": MAX_MEMORY_TOKENS}
+
+        for chunk_ids in chunks_ids:
+            chunk_text = state.tokenizer.decode(chunk_ids, skip_special_tokens=True)
+            messages = [
+                {
+                    "role": "user",
+                    "content": _MEMORY_TEMPLATE.format(prompt=question, memory=memory, chunk=chunk_text),
+                }
+            ]
+            out = await client.generate(messages, sampling_params=mem_params)
+            memory = _strip_stop_tokens(out.response) or memory
+            turns.append(
+                {
+                    "tokens": out.prompt_token_ids + out.token_ids,
+                    "response_length": len(out.token_ids),
+                    "loss_mask": [1] * len(out.token_ids),
+                    "rollout_log_probs": out.log_probs,
+                }
+            )
+
+        final_messages = [
+            {
+                "role": "user",
+                "content": _FINAL_TEMPLATE.format(prompt=question, memory=memory),
+            }
+        ]
+        final_out = await client.generate(
+            final_messages,
+            sampling_params={**sampling_params, "max_new_tokens": MAX_FINAL_TOKENS},
+        )
+        turns.append(
+            {
+                "tokens": final_out.prompt_token_ids + final_out.token_ids,
+                "response_length": len(final_out.token_ids),
+                "loss_mask": [1] * len(final_out.token_ids),
+                "rollout_log_probs": final_out.log_probs,
+            }
+        )
+
+        sample.metadata["final_output"] = _strip_stop_tokens(final_out.response)
+        sample.train_metadata = {"turns": turns}
+
+        if os.environ.get("MEM_DEBUG"):
+            print(
+                f"[MemAgent] {len(chunks_ids)} chunks -> {len(turns)} turns, "
+                f"response_lengths={[t['response_length'] for t in turns]}"
+            )
+
+        first = turns[0]
+        first_prompt_len = len(first["tokens"]) - first["response_length"]
+        prompt_token_ids = first["tokens"][:first_prompt_len]
+
+        cat_token_ids: list[int] = []
+        cat_loss_mask: list[int] = []
+        cat_log_probs: list[float] = []
+        for t in turns:
+            p_len = len(t["tokens"]) - t["response_length"]
+            cat_token_ids += t["tokens"]
+            cat_loss_mask += [0] * p_len + t["loss_mask"]
+            cat_log_probs += [0.0] * p_len + t["rollout_log_probs"]
+
+        sample.prompt = final_messages[0]["content"]
+        sample.response = _strip_stop_tokens(final_out.response)
+        sample.tokens = prompt_token_ids + cat_token_ids
+        sample.response_length = len(cat_token_ids)
+        sample.loss_mask = cat_loss_mask
+        sample.rollout_log_probs = cat_log_probs
+        sample.status = Sample.Status.TRUNCATED if final_out.finish_reason == "length" else Sample.Status.COMPLETED
+
+    except Exception:
+        traceback.print_exc()
+        sample.response = ""
+        sample.rollout_log_probs = []
+        sample.status = Sample.Status.FAILED
+
+    return sample
+
+
+def _last_boxed_only_string(string: str) -> str | None:
+    if "\\boxed " in string:
+        return "\\boxed " + string.split("\\boxed ")[-1].split("$")[0]
+    idx = string.rfind("\\boxed")
+    if idx < 0:
+        idx = string.rfind("\\fbox")
+        if idx < 0:
+            return None
+    i, right_brace_idx, num_left_braces_open = idx, None, 0
+    while i < len(string):
+        if string[i] == "{":
+            num_left_braces_open += 1
+        if string[i] == "}":
+            num_left_braces_open -= 1
+            if num_left_braces_open == 0:
+                right_brace_idx = i
+                break
+        i += 1
+    return string[idx : right_brace_idx + 1] if right_brace_idx is not None else None
+
+
+def _remove_boxed(s: str) -> str:
+    if s.startswith("\\boxed "):
+        return s[len("\\boxed ") :]
+    left = "\\boxed{"
+    assert s.startswith(left) and s.endswith("}")
+    return s[len(left) : -1]
+
+
+def _extract_boxed(text: str) -> str:
+    s = _last_boxed_only_string(text)
+    if s is None:
+        return ""
+    try:
+        return _remove_boxed(s).strip()
+    except Exception:
+        return ""
+
+
+def _strip_string(string: str) -> str:
+    string = string.replace("\n", "")
+    string = string.replace("\\!", "")
+    string = string.replace("\\\\", "\\")
+    string = string.replace("tfrac", "frac")
+    string = string.replace("dfrac", "frac")
+    string = string.replace("\\left", "")
+    string = string.replace("\\right", "")
+    string = string.replace("^{\\circ}", "")
+    string = string.replace("^\\circ", "")
+    string = string.replace("\\$", "")
+    string = string.replace("\\%", "")
+    string = string.replace(" .", " 0.")
+    string = string.replace("{.", "{0.")
+    if len(string) == 0:
+        return string
+    return string.replace(" ", "")
+
+
+def _is_equiv(str1: str, str2: str) -> bool:
+    if str1 is None and str2 is None:
+        return True
+    if str1 is None or str2 is None:
+        return False
+    try:
+        return _strip_string(str1) == _strip_string(str2)
+    except Exception:
+        return str1 == str2
+
+
+async def reward_func(args: Any, sample: Any, **kwargs) -> dict:
+    metadata = sample.metadata if isinstance(sample.metadata, dict) else {}
+    final_output = metadata.get("final_output", "") or sample.response or ""
+    ground_truth = metadata.get("ground_truth", [])
+    if not ground_truth:
+        label = str(sample.label) if sample.label is not None else ""
+        ground_truth = [label] if label else []
+
+    solution_str = final_output[-300:].lower()
+    pred = _extract_boxed(solution_str) or ""
+
+    score = 0.0
+    for gt in ground_truth:
+        gt_lower = gt.lower()
+        try:
+            boxed = _last_boxed_only_string(solution_str)
+            if boxed is not None:
+                answer = _remove_boxed(boxed)
+                if _is_equiv(answer, gt_lower):
+                    score = 1.0
+                    break
+        except Exception:
+            pass
+
+    return {"score": score, "pred": pred, "gt": ground_truth[0] if ground_truth else ""}

--- a/examples/mem_agent/rollout.py
+++ b/examples/mem_agent/rollout.py
@@ -244,7 +244,7 @@ async def reward_func(args: Any, sample: Any, **kwargs) -> dict:
         label = str(sample.label) if sample.label is not None else ""
         ground_truth = [label] if label else []
 
-    solution_str = final_output[-300:].lower()
+    solution_str = final_output[-300:]
     pred = _extract_boxed(solution_str) or ""
 
     score = 0.0
@@ -254,7 +254,7 @@ async def reward_func(args: Any, sample: Any, **kwargs) -> dict:
             boxed = _last_boxed_only_string(solution_str)
             if boxed is not None:
                 answer = _remove_boxed(boxed)
-                if _is_equiv(answer, gt_lower):
+                if _is_equiv(answer.lower(), gt_lower):
                     score = 1.0
                     break
         except Exception:

--- a/examples/mem_agent/rollout_client.py
+++ b/examples/mem_agent/rollout_client.py
@@ -1,0 +1,84 @@
+"""Lightweight vLLM router client for MemAgent multi-turn rollouts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from vime.rollout.vllm_rollout import (
+    _align_engine_tokens_and_logprobs,
+    _build_inference_sampling_params,
+    _inference_generate_tokens_and_logprobs,
+)
+from vime.utils.http_utils import post
+
+
+@dataclass
+class GenerationOutput:
+    prompt_text: str
+    prompt_token_ids: list[int]
+    response: str
+    token_ids: list[int]
+    log_probs: list[float]
+    finish_reason: str
+
+
+class MemAgentRolloutClient:
+    """Wrap vLLM ``/inference/v1/generate`` for chat-style MemAgent turns."""
+
+    def __init__(self, args: Any, tokenizer: Any, sampling_params: dict):
+        self.base = f"http://{args.vllm_router_ip}:{args.vllm_router_port}"
+        self.model = args.hf_checkpoint
+        self.tokenizer = tokenizer
+        self.sampling_params = dict(sampling_params)
+
+    async def generate(
+        self,
+        messages: list[dict[str, str]],
+        sampling_params: dict | None = None,
+    ) -> GenerationOutput:
+        params = dict(self.sampling_params)
+        if sampling_params:
+            params.update(sampling_params)
+
+        prompt_text = self.tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        prompt_token_ids = self.tokenizer(prompt_text, add_special_tokens=False)["input_ids"]
+
+        payload = {
+            "model": self.model,
+            "token_ids": prompt_token_ids,
+            "sampling_params": _build_inference_sampling_params(params),
+        }
+        output = await post(f"{self.base}/inference/v1/generate", payload)
+        choice = output["choices"][0]
+
+        skip_sp = params.get("skip_special_tokens")
+        skip_decode = True if skip_sp is None else bool(skip_sp)
+        out_ids = choice.get("token_ids") or []
+        text = (
+            self.tokenizer.decode(out_ids, skip_special_tokens=skip_decode)
+            if isinstance(out_ids, list) and out_ids
+            else ""
+        )
+
+        token_ids, log_probs = _inference_generate_tokens_and_logprobs(choice)
+        token_ids, log_probs = _align_engine_tokens_and_logprobs(token_ids, log_probs)
+
+        fr = choice.get("finish_reason") or "stop"
+        if isinstance(fr, dict):
+            finish_reason = fr.get("type", "stop")
+        else:
+            finish_reason = "length" if fr == "length" else "stop"
+
+        return GenerationOutput(
+            prompt_text=prompt_text,
+            prompt_token_ids=prompt_token_ids,
+            response=text,
+            token_ids=token_ids,
+            log_probs=log_probs,
+            finish_reason=finish_reason,
+        )

--- a/examples/mem_agent/run-eval.sh
+++ b/examples/mem_agent/run-eval.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# MemAgent RULER-HQA evaluation via vLLM serve + eval_ruler_hqa.py.
+#
+# Usage:
+#   MODEL_PATH=/path/to/hf_ckpt bash examples/mem_agent/run-eval.sh
+#   CONVERT=1 SINGLE_ITER=iter_0000199 bash examples/mem_agent/run-eval.sh
+#   MODEL_PATH=/root/Qwen3-4B SAVE_FILE=Qwen3-4B-base bash examples/mem_agent/run-eval.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# shellcheck source=_common.sh
+source "${SCRIPT_DIR}/_common.sh"
+
+EVAL_PY="${MEM_AGENT_DIR}/eval_ruler_hqa.py"
+TP="${TP:-1}"
+SERVE_HOST="${SERVE_HOST:-127.0.0.1}"
+SERVE_PORT="${SERVE_PORT:-8000}"
+LENGTH="${LENGTH:-50 200 800}"
+SAVE_DIR="${SAVE_DIR:-${MEM_AGENT_DIR}/results}"
+API="${API:-recurrent}"
+N_PROC="${N_PROC:-16}"
+TEMPERATURE="${TEMPERATURE:-0.7}"
+TOP_P="${TOP_P:-0.95}"
+FORCE="${FORCE:-0}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-8192}"
+GPU_MEMORY_UTIL="${GPU_MEMORY_UTIL:-0.85}"
+
+CHECKPOINT_DIR="${CHECKPOINT_DIR:-${SAVE_PATH}}"
+SINGLE_ITER="${SINGLE_ITER:-iter_0000199}"
+CONVERT="${CONVERT:-0}"
+
+STAMP=$(date +%Y%m%d_%H%M%S)
+LOG_FILE="${SAVE_DIR}/eval_${STAMP}.log"
+mkdir -p "${SAVE_DIR}"
+
+exec > >(tee -a "${LOG_FILE}") 2>&1
+echo "=== MemAgent eval started at $(date) ==="
+echo "LOG_FILE=${LOG_FILE}"
+
+if [[ "${CONVERT}" == "1" ]]; then
+  echo "[step] Converting ${SINGLE_ITER} ..."
+  SINGLE_ITER="${SINGLE_ITER}" CHECKPOINT_DIR="${CHECKPOINT_DIR}" \
+    bash "${MEM_AGENT_DIR}/convert-to-hf.sh"
+  MODEL_PATH="${MODEL_PATH:-${CHECKPOINT_DIR}-HF/${SINGLE_ITER}}"
+fi
+
+if [[ -z "${MODEL_PATH:-}" ]]; then
+  echo "ERROR: MODEL_PATH is required."
+  echo "  MODEL_PATH=/path/to/hf_ckpt bash examples/mem_agent/run-eval.sh"
+  echo "  CONVERT=1 bash examples/mem_agent/run-eval.sh"
+  exit 1
+fi
+
+if [[ ! -d "${MODEL_PATH}" ]]; then
+  echo "ERROR: MODEL_PATH not found: ${MODEL_PATH}"
+  exit 1
+fi
+
+SAVE_FILE="${SAVE_FILE:-$(basename "${MODEL_PATH%/}")}"
+MODEL_NAME="${MODEL_PATH}"
+
+LENGTHS="${LENGTH}" bash "${MEM_AGENT_DIR}/prepare-eval-data.sh"
+
+export PYTHONPATH="/root/Megatron-LM:${VIME_ROOT}:${PYTHONPATH:-}"
+export VLLM_SERVE_HOST="${SERVE_HOST}" VLLM_SERVE_PORT="${SERVE_PORT}"
+export SERVE_HOST SERVE_PORT
+export DATAROOT="${DATA_ROOT}"
+
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+
+wait_for_server() {
+  local url="http://${SERVE_HOST}:${SERVE_PORT}/v1/models"
+  log "Waiting for vLLM at ${url} ..."
+  local attempts=0
+  while true; do
+    resp=$(curl -sf --max-time 10 "${url}" 2>/dev/null || true)
+    if echo "${resp}" | grep -Fq "${MODEL_NAME}" 2>/dev/null; then
+      log "vLLM ready."
+      break
+    fi
+    attempts=$((attempts + 1))
+    if (( attempts % 6 == 0 )); then
+      found=$(echo "${resp}" | grep -o '"id":"[^"]*"' 2>/dev/null | head -3 || echo "(no response)")
+      log "Still waiting... models: ${found}"
+    fi
+    sleep 5
+  done
+}
+
+kill_server() {
+  if [[ -n "${VLLM_PID:-}" ]]; then
+    log "Stopping vLLM (pid=${VLLM_PID}) ..."
+    kill -TERM "${VLLM_PID}" 2>/dev/null || true
+    wait "${VLLM_PID}" 2>/dev/null || true
+  fi
+}
+
+build_common_args() {
+  local extra=()
+  extra+=(--model "${MODEL_NAME}")
+  extra+=(--tokenizer "${MODEL_PATH}")
+  extra+=(--api "${API}")
+  extra+=(--n-proc "${N_PROC}")
+  extra+=(--temperature "${TEMPERATURE}")
+  extra+=(--top-p "${TOP_P}")
+  if [[ "${FORCE}" == "1" ]]; then
+    extra+=(--force)
+  fi
+  echo "${extra[@]}"
+}
+
+run_hqa() {
+  local common
+  read -ra common <<< "$(build_common_args)"
+  for length in ${LENGTH}; do
+    local subdir="${SAVE_DIR}/ruler_hqa_${length}"
+    log "==> ruler_hqa n_docs=${length}"
+    python3 "${EVAL_PY}" \
+      "${common[@]}" \
+      --length "${length}" \
+      --data-root "${DATA_ROOT}" \
+      --save-dir "${subdir}" \
+      --save-file "${SAVE_FILE}"
+  done
+}
+
+log "MODEL_PATH=${MODEL_PATH}"
+log "TP=${TP}  LENGTH=${LENGTH}  N_PROC=${N_PROC}"
+log "DATA_ROOT=${DATA_ROOT}  SAVE_DIR=${SAVE_DIR}"
+
+pkill -9 -f '[v]llm serve' 2>/dev/null || true
+sleep 2
+
+VLLM_LOG="${SAVE_DIR}/vllm_server_${STAMP}.log"
+log "Starting vLLM serve (tp=${TP}, port=${SERVE_PORT}, max_len=${MAX_MODEL_LEN}) ..."
+
+CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}" \
+  vllm serve "${MODEL_PATH}" \
+    --tensor-parallel-size "${TP}" \
+    --host "${SERVE_HOST}" \
+    --port "${SERVE_PORT}" \
+    --max-model-len "${MAX_MODEL_LEN}" \
+    --gpu-memory-utilization "${GPU_MEMORY_UTIL}" \
+    --trust-remote-code \
+    > "${VLLM_LOG}" 2>&1 &
+VLLM_PID=$!
+trap 'kill_server' EXIT INT TERM
+
+wait_for_server
+run_hqa
+
+log "=== Eval finished. Results: ${SAVE_DIR} ==="

--- a/examples/mem_agent/run-eval.sh
+++ b/examples/mem_agent/run-eval.sh
@@ -72,13 +72,22 @@ wait_for_server() {
   local url="http://${SERVE_HOST}:${SERVE_PORT}/v1/models"
   log "Waiting for vLLM at ${url} ..."
   local attempts=0
+  local max_attempts=120
   while true; do
+    if [[ -n "${VLLM_PID:-}" ]] && ! kill -0 "${VLLM_PID}" 2>/dev/null; then
+      log "ERROR: vLLM process (PID ${VLLM_PID}) died. See ${VLLM_LOG:-server log}."
+      exit 1
+    fi
     resp=$(curl -sf --max-time 10 "${url}" 2>/dev/null || true)
     if echo "${resp}" | grep -Fq "${MODEL_NAME}" 2>/dev/null; then
       log "vLLM ready."
       break
     fi
     attempts=$((attempts + 1))
+    if (( attempts >= max_attempts )); then
+      log "ERROR: vLLM not ready after ${max_attempts} attempts."
+      exit 1
+    fi
     if (( attempts % 6 == 0 )); then
       found=$(echo "${resp}" | grep -o '"id":"[^"]*"' 2>/dev/null | head -3 || echo "(no response)")
       log "Still waiting... models: ${found}"

--- a/examples/mem_agent/run-qwen3-4b-train.sh
+++ b/examples/mem_agent/run-qwen3-4b-train.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# MemAgent GRPO training — Qwen3-4B, vime + vLLM colocate.
+#
+# Usage:
+#   bash examples/mem_agent/run-qwen3-4b-train.sh
+#   NUM_ROLLOUT=200 SAVE_PATH=/path/to/save bash examples/mem_agent/run-qwen3-4b-train.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# shellcheck source=_common.sh
+source "${SCRIPT_DIR}/_common.sh"
+
+export NUM_ROLLOUT="${NUM_ROLLOUT:-100}"
+export ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:-8}"
+export N_SAMPLES_PER_PROMPT="${N_SAMPLES_PER_PROMPT:-8}"
+export GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:-64}"
+export SAVE_INTERVAL="${SAVE_INTERVAL:-50}"
+
+echo "=== MemAgent train NUM_ROLLOUT=${NUM_ROLLOUT} SAVE_PATH=${SAVE_PATH} ==="
+if [[ ! -f "${TRAIN_DATA}" ]]; then
+  echo "ERROR: training data not found: ${TRAIN_DATA}"
+  exit 1
+fi
+
+mem_agent_detect_nvlink
+mem_agent_detect_gpus
+mem_agent_cleanup
+mem_agent_launch_train
+
+echo "=== MemAgent train finished ==="


### PR DESCRIPTION
## Summary
Add \`examples/mem_agent\`, a vime port of [MemAgent](https://arxiv.org/abs/2507.02259) for long-context QA with RL:
- **Multi-turn rollout**: chunk-wise memory update + final \`\\boxed{}\` answer (HotpotQA reward)
- **Training**: GRPO on Qwen3-4B via vLLM colocate (\`run-qwen3-4b-train.sh\`)
- **Evaluation**: RULER-HQA offline eval via vLLM serve (\`run-eval.sh\`, \`eval_ruler_hqa.py\`)
- **Data prep**: HuggingFace dataset \`BytedTsinghua-SIA/hotpotqa\` -> training JSONL + eval JSON download
Also updates \`examples/README.md\` with a directory entry.
## Files
| File | Description |
|------|-------------|
| \`rollout.py\` / \`rollout_client.py\` | Multi-turn MemAgent rollout + vLLM router client |
| \`custom_convert.py\` | Unroll trajectories for GRPO |
| \`prepare_data.py\` / \`prepare-eval-data.sh\` | Training and eval data preparation |
| \`eval_ruler_hqa.py\` / \`run-eval.sh\` | RULER-HQA evaluation |
| \`run-qwen3-4b-train.sh\` / \`_common.sh\` | GRPO training launch scripts |
| \`convert-to-hf.sh\` | Megatron checkpoint -> HuggingFace |
See \`examples/mem_agent/README.md\` for quick start (data download, training, eval).
## Test plan
- [x] Pre-commit passed (ruff, isort, black)
- [x] GRPO training smoke on H800 (Qwen3-4B, colocate vLLM)
- [x] RULER-HQA eval at n_docs = 50 / 200 / 800 (RL checkpoint vs base Qwen3-4B)
- [x] CI (await upstream checks)