### PR TITLE
[WIP]fix(npu): trim vllm-ascend colocate patch and pin native IPC engine

### DIFF
--- a/docker/Dockerfile.npu
+++ b/docker/Dockerfile.npu
@@ -7,6 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /root
 
 ARG MEGATRON_COMMIT=3714d81d418c9f1bca4594fc35f9e8289f652862
+ARG VLLM_ASCEND_COMMIT=5ca762a704f2a7acbd1bd839c3f3b421e5c0dcaf
 ARG MEGATRON_BRIDGE_COMMIT=3fd3768045422d0aa5c97e90a4e6c659aea9acb9
 ARG MINDSPEED_COMMIT=fc63de5c48426dd019c3b3f39e65f5bdf56e4086
 ARG MBRIDGE_COMMIT=89eb10887887bc74853f89a4de258c0702932a1c
@@ -44,12 +45,12 @@ RUN sed -i '/ports\.ubuntu\.com/ {h;s|ports\.ubuntu\.com|mirrors.tuna.tsinghua.e
       "https://download.pytorch.org/whl/cpu/ https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
     git config --global http.version HTTP/1.1
 
-# Clone vllm and vllm-ascend sources.
+# Clone vllm and vllm-ascend sources (pin ascend for native NPU IPC engine).
 RUN pip uninstall -y \
       vllm vllm-ascend megatron-bridge megatron-core mindspeed mbridge vime || true && \
     git clone https://github.com/vllm-project/vllm.git /root/vllm && \
-    git clone --depth 1 --branch main \
-      https://github.com/vllm-project/vllm-ascend.git /root/vllm-ascend
+    git clone https://github.com/vllm-project/vllm-ascend.git /root/vllm-ascend && \
+    git -C /root/vllm-ascend checkout "${VLLM_ASCEND_COMMIT}"
 
 # Switch vllm to the vllm-ascend verified commit, apply the NPU patch, install.
 RUN VLLM_COMMIT=$(cat /root/vllm-ascend/.github/vllm-main-verified.commit) && \
@@ -58,7 +59,7 @@ RUN VLLM_COMMIT=$(cat /root/vllm-ascend/.github/vllm-main-verified.commit) && \
       VLLM_TARGET_DEVICE=empty pip install -v -e /root/vllm --trusted-host download.pytorch.org \
       --trusted-host download-r2.pytorch.org
 
-# vLLM Ascend: apply colocate patch before install.
+# vLLM Ascend: apply colocate worker patch only (IPC engine fix is upstream).
 RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     git -C /root/vllm-ascend submodule update --init --recursive && \

