### PR TITLE
fix(rollout): abort vLLM rollout via delete-type /abort_requests

### DIFF
--- a/docker/patch/latest/vllm.patch
+++ b/docker/patch/latest/vllm.patch
@@ -52,3 +52,46 @@ diff --git a/vllm/model_executor/layers/fused_moe/all2all_utils.py b/vllm/model_
          if quant_config.quant_dtype is None:
              dispatch_dtype_bytes_per_elem = 2
              dispatch_scale_bytes_per_token = 0
+
+diff --git a/vllm/entrypoints/serve/dev/rlhf/api_router.py b/vllm/entrypoints/serve/dev/rlhf/api_router.py
+--- a/vllm/entrypoints/serve/dev/rlhf/api_router.py
++++ b/vllm/entrypoints/serve/dev/rlhf/api_router.py
+@@ -91,6 +91,38 @@ async def resume_generation(raw_request: Request) -> JSONResponse:
+         )
+ 
+ 
++@router.post("/abort_requests")
++async def abort_requests(raw_request: Request) -> JSONResponse:
++    """Abort in-flight requests without pausing the scheduler.
++
++    Empty/missing ``request_ids`` aborts all in-flight requests.
++    """
++
++    engine = engine_client(raw_request)
++
++    try:
++        body = await raw_request.json()
++    except json.JSONDecodeError:
++        body = {}
++
++    request_ids = body.get("request_ids")
++    if not request_ids:
++        request_ids = list(engine.output_processor.request_states.keys())
++
++    try:
++        await engine.abort(request_ids)
++        return JSONResponse(
++            content={"status": "aborted", "aborted": len(request_ids)},
++            status_code=HTTPStatus.OK.value,
++        )
++    except Exception as err:  # pragma: no cover - defensive
++        logger.exception("Failed to abort requests")
++        return JSONResponse(
++            content={"error": f"Failed to abort requests: {err}"},
++            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
++        )
++
++
+ @router.get("/is_paused")
+ async def is_paused(raw_request: Request) -> JSONResponse:
+     """Return the current pause status."""

--- a/tests/test_vllm_rollout.py
+++ b/tests/test_vllm_rollout.py
@@ -542,5 +542,87 @@ def test_eval_rollout_passk_requests_do_not_share_session_ids(patch_generate_sta
     assert result[dataset_cfg.name]["samples"][0].session_id != result[dataset_cfg.name]["samples"][1].session_id
 
 
+@pytest.mark.unit
+def test_abort_deletes_inflight_without_pause_resume(patch_generate_state, monkeypatch):
+    from vime.backends.vllm_utils import server_control
+
+    state = _PatchedGenerateState(_rollout_args())
+    monkeypatch.setattr(mod, "GenerateState", lambda args: state)
+
+    aborted = asyncio.Event()
+    posted_paths: list[str] = []
+
+    async def fake_get(url):
+        return {"workers": [{"url": "http://w0:9000"}]}
+
+    async def fake_post(url, payload, max_retries=60, headers=None):
+        posted_paths.append(url)
+        if url.endswith("/abort_requests"):
+            aborted.set()
+        return {}
+
+    monkeypatch.setattr(mod, "get", fake_get)
+    # abort() drives the delete-type sweep through the server_control helper.
+    monkeypatch.setattr(server_control, "post", fake_post)
+
+    sample = Sample(index=0, prompt="p")
+
+    async def pending_group():
+        # Delete-type abort makes the in-flight /generate return on its own.
+        await aborted.wait()
+        sample.status = Sample.Status.ABORTED
+        return [sample]
+
+    async def run_abort():
+        state.pendings = {asyncio.create_task(pending_group())}
+        return await asyncio.wait_for(mod.abort(_rollout_args(), rollout_id=0), timeout=5.0)
+
+    aborted_samples = asyncio.run(run_abort())
+
+    # Only /abort_requests is posted -- never /pause or /resume.
+    assert posted_paths and all(u.endswith("/abort_requests") for u in posted_paths)
+    assert state.pendings == set()
+    # partial_rollout is off by default, so drained groups are discarded, not returned.
+    assert aborted_samples == []
+
+
+@pytest.mark.unit
+def test_abort_collects_partial_samples_when_partial_rollout(patch_generate_state, monkeypatch):
+    from vime.backends.vllm_utils import server_control
+
+    args = _rollout_args(partial_rollout=True)
+    state = _PatchedGenerateState(args)
+    monkeypatch.setattr(mod, "GenerateState", lambda a: state)
+
+    aborted = asyncio.Event()
+
+    async def fake_get(url):
+        return {"workers": [{"url": "http://w0:9000"}]}
+
+    async def fake_post(url, payload, max_retries=60, headers=None):
+        if url.endswith("/abort_requests"):
+            aborted.set()
+        return {}
+
+    monkeypatch.setattr(mod, "get", fake_get)
+    monkeypatch.setattr(server_control, "post", fake_post)
+
+    sample = Sample(index=0, prompt="p")
+    sample.response = "partial"
+
+    async def pending_group():
+        await aborted.wait()
+        return [sample]
+
+    async def run_abort():
+        state.pendings = {asyncio.create_task(pending_group())}
+        return await asyncio.wait_for(mod.abort(args, rollout_id=7), timeout=5.0)
+
+    aborted_samples = asyncio.run(run_abort())
+
+    assert aborted_samples == [[sample]]
+    assert sample.metadata["start_rollout_id"] == 7
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))

