### PR TITLE
fix(rollout): Resume vLLM workers before draining in abort

### DIFF
--- a/tests/test_vllm_rollout.py
+++ b/tests/test_vllm_rollout.py
@@ -542,5 +542,84 @@ def test_eval_rollout_passk_requests_do_not_share_session_ids(patch_generate_sta
     assert result[dataset_cfg.name]["samples"][0].session_id != result[dataset_cfg.name]["samples"][1].session_id
 
 
+@pytest.mark.unit
+def test_abort_resumes_workers_before_draining(patch_generate_state, monkeypatch):
+    state = _PatchedGenerateState(_rollout_args())
+    monkeypatch.setattr(mod, "GenerateState", lambda args: state)
+
+    resumed = asyncio.Event()
+    call_order: list[str] = []
+
+    async def fake_get(url):
+        return {"workers": [{"url": "http://w0:9000"}]}
+
+    async def fake_post(url, payload, max_retries=60, headers=None):
+        if url.endswith("/resume"):
+            call_order.append("resume")
+            resumed.set()
+        else:
+            call_order.append("pause")
+        return {}
+
+    monkeypatch.setattr(mod, "get", fake_get)
+    monkeypatch.setattr(mod, "post", fake_post)
+
+    sample = Sample(index=0, prompt="p")
+
+    async def pending_group():
+        # Mirrors an in-flight generate POST wedged on the paused worker: it only
+        # returns once the worker is resumed.
+        await resumed.wait()
+        sample.status = Sample.Status.ABORTED
+        return [sample]
+
+    async def run_abort():
+        state.pendings = {asyncio.create_task(pending_group())}
+        return await asyncio.wait_for(mod.abort(_rollout_args(), rollout_id=0), timeout=5.0)
+
+    aborted_samples = asyncio.run(run_abort())
+
+    assert call_order == ["pause", "resume"]
+    assert state.pendings == set()
+    # partial_rollout is off by default, so drained groups are discarded, not returned.
+    assert aborted_samples == []
+
+
+@pytest.mark.unit
+def test_abort_collects_partial_samples_when_partial_rollout(patch_generate_state, monkeypatch):
+    args = _rollout_args(partial_rollout=True)
+    state = _PatchedGenerateState(args)
+    monkeypatch.setattr(mod, "GenerateState", lambda a: state)
+
+    resumed = asyncio.Event()
+
+    async def fake_get(url):
+        return {"workers": [{"url": "http://w0:9000"}]}
+
+    async def fake_post(url, payload, max_retries=60, headers=None):
+        if url.endswith("/resume"):
+            resumed.set()
+        return {}
+
+    monkeypatch.setattr(mod, "get", fake_get)
+    monkeypatch.setattr(mod, "post", fake_post)
+
+    sample = Sample(index=0, prompt="p")
+    sample.response = "partial"
+
+    async def pending_group():
+        await resumed.wait()
+        return [sample]
+
+    async def run_abort():
+        state.pendings = {asyncio.create_task(pending_group())}
+        return await asyncio.wait_for(mod.abort(args, rollout_id=7), timeout=5.0)
+
+    aborted_samples = asyncio.run(run_abort())
+
+    assert aborted_samples == [[sample]]
+    assert sample.metadata["start_rollout_id"] == 7
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))

