### PR TITLE
[Bugfix][Rollout] Wire prefix_cache_hit_rate through vLLM usage

### DIFF
--- a/docker/patch/latest/vllm.patch
+++ b/docker/patch/latest/vllm.patch
@@ -95,3 +95,16 @@ diff --git a/vllm/entrypoints/serve/dev/rlhf/api_router.py b/vllm/entrypoints/se
  @router.get("/is_paused")
  async def is_paused(raw_request: Request) -> JSONResponse:
      """Return the current pause status."""
+diff --git a/vllm/entrypoints/serve/disagg/protocol.py b/vllm/entrypoints/serve/disagg/protocol.py
+index 60d2a64..67f3f98 100644
+--- a/vllm/entrypoints/serve/disagg/protocol.py
++++ b/vllm/entrypoints/serve/disagg/protocol.py
+@@ -203,6 +203,8 @@ class GenerateResponse(BaseModel):
+     )
+     choices: list[GenerateResponseChoice]
+ 
++    usage: UsageInfo | None = Field(default=None)
++
+     prompt_logprobs: list[dict[int, Logprob] | None] | None = None
+ 
+     kv_transfer_params: dict[str, Any] | None = Field(

--- a/vime/rollout/vllm_rollout.py
+++ b/vime/rollout/vllm_rollout.py
@@ -388,6 +388,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
     if usage:
         meta["prompt_tokens"] = usage.get("prompt_tokens", 0)
         meta["completion_tokens"] = usage.get("completion_tokens", 0)
+        meta["cached_tokens"] = (usage.get("prompt_tokens_details") or {}).get("cached_tokens", 0)
 
     # MoE routing replay: vLLM ships routed_experts as a base64 .npy blob on the choice;
     # decode here and route through meta_info. #183: guard on value (null when replay off).

--- a/vime/rollout/vllm_streaming_rollout.py
+++ b/vime/rollout/vllm_streaming_rollout.py
@@ -140,6 +140,8 @@ async def generate_streaming(args: Namespace, sample: Sample, sampling_params: d
             "stream": True,
         }
 
+    payload["stream_options"] = {"include_usage": True}
+
     # Snapshot pre-call sample state. vLLM's SSE chunks are *deltas* within this
     # call; on each chunk we append the delta and rebuild the post-call view of
     # the sample = prior state + accumulated deltas. A mid-stream break leaves
@@ -249,6 +251,7 @@ async def generate_streaming(args: Namespace, sample: Sample, sampling_params: d
         if last_usage:
             meta["prompt_tokens"] = last_usage.get("prompt_tokens", 0)
             meta["completion_tokens"] = last_usage.get("completion_tokens", 0)
+            meta["cached_tokens"] = (last_usage.get("prompt_tokens_details") or {}).get("cached_tokens", 0)
         if new_response_tokens:
             meta["output_token_logprobs"] = [
                 [float(lp), int(tid)] for lp, tid in zip(new_response_log_probs, new_response_tokens, strict=True)


### PR DESCRIPTION
## Summary

`rollout/prefix_cache_hit_rate` (and `avg_cached_tokens_per_sample`) were **structurally 0**. Root cause is three coupled gaps at the vime↔vLLM interface:

1. **vLLM drops `usage` on the non-streaming endpoint.** `/inference/v1/generate`'s `serve_tokens_full_generator` builds a `usage` block (incl. `prompt_tokens_details.cached_tokens`, since vime already passes `--enable-prompt-tokens-details`) but hands it to `GenerateResponse(..., usage=usage, ...)` — and `GenerateResponse` (v0.23.0 `serve/disagg/protocol.py`) never declared a `usage` field, so pydantic silently discards it. vime's parser gets `usage=None` → both numerator and denominator are 0. Patched in `docker/patch/latest/vllm.patch` for the pinned v0.23.0 base image (mirrors `GenerateStreamResponse`).
2. **Parser never read the cached count.** `vllm_rollout` / `vllm_streaming_rollout` read `usage.prompt_tokens`/`completion_tokens` but not `usage.prompt_tokens_details.cached_tokens` → `PrefixCacheInfo` numerator pinned to 0. Now read in both paths.
3. **Streaming needs `stream_options.include_usage=True`** for vLLM to emit the terminal usage SSE chunk.

## Upstream

The vLLM-side field omission is filed upstream against `vllm-project/vllm` (branch `aoshen02:fix/token-in-token-out-generate-usage`). The docker patch here is the interim fix so the deployed image reports the metric without waiting for an upstream release.

## Test plan

Not runnable on the current GPU-less edit host; requires a live rollout with prefix caching to confirm a non-zero `rollout/prefix_cache_hit_rate`.