--- a/vime/backends/vllm_utils/server_control.py
+++ b/vime/backends/vllm_utils/server_control.py
@@ -1,67 +1,24 @@
+"""Control-plane helper for aborting in-flight requests on vLLM workers."""
+
 import asyncio
 import logging
-from typing import Any
 
-from vime.utils.http_utils import get, post
+from vime.utils.http_utils import post
 
 logger = logging.getLogger(__name__)
 
-ABORT_RETRY_INTERVAL_SECONDS = 3
 
+async def abort_inflight_requests(urls: list[str]) -> None:
+    """Abort all in-flight requests on each worker (one best-effort sweep).
 
-def num_requests_from_load(load: Any) -> int:
-    if isinstance(load, list):
-        return sum(num_requests_from_load(item) for item in load)
+    Posts to ``/abort_requests`` with an empty body; failures are logged, not
+    raised. Idempotent, so the caller may re-issue it to converge.
+    """
 
-    if not isinstance(load, dict):
-        return 0
-
-    if "loads" in load:
-        return num_requests_from_load(load["loads"])
-
-    for key in ("num_reqs", "num_total_reqs", "total_reqs"):
-        value = load.get(key)
-        if isinstance(value, int):
-            return value
-
-    running = load.get("num_running_reqs", load.get("total_running_reqs"))
-    waiting = load.get("num_waiting_reqs", load.get("total_waiting_reqs"))
-    return (running if isinstance(running, int) else 0) + (waiting if isinstance(waiting, int) else 0)
-
-
-async def _abort_server_once(url: str) -> None:
-    try:
-        await post(f"{url}/abort_request", {"abort_all": True})
-    except Exception as e:
-        logger.warning(f"Failed to abort vLLM server at {url}: {e}")
-
-
-async def _get_server_num_requests(url: str) -> int:
-    return num_requests_from_load(await get(f"{url}/v1/loads?include=core"))
-
-
-async def abort_server_until_idle(url: str, retry_interval: int = ABORT_RETRY_INTERVAL_SECONDS) -> None:
-    attempt = 1
-    while True:
-        logger.info(f"Abort request for vLLM server {url}")
-        await _abort_server_once(url)
-
+    async def _abort_one(url: str) -> None:
         try:
-            num_requests = await _get_server_num_requests(url)
+            await post(f"{url.rstrip('/')}/abort_requests", {}, max_retries=3)
         except Exception as e:
-            logger.warning(f"Failed to get vLLM server load from {url}: {e}")
-            return
+            logger.warning(f"Failed to abort requests on {url}: {e}")
 
-        if num_requests <= 0:
-            return
-
-        logger.info(
-            f"vLLM server {url} still has {num_requests} requests after abort attempt {attempt}; "
-            f"retrying in {retry_interval} seconds."
-        )
-        await asyncio.sleep(retry_interval)
-        attempt += 1
-
-
-async def abort_servers_until_idle(urls: list[str]) -> None:
-    await asyncio.gather(*(abort_server_until_idle(url) for url in urls))
+    await asyncio.gather(*(_abort_one(url) for url in urls))

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -207,32 +207,23 @@ class VLLMEngine(RayActor):
             return
 
         if self.node_rank == 0 and self.router_ip and self.router_port:
-            import vllm_router
-            from packaging.version import parse
-
             worker_url = f"http://{self.server_host}:{self.server_port}"
-            if parse(vllm_router.__version__) <= parse("0.2.1"):
-                assert self.worker_type == "regular", "pd disaggregation is not supported in old router."
-                response = requests.post(
-                    f"http://{self.router_ip}:{self.router_port}/add_worker?url={worker_url}",
-                )
-            else:
-                payload = {
-                    "url": worker_url,
-                    "worker_type": self.worker_type,
-                }
-                if self.worker_type == "prefill":
-                    bootstrap_port = server_args_dict.get("disaggregation_bootstrap_port")
-                    if bootstrap_port is None:
-                        raise RuntimeError(
-                            f"Prefill worker {worker_url} does not have disaggregation_bootstrap_port; "
-                            "cannot register it to the PD router."
-                        )
-                    payload["bootstrap_port"] = bootstrap_port
-                response = requests.post(
-                    f"http://{self.router_ip}:{self.router_port}/workers",
-                    json=payload,
-                )
+            payload = {
+                "url": worker_url,
+                "worker_type": self.worker_type,
+            }
+            if self.worker_type == "prefill":
+                bootstrap_port = server_args_dict.get("disaggregation_bootstrap_port")
+                if bootstrap_port is None:
+                    raise RuntimeError(
+                        f"Prefill worker {worker_url} does not have disaggregation_bootstrap_port; "
+                        "cannot register it to the PD router."
+                    )
+                payload["bootstrap_port"] = bootstrap_port
+            response = requests.post(
+                f"http://{self.router_ip}:{self.router_port}/workers",
+                json=payload,
+            )
             response.raise_for_status()
 
     def _make_request(self, endpoint: str, payload: dict | None = None):

--- a/vime/rollout/vllm_rollout.py
+++ b/vime/rollout/vllm_rollout.py
@@ -15,6 +15,7 @@ import numpy as np
 import vllm_router  # noqa: F401 — ensures vllm-router is importable on startup
 from tqdm import tqdm
 
+from vime.backends.vllm_utils.server_control import abort_inflight_requests
 from vime.rollout.base_types import RolloutFnEvalOutput, RolloutFnTrainOutput
 from vime.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
 from vime.utils.async_utils import run
@@ -38,6 +39,9 @@ __all__ = ["generate_rollout", "get_model_url"]
 logger = logging.getLogger(__name__)
 
 _PROCESSOR_PROMPT_KEYS = {"input_ids", "attention_mask"}
+
+# Re-sweep interval while draining; bounds how long a late straggler can run.
+_ABORT_RESWEEP_INTERVAL_S = 3.0
 
 
 def _coerce_flat_int_token_ids(ids: Any) -> list[int]:
@@ -518,35 +522,36 @@ async def generate_and_rm_group(
 
 
 async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
-    aborted_samples: list[list[Sample]] = []
+    aborted_samples = []
 
     state = GenerateState(args)
     assert not state.aborted
     state.aborted = True
 
-    urls: list[str] = []
-    paused_workers = False
+    loop = asyncio.get_running_loop()
     if state.pendings:
         base = f"http://{args.vllm_router_ip}:{args.vllm_router_port}"
-        try:
-            response = await get(f"{base}/workers")
-            urls = [worker["url"] for worker in response["workers"]]
-        except Exception:
-            response = await get(f"{base}/list_workers")
-            urls = list(response["urls"])
+        response = await get(f"{base}/workers")
+        urls = [worker["url"] for worker in response["workers"]]
 
-        logger.info(f"Abort request for {urls}")
-        pause_tasks = [post(f"{url.rstrip('/')}/pause?mode=abort", {}, max_retries=3) for url in urls]
-        pause_results = await asyncio.gather(*pause_tasks, return_exceptions=True)
-        for url, result in zip(urls, pause_results, strict=False):
-            if isinstance(result, Exception):
-                logger.warning(f"Failed to abort worker at {url}: {result}")
-        paused_workers = True
+        # Delete-type abort: drop in-flight requests without pausing the scheduler.
+        await abort_inflight_requests(urls)
+        last_sweep = loop.time()
 
     # make sure all the pending tasks are finished
     count = 0
     while state.pendings:
-        done, state.pendings = await asyncio.wait(state.pendings, return_when=asyncio.FIRST_COMPLETED)
+        done, state.pendings = await asyncio.wait(
+            state.pendings,
+            timeout=_ABORT_RESWEEP_INTERVAL_S,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        # Re-sweep on a fixed interval to truncate late stragglers (e.g. a
+        # multi-turn turn-2 fired after the initial abort), regardless of drain.
+        if loop.time() - last_sweep >= _ABORT_RESWEEP_INTERVAL_S:
+            await abort_inflight_requests(urls)
+            last_sweep = loop.time()
 
         if not args.partial_rollout:
             continue
@@ -562,15 +567,6 @@ async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
 
     if args.partial_rollout:
         logger.info(f"Collected {count} partial samples into the data buffer")
-
-    state.pendings = set()
-    if paused_workers:
-        logger.info("rollout: resuming workers after abort drain: %s", urls)
-        resume_tasks = [post(f"{url.rstrip('/')}/resume", {}, max_retries=3) for url in urls]
-        resume_results = await asyncio.gather(*resume_tasks, return_exceptions=True)
-        for url, result in zip(urls, resume_results, strict=False):
-            if isinstance(result, Exception):
-                logger.warning("Failed to resume worker at %s: %s", url, result)
 
     return aborted_samples
 


### PR DESCRIPTION
## What

Replace the pause/resume-based rollout abort with a **delete-type** abort, so that under `--partial-rollout` the long tail is **truncated to partial** (and resumable next step) instead of either deadlocking or running to completion.