--- a/tests/test_vllm_rollout.py
+++ b/tests/test_vllm_rollout.py
@@ -567,8 +567,8 @@ def test_abort_resumes_workers_before_draining(patch_generate_state, monkeypatch
     sample = Sample(index=0, prompt="p")
 
     async def pending_group():
-        # Mirrors an in-flight generate POST wedged on the paused worker: it only
-        # returns once the worker is resumed.
+        # Models a generate POST that raced in after mode=abort: under PAUSED_NEW it
+        # parks in the scheduler's waiting queue and only returns once /resume reopens it.
         await resumed.wait()
         sample.status = Sample.Status.ABORTED
         return [sample]

--- a/vime/rollout/vllm_rollout.py
+++ b/vime/rollout/vllm_rollout.py
@@ -516,6 +516,15 @@ async def generate_and_rm_group(
     return group
 
 
+async def _broadcast_to_workers(urls: list[str], endpoint: str, action: str) -> None:
+    """POST a no-body control endpoint to every worker, logging (not raising) failures."""
+    tasks = [post(f"{url.rstrip('/')}/{endpoint}", {}, max_retries=3) for url in urls]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    for url, result in zip(urls, results, strict=False):
+        if isinstance(result, Exception):
+            logger.warning("Failed to %s worker at %s: %s", action, url, result)
+
+
 async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
     aborted_samples: list[list[Sample]] = []
 
@@ -532,8 +541,10 @@ async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
             response = await get(f"{base}/list_workers")
             urls = list(response["urls"])
 
-        # mode=abort aborts the running request but leaves the worker paused; resume here,
-        # before draining, so the aborted requests return and the drain below can progress.
+        # mode=abort answers all requests the worker already knows about but sets PAUSED_NEW:
+        # the scheduler stops promoting the waiting queue until /resume. A /generate POST that
+        # races in after the pause parks in `waiting` and never returns (client timeout is
+        # None), so resume before draining — otherwise `while state.pendings` hangs on it.
         logger.info(f"Abort request for {urls}")
         pause_tasks = [post(f"{url.rstrip('/')}/pause?mode=abort", {}, max_retries=3) for url in urls]
         pause_results = await asyncio.gather(*pause_tasks, return_exceptions=True)

--- a/vime/rollout/vllm_rollout.py
+++ b/vime/rollout/vllm_rollout.py
@@ -523,8 +523,6 @@ async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
     assert not state.aborted
     state.aborted = True
 
-    urls: list[str] = []
-    paused_workers = False
     if state.pendings:
         base = f"http://{args.vllm_router_ip}:{args.vllm_router_port}"
         try:
@@ -534,13 +532,21 @@ async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
             response = await get(f"{base}/list_workers")
             urls = list(response["urls"])
 
+        # mode=abort aborts the running request but leaves the worker paused; resume here,
+        # before draining, so the aborted requests return and the drain below can progress.
         logger.info(f"Abort request for {urls}")
         pause_tasks = [post(f"{url.rstrip('/')}/pause?mode=abort", {}, max_retries=3) for url in urls]
         pause_results = await asyncio.gather(*pause_tasks, return_exceptions=True)
         for url, result in zip(urls, pause_results, strict=False):
             if isinstance(result, Exception):
                 logger.warning(f"Failed to abort worker at {url}: {result}")
-        paused_workers = True
+
+        logger.info("rollout: resuming workers before abort drain: %s", urls)
+        resume_tasks = [post(f"{url.rstrip('/')}/resume", {}, max_retries=3) for url in urls]
+        resume_results = await asyncio.gather(*resume_tasks, return_exceptions=True)
+        for url, result in zip(urls, resume_results, strict=False):
+            if isinstance(result, Exception):
+                logger.warning("Failed to resume worker at %s: %s", url, result)
 
     count = 0
     while state.pendings:
@@ -561,13 +567,6 @@ async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
         logger.info(f"Collected {count} partial samples into the data buffer")
 
     state.pendings = set()
-    if paused_workers:
-        logger.info("rollout: resuming workers after abort drain: %s", urls)
-        resume_tasks = [post(f"{url.rstrip('/')}/resume", {}, max_retries=3) for url in urls]
-        resume_results = await asyncio.gather(*resume_tasks, return_exceptions=True)
-        for url, result in zip(urls, resume_results, strict=False):
-            if isinstance(result, Exception):
-                logger.warning("Failed to resume worker at %s: %s", url, result)
 
     return aborted_samples
 

--- a/vime/rollout/vllm_rollout.py
+++ b/vime/rollout/vllm_rollout.py
@@ -518,11 +518,12 @@ async def generate_and_rm_group(
 
 async def _broadcast_to_workers(urls: list[str], endpoint: str, action: str) -> None:
     """POST a no-body control endpoint to every worker, logging (not raising) failures."""
+    logger.info(f"rollout: {action} workers: {urls}")
     tasks = [post(f"{url.rstrip('/')}/{endpoint}", {}, max_retries=3) for url in urls]
     results = await asyncio.gather(*tasks, return_exceptions=True)
     for url, result in zip(urls, results, strict=False):
         if isinstance(result, Exception):
-            logger.warning("Failed to %s worker at %s: %s", action, url, result)
+            logger.warning(f"Failed to {action} worker at {url}: {result}")
 
 
 async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
@@ -545,19 +546,8 @@ async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
         # the scheduler stops promoting the waiting queue until /resume. A /generate POST that
         # races in after the pause parks in `waiting` and never returns (client timeout is
         # None), so resume before draining — otherwise `while state.pendings` hangs on it.
-        logger.info(f"Abort request for {urls}")
-        pause_tasks = [post(f"{url.rstrip('/')}/pause?mode=abort", {}, max_retries=3) for url in urls]
-        pause_results = await asyncio.gather(*pause_tasks, return_exceptions=True)
-        for url, result in zip(urls, pause_results, strict=False):
-            if isinstance(result, Exception):
-                logger.warning(f"Failed to abort worker at {url}: {result}")
-
-        logger.info("rollout: resuming workers before abort drain: %s", urls)
-        resume_tasks = [post(f"{url.rstrip('/')}/resume", {}, max_retries=3) for url in urls]
-        resume_results = await asyncio.gather(*resume_tasks, return_exceptions=True)
-        for url, result in zip(urls, resume_results, strict=False):
-            if isinstance(result, Exception):
-                logger.warning("Failed to resume worker at %s: %s", url, result)
+        await _broadcast_to_workers(urls, "pause?mode=abort", "abort")
+        await _broadcast_to_workers(urls, "resume", "resume")
 
     count = 0
     while state.pendings:


### PR DESCRIPTION
`abort()` ordered the worker calls as pause → drain → resume, which can hang the rollout under `--partial-rollout` with continuously-submitting (e.g. multi-turn) rollouts.

The call to `/pause?mode=abort` aborts the known requests but leaves the engine in`PAUSED_NEW` status, so a `/generate` POST that races in after the pause ends up in the waiting queue and never returns. One such request blocks the `while state.pendings` drain forever - and `/resume`, the only thing that frees it, sat after the drain.


The fix here is to reorder to pause → resume → drain so the parked requests get scheduled and return, letting the drain complete. Tasks still queued on the semaphore short-circuit on `state.aborted`, so nothing new is generated.