### PR TITLE
[Doc] Fix broken Qwen3-4B example link in rollout_buffer README

### DIFF
--- a/vime_plugins/rollout_buffer/README.md
+++ b/vime_plugins/rollout_buffer/README.md
@@ -40,7 +40,7 @@ In addition, Rollout Buffer also provides some customizable functions to meet sp
 
 ### Example Script
 
-First, you need to follow [Example: Qwen3-4B Model](../../docs/en/models/qwen3-4B.md) to configure the environment, download data and convert model checkpoints. And then run the following scripts:
+First, you need to follow [Example: Qwen3-4B Model](../../docs/en/examples/qwen3-4B.md) to configure the environment, download data and convert model checkpoints. And then run the following scripts:
 ```bash
 cd vime_plugins/rollout_buffer
 bash rollout_buffer_example.sh

--- a/vime_plugins/rollout_buffer/README_zh.md
+++ b/vime_plugins/rollout_buffer/README_zh.md
@@ -40,7 +40,7 @@ generator/
 
 ### 示例脚本
 
-请仿照 [示例：Qwen3-4B 模型](../../docs/zh/models/qwen3-4B.md) 文档中配置好 vime 的运行环境，下载数据，并转换模型 ckpt。之后分别运行
+请仿照 [示例：Qwen3-4B 模型](../../docs/zh/examples/qwen3-4B.md) 文档中配置好 vime 的运行环境，下载数据，并转换模型 ckpt。之后分别运行
 
 ```bash
 cd vime_plugins/rollout_buffer


### PR DESCRIPTION
## Summary

The Rollout Buffer plugin README (both English and Chinese) links to the
Qwen3-4B setup doc at `docs/{en,zh}/models/qwen3-4B.md`, but there is no
`models/` directory in `docs/`. The referenced doc actually lives under
`examples/`:

- `docs/en/examples/qwen3-4B.md`
- `docs/zh/examples/qwen3-4B.md`

So the "Example Script" setup link in both files is broken (404 in the
rendered docs / on GitHub). This PR repoints both links to the correct
`examples/` path.

## Changes

- `vime_plugins/rollout_buffer/README.md`: `docs/en/models/qwen3-4B.md` → `docs/en/examples/qwen3-4B.md`
- `vime_plugins/rollout_buffer/README_zh.md`: `docs/zh/models/qwen3-4B.md` → `docs/zh/examples/qwen3-4B.md`

## Verification

- Confirmed `docs/en/examples/qwen3-4B.md` and `docs/zh/examples/qwen3-4B.md` exist.
- Confirmed no `docs/{en,zh}/models/` directory exists.
- Docs-only change; no code paths affected.

## AI assistance disclosure

This contribution was prepared with AI assistance (Claude Code). The broken
link was identified by scanning the repo's markdown for relative links whose
targets do not exist, and the fix was verified locally against the actual
`docs/` tree.
