### PR TITLE
[Bugfix] Make reward CPU tests collectable without optional runtime deps

### DIFF
--- a/tests/test_rm_math.py
+++ b/tests/test_rm_math.py
@@ -16,6 +16,8 @@ holds.
 
 from __future__ import annotations
 
+import importlib.util
+
 import pytest
 
 from vime.rollout.rm_hub.math_utils import (
@@ -32,6 +34,11 @@ from vime.rollout.rm_hub.math_utils import (
 
 
 NUM_GPUS = 0
+
+requires_sympy = pytest.mark.skipif(
+    any(importlib.util.find_spec(mod) is None for mod in ("sympy", "pylatexenc")),
+    reason="sympy/pylatexenc not installed",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -197,12 +204,14 @@ def test_grade_answer_mathd_rejects_different():
 
 
 @pytest.mark.unit
+@requires_sympy
 def test_grade_answer_sympy_equivalent_expressions():
     """Symbolically equal expressions should compare equal under sympy."""
     assert grade_answer_sympy("x+1", "1+x") is True
 
 
 @pytest.mark.unit
+@requires_sympy
 def test_grade_answer_sympy_fraction_must_match_exactly():
     """Reducible fractions are intentionally NOT considered equal — pinning
     the explicit ``_is_frac`` short-circuit at math_utils.py:453-456."""

--- a/vime/rollout/rm_hub/__init__.py
+++ b/vime/rollout/rm_hub/__init__.py
@@ -1,13 +1,9 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import random
-
-import aiohttp
-
-logger = logging.getLogger(__name__)
-
-from vime.utils.misc import load_function
-from vime.utils.types import Sample
+from typing import TYPE_CHECKING
 
 from .deepscaler import get_deepscaler_rule_based_reward
 from .f1 import f1_score
@@ -16,10 +12,19 @@ from .math_dapo_utils import compute_score as compute_score_dapo
 from .math_utils import extract_answer as extract_boxed_answer
 from .math_utils import grade_answer_verl
 
+if TYPE_CHECKING:
+    import aiohttp
+
+    from vime.utils.types import Sample
+
+logger = logging.getLogger(__name__)
+
 _shared_session: aiohttp.ClientSession | None = None
 
 
 def _get_shared_session() -> aiohttp.ClientSession:
+    import aiohttp
+
     global _shared_session
     if _shared_session is None or _shared_session.closed:
         connector = aiohttp.TCPConnector(
@@ -53,6 +58,8 @@ async def remote_rm(args, sample: Sample, max_retries: int = 10):
 
 
 async def async_rm(args, sample: Sample, **kwargs):
+    from vime.utils.misc import load_function
+
     # Per-sample custom_rm_path (from eval dataset config) takes priority
     if sample.custom_rm_path:
         rm_function = load_function(sample.custom_rm_path)
@@ -103,6 +110,8 @@ async def batched_async_rm(
 ) -> list[int | float]:
     if args.custom_rm_path is not None:
         # Ensure the custom reward function is implemented in batch mode
+        from vime.utils.misc import load_function
+
         rm_function = load_function(args.custom_rm_path)
         return await rm_function(args, samples, **kwargs)
     tasks = [async_rm(args, sample, **kwargs) for sample in samples]

--- a/vime/rollout/rm_hub/math_utils.py
+++ b/vime/rollout/rm_hub/math_utils.py
@@ -6,10 +6,6 @@ Call grade_answer(given_answer: str, ground_truth: str).
 """
 import re
 
-import sympy
-from pylatexenc import latex2text
-from sympy.parsing import sympy_parser
-
 
 # Dan Hendrycks' code
 def mathd_normalize_answer(answer: str | None) -> str | None:
@@ -167,6 +163,9 @@ TUPLE_CHARS = "()[]"
 
 def _sympy_parse(expr: str):
     """Parses an expression with sympy."""
+    import sympy
+    from sympy.parsing import sympy_parser
+
     py_expr = expr.replace("^", "**")
     # We allow basic SymPy names but no builtins to prevent arbitrary code execution
     # This whitelist approach ensures SymPy's internal transformations (like Integer) still work
@@ -181,6 +180,8 @@ def _sympy_parse(expr: str):
 
 def _parse_latex(expr: str) -> str:
     """Attempts to parse latex to an expression sympy can read."""
+    from pylatexenc import latex2text
+
     expr = expr.replace("\\tfrac", "\\frac")
     expr = expr.replace("\\dfrac", "\\frac")
     expr = expr.replace("\\frac", " \\frac")  # Play nice with mixed numbers.
@@ -351,6 +352,8 @@ def should_allow_eval(expr: str):
 def are_equal_under_sympy(ground_truth_normalized: str, given_normalized: str):
     are_equal = False
     try:
+        import sympy
+
         expr = f"({ground_truth_normalized})-({given_normalized})"
         if should_allow_eval(expr):
             sympy_diff = _sympy_parse(expr)


### PR DESCRIPTION
## Description

Fixes #304

Importing any `rm_hub` submodule executes `vime/rollout/rm_hub/__init__.py`, which imports runtime-only deps at module level, so the reward CPU tests fail at pytest collection in lightweight environments. The chain is deeper than the issue's traceback shows: `aiohttp` (used by `remote_rm` only), `vime.utils.misc` / `vime.utils.types` (pull in `torch` and `httpx`), and `sympy` / `pylatexenc` at the top of `math_utils`.

## Changes

- `rm_hub/__init__.py`: defer `aiohttp` and `load_function` to their call sites; move `Sample` / `aiohttp` under `TYPE_CHECKING` (same lazy-import pattern as `ray` in `vime/utils/misc.py`)
- `math_utils.py`: defer `sympy` / `pylatexenc` into `_sympy_parse` / `_parse_latex` / `are_equal_under_sympy`
- `tests/test_rm_math.py`: skip the two symbolic-equality tests when sympy is absent

No behaviour change.

## Testing

`tests/` CPU unit tests are not on CI, local results:

```bash
PYTHONPATH=$PWD python -m pytest -q tests/test_rm_math.py tests/test_rm_deepscaler.py \
  tests/test_rm_math_dapo.py tests/test_rm_f1.py tests/test_rm_gpqa.py
```

| | lightweight env (pytest only) | full deps |
|---|---|---|
| main | 5 collection errors (reproduces #304) | 106 passed |
| this PR | 104 passed, 2 skipped | 106 passed |

`pre-commit run --all-files`: passed.