--- a/docker/npu_patch/README.md
+++ b/docker/npu_patch/README.md
@@ -7,8 +7,8 @@ This guide provides instructions for installing Vime with NPU support, including
 | Component       | Version/Commit                           | Source                                                                                                              |
 | --------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | vime            | ascend                                   | [GitHub](https://github.com/vllm-project/vime/tree/ascend)                                                            |
-| vLLM            | see `.github/vllm-main-verified.commit` at pinned vLLM Ascend | [GitHub](https://github.com/vllm-project/vllm)                                                                      |
-| vLLM Ascend     | 5ca762a704f2a7acbd1bd839c3f3b421e5c0dcaf | [GitHub](https://github.com/vllm-project/vllm-ascend)                                                               |
+| vLLM            | `0.22.1rc1` (see `.github/vllm-main-verified.commit` at pinned vLLM Ascend) | [GitHub](https://github.com/vllm-project/vllm) — e.g. `967c5c3bc38891f4465d3f4e99917ed837bb3833` at pin above |
+| vLLM Ascend     | `0.1.dev1+g5ca762a704f2` (dev snapshot; pin commit below) | [GitHub](https://github.com/vllm-project/vllm-ascend) — commit `5ca762a704f2a7acbd1bd839c3f3b421e5c0dcaf` (#10996) |
 | Megatron-Bridge | 3fd3768045422d0aa5c97e90a4e6c659aea9acb9 | [GitHub](https://github.com/radixark/Megatron-Bridge)                                                               |
 | Megatron-LM     | 3714d81d418c9f1bca4594fc35f9e8289f652862 | [GitHub](https://github.com/NVIDIA/Megatron-LM)                                                                     |
 | MindSpeed       | fc63de5c48426dd019c3b3f39e65f5bdf56e4086 | [GitCode](https://gitcode.com/Ascend/MindSpeed)                                                                     |

--- a/docker/npu_patch/README.md
+++ b/docker/npu_patch/README.md
@@ -6,7 +6,9 @@ This guide provides instructions for installing Vime with NPU support, including
 
 | Component       | Version/Commit                           | Source                                                                                                              |
 | --------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| vime            | main                                     | [GitHub](https://github.com/vllm-project/vime/tree/main)                                                            |
+| vime            | ascend                                   | [GitHub](https://github.com/vllm-project/vime/tree/ascend)                                                            |
+| vLLM            | see `.github/vllm-main-verified.commit` at pinned vLLM Ascend | [GitHub](https://github.com/vllm-project/vllm)                                                                      |
+| vLLM Ascend     | 5ca762a704f2a7acbd1bd839c3f3b421e5c0dcaf | [GitHub](https://github.com/vllm-project/vllm-ascend)                                                               |
 | Megatron-Bridge | 3fd3768045422d0aa5c97e90a4e6c659aea9acb9 | [GitHub](https://github.com/radixark/Megatron-Bridge)                                                               |
 | Megatron-LM     | 3714d81d418c9f1bca4594fc35f9e8289f652862 | [GitHub](https://github.com/NVIDIA/Megatron-LM)                                                                     |
 | MindSpeed       | fc63de5c48426dd019c3b3f39e65f5bdf56e4086 | [GitCode](https://gitcode.com/Ascend/MindSpeed)                                                                     |
@@ -100,22 +102,33 @@ pip install --no-deps output/torch_memory_saver-0.0.8-cp312-cp312-linux_aarch64.
 
 
 ```bash
-export VLLM_COMMIT=9090368b650896bf5fc990c921df7eb4c20355a5
+export VLLM_ASCEND_COMMIT=5ca762a704f2a7acbd1bd839c3f3b421e5c0dcaf
+
+git clone https://github.com/vllm-project/vllm-ascend.git "${WORKSPACE}/vllm-ascend"
+git -C "${WORKSPACE}/vllm-ascend" checkout "${VLLM_ASCEND_COMMIT}"
+git -C "${WORKSPACE}/vllm-ascend" submodule update --init --recursive
+export VLLM_COMMIT="$(cat "${WORKSPACE}/vllm-ascend/.github/vllm-main-verified.commit")"
 
 git clone https://github.com/vllm-project/vllm.git "${WORKSPACE}/vllm"
 git -C "${WORKSPACE}/vllm" checkout "${VLLM_COMMIT}"
+git -C "${WORKSPACE}/vllm" apply --whitespace=nowarn "${PATCH_DIR}/vllm.patch"
 VLLM_TARGET_DEVICE=empty pip install -v -e "${WORKSPACE}/vllm"
 
-git clone https://github.com/vllm-project/vllm-ascend.git "${WORKSPACE}/vllm-ascend"
-git -C "${WORKSPACE}/vllm-ascend" submodule update --init --recursive
+git -C "${WORKSPACE}/vllm-ascend" apply --whitespace=nowarn "${PATCH_DIR}/vllm-ascend.patch"
 pip install -v -e "${WORKSPACE}/vllm-ascend"
 ```
 
 > [!NOTE]
 > vLLM Ascend has not yet cut a release tag against vLLM 0.22.0. As a temporary
-> measure we pin vLLM to the commit below and build vLLM Ascend from source.
+> measure we pin vLLM and vLLM Ascend to the commits above and build from source.
 > Once vLLM Ascend officially supports 0.22.0, this whole step can be omitted and
 > the released packages used instead.
+
+> [!NOTE]
+> `vllm-ascend.patch` only patches `worker.py` for colocate (skip free-memory
+> checks when training and inference share NPUs). The `NPUIPCWeightTransferEngine`
+> init fix is upstream since vLLM Ascend `5ca762a` (#10996); do not re-patch
+> `npu_ipc_engine.py`.
 
 ## Additional Dependencies
 

--- a/docker/npu_patch/vllm-ascend.patch
+++ b/docker/npu_patch/vllm-ascend.patch
@@ -37,18 +37,3 @@ index 63ee94c..4e81943 100644
          self.available_kv_cache_memory_bytes = (
              self.requested_memory - profile_result.non_kv_cache_memory - npugraph_memory_estimate_applied
          )
-diff --git a/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py b/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
-index 0000000..0000000 100644
---- a/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
-+++ b/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
-@@ -116,8 +116,8 @@ class NPUIPCWeightTransferEngine(WeightTransferEngine[NPUIPCWeightTransferInitIn
-     init_info_cls = NPUIPCWeightTransferInitInfo
-     update_info_cls = NPUIPCWeightTransferUpdateInfo
- 
--    def __init__(self, config: WeightTransferConfig, parallel_config: ParallelConfig) -> None:
--        super().__init__(config, parallel_config)
-+    def __init__(self, config: WeightTransferConfig, parallel_config: ParallelConfig, model: torch.nn.Module = None) -> None:
-+        super().__init__(config, parallel_config, model)
- 
-     def parse_update_info(self, update_dict: dict[str, Any]) -> NPUIPCWeightTransferUpdateInfo:
-         """Parse update dict, deserializing pickled IPC handles if present.

--- a/docs/en/get_started/NPU.md
+++ b/docs/en/get_started/NPU.md
@@ -8,8 +8,8 @@ issue on [vllm-project/vime](https://github.com/vllm-project/vime/issues).
 If you are running vime on Ascend NPU, please refer to the following materials.
 This tutorial explains how to set up the runtime environment and provides an
 end-to-end example for running GRPO training. It uses the **Megatron** training
-backend together with the **vLLM Ascend** rollout backend, synchronizing actor 
-weights to vLLM through the native HCCL weight-sync path.
+backend together with the **vLLM Ascend** rollout backend. In decoupled mode,
+weights sync over HCCL; in colocate mode (`--colocate`), weights sync over NPU IPC.
 
 The current NPU support targets Ascend **Atlas A2 / A3** (aarch64) hosts with the
 Ascend driver and **CANN 9.0.0** (Toolkit, Kernels, and NNAL/ATB) installed.
@@ -27,7 +27,7 @@ docker pull "${IMAGE}"
 ```
 
 For source builds and dependency debugging, the patch list and pinned commits are
-documented in [`docker/npu_patch/README.md`](https://github.com/vllm-project/vime/blob/npu/docker/npu_patch/README.md).
+documented in [`docker/npu_patch/README.md`](https://github.com/vllm-project/vime/blob/ascend/docker/npu_patch/README.md).
 
 ## Quick Start
 
@@ -202,3 +202,36 @@ python /root/vime/train.py \
   --train-memory-margin-bytes 2147483648 \
   2>&1 | tee -a "$LOG_FILE"
 ```
+
+### Example: Qwen3-4B Colocate
+
+Colocate runs training and rollout on the same NPUs (8×910B validated). Add
+`--colocate` and set `--tensor-model-parallel-size` to match the NPU count.
+Use `--megatron-to-hf-mode bridge` for weight export.
+
+```bash
+python /root/vime/train.py \
+  --train-backend megatron \
+  --actor-num-nodes 1 \
+  --actor-num-gpus-per-node 8 \
+  --rollout-num-gpus 8 \
+  --rollout-num-gpus-per-engine 8 \
+  --colocate \
+  --train-memory-margin-bytes 2147483648 \
+  --megatron-to-hf-mode bridge \
+  --tensor-model-parallel-size 8 \
+  ...  # same GRPO / optimizer flags as the decoupled example
+```
+
+Colocate notes (validated on 8× Ascend910B1, Qwen3-4B TP=8):
+
+- Do **not** pass `--vllm-enforce-eager`; it raises `train_rollout_logprob_abs_diff`
+  to ~0.2 (normal colocate diff is ~0.012).
+- Kill leftover `VLLMWorker` / `train.py` processes and release HBM before each
+  run (`npu-smi info` should show ~3 GB per card idle).
+- vLLM Ascend must be at least `5ca762a` (#10996) for the native NPU IPC weight
+  transfer engine; only the colocate `worker.py` patch in `vllm-ascend.patch`
+  is still required from Vime.
+
+Validated results: smoke (4 rollouts) diff ~0.012; 100-step long run diff
+0.00785–0.01257 with stable convergence.


### PR DESCRIPTION
## Summary

Follow-up to #285 per reviewer feedback (@Meihan-chen): drop the redundant
`npu_ipc_engine.py` hunk from `vllm-ascend.patch` now that upstream provides
the NPU IPC engine fix, pin a verified vLLM Ascend commit in `Dockerfile.npu`,
and document NPU colocate validation notes.

- **`vllm-ascend.patch`**: keep only colocate `worker.py` hunks (skip free-memory
  checks when training and inference share NPUs).
- **`Dockerfile.npu`**: pin `VLLM_ASCEND_COMMIT=5ca762a704f2a7acbd1bd839c3f3b421e5c0dcaf`;
  vLLM commit is still taken from `.github/vllm-main-verified.commit` at that pin.
- **`docs/en/get_started/NPU.md`**: add colocate caveats (no `--vllm-enforce-eager`,
  pre-run HBM cleanup, upstream IPC requirement).

## Pinned versions

| Component | Version | Commit / notes |
|-----------|---------|----------------|
| **vime** | `0.3.0` (`ascend` branch, post #285) | — |
| **vLLM Ascend** | `0.1.dev1+g5ca762a704f2` (dev snapshot) | `5ca762a704f2a7acbd1bd839c3f3b421e5c0dcaf` — [vllm-ascend #10996](https://github.com/vllm-project/vllm-ascend/pull/10996) on `main` (native `NPUIPCWeightTransferEngine`); rc backport: [vllm-ascend #11030](https://github.com/vllm-project/vllm-ascend/pull/11030) @ `f206fbf31` on `v0.22.1rc` |
| **vLLM** | `0.22.1rc1.dev263+g967c5c3bc` | `967c5c3bc38891f4465d3f4e99917ed837bb3833` (from `.github/vllm-main-verified.commit` at the vLLM Ascend pin above) |
| **PyTorch** | `2.10.0+cpu` | — |
| **Python** | `3.12.13` | — |
| **CANN** | `9.0.0` | — |
| **Hardware** | 8× Ascend910B1 (64GB HBM) | Atlas A2 |

> **Note:** vLLM Ascend has no stable PyPI release tag for this stack yet; the
> commit hash is the source of truth for Docker/README pins. The `0.1.dev1+g…`
> string is the setuptools-scm dev version observed after `pip install -e` at
> commit `5ca762a` (same pattern as the pre-upgrade `0.1.dev1+gbad0caf65…` build).

## Validation

Qwen3-4B, TP=8, colocate + `--megatron-to-hf-mode bridge`, native IPC weight sync,
direct `python train.py` (no Ray job submit), **no** `--vllm-enforce-eager`.

Container image: `registry-cbu.huawei.com/vime/vime-ascend-npu:vime_0.3.0-vllm_0.22.1-pytorch_2.10.0-cann_9.0.0-py_3.12-snt9b`

| Test | Steps | `train_rollout_logprob_abs_diff` |
|------|-------|----------------------------------|
| Smoke | 4 rollouts | ~0.0115–0.0123 |
| Short | 20 rollouts / 20 steps | ~0.0114–0.0121 |
| Long | 100 rollouts / 100 steps | 0.00785–0.01257 (stable, ~88 min) |

<img width="2358" height="1014" alt="image" src="https://github.com/user-attachments/assets/c758c20c-169f-4462-a1aa-3fa37ce4058a" />

## Follow-up (out of scope)

Migrate colocate weight sync to fully reuse native `NPUIPCWeightTransferEngine`
(replace custom `vLLMColocateWorkerExtension` path) — tracked separately.

## Test plan

- [x] Colocate smoke on 8×910B (Qwen3-4B, diff ~0.012)
- [x] 100-step long run (diff stable, converging to ~0.008–0.009)
- [ ] Docker image rebuild with updated `Dockerfile.npu` (CI / manual)




