### PR TITLE
docker: rebase vllm.patch onto vLLM 0.24.0 (drop sleep hunk, add abort+usage)

### DIFF
--- a/docker/patch/latest/vllm.patch
+++ b/docker/patch/latest/vllm.patch
@@ -20,3 +20,59 @@ diff --git a/vllm/model_executor/layers/fused_moe/all2all_utils.py b/vllm/model_
          if quant_config.quant_dtype is None:
              dispatch_dtype_bytes_per_elem = 2
              dispatch_scale_bytes_per_token = 0
+
+diff --git a/vllm/entrypoints/serve/dev/rlhf/api_router.py b/vllm/entrypoints/serve/dev/rlhf/api_router.py
+--- a/vllm/entrypoints/serve/dev/rlhf/api_router.py
++++ b/vllm/entrypoints/serve/dev/rlhf/api_router.py
+@@ -91,6 +91,38 @@ async def resume_generation(raw_request: Request) -> JSONResponse:
+         )
+ 
+ 
++@router.post("/abort_requests")
++async def abort_requests(raw_request: Request) -> JSONResponse:
++    """Abort in-flight requests without pausing the scheduler.
++
++    Empty/missing ``request_ids`` aborts all in-flight requests.
++    """
++
++    engine = engine_client(raw_request)
++
++    try:
++        body = await raw_request.json()
++    except json.JSONDecodeError:
++        body = {}
++
++    request_ids = body.get("request_ids")
++    if not request_ids:
++        request_ids = list(engine.output_processor.request_states.keys())
++
++    try:
++        await engine.abort(request_ids)
++        return JSONResponse(
++            content={"status": "aborted", "aborted": len(request_ids)},
++            status_code=HTTPStatus.OK.value,
++        )
++    except Exception as err:  # pragma: no cover - defensive
++        logger.exception("Failed to abort requests")
++        return JSONResponse(
++            content={"error": f"Failed to abort requests: {err}"},
++            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
++        )
++
++
+ @router.get("/is_paused")
+ async def is_paused(raw_request: Request) -> JSONResponse:
+     """Return the current pause status."""
+diff --git a/vllm/entrypoints/serve/disagg/protocol.py b/vllm/entrypoints/serve/disagg/protocol.py
+index 60d2a64..67f3f98 100644
+--- a/vllm/entrypoints/serve/disagg/protocol.py
++++ b/vllm/entrypoints/serve/disagg/protocol.py
+@@ -203,6 +203,8 @@ class GenerateResponse(BaseModel):
+     )
+     choices: list[GenerateResponseChoice]
+ 
++    usage: UsageInfo | None = Field(default=None)
++
+     prompt_logprobs: list[dict[int, Logprob] | None] | None = None
+ 
+     kv_transfer_params: dict[str, Any] | None = Field(


### PR DESCRIPTION
## Summary

Base image moved to `vllm/vllm-openai:latest-ubuntu2404` (v0.24.0). Rebase `docker/patch/latest/vllm.patch` accordingly:

- **Drop** the `vllm/v1/engine/core.py` partial-wake / dummy-batch hunk — the `if not self.model_executor.is_sleeping` guard is now upstream in 0.24.0, so patching it is unnecessary and would fail to apply.
- **Keep** the `all2all_utils.py` (`max_num_tokens = moe.max_num_tokens`) hunk.
- **Add** `/abort_requests` endpoint (`api_router.py`, from #296) and `GenerateResponse.usage` field (`disagg/protocol.py`, from #303).

## Verification

All three hunks checked with `git apply --check --allow-empty` against a real `vllm/vllm-openai:v0.24.0-ubuntu2404` container → RC=0 (minor line offsets absorbed by git apply's context matching).