### PR TITLE
[NPU] Add Search-R1 example

### DIFF
--- a/examples/search-r1/README.md
+++ b/examples/search-r1/README.md
@@ -14,15 +14,15 @@ The Search-R1 example provides:
 
 ## Files
 
-| File | Description |
-|------|-------------|
-| `generate_with_search.py` | Main generation function with multi-turn search + answer tool-calling, and reward function |
-| `google_search_server.py` | Google Search backend via serper.dev API |
-| `local_search_server.py` | Local search backend that wraps the retrieval server |
-| `qa_em_format.py` | QA exact-match scoring with format validation and retrieval correctness check |
-| `run_qwen2.5_3B.sh` | Training launch script (NPU 8-card, Qwen2.5-3B, GRPO) |
-| `local_dense_retriever/retrieval_server.py` | Dense retriever server (FAISS + E5 model) |
-| `local_dense_retriever/download.py` | Download wiki-18 index and corpus from HuggingFace |
+| File                                        | Description                                                                        |
+|---------------------------------------------|------------------------------------------------------------------------------------|
+| `generate_with_search.py`                   | Main generation function with multi-turn search + answer tool-calling, and reward function |
+| `google_search_server.py`                   | Google Search backend via serper.dev API                                           |
+| `local_search_server.py`                    | Local search backend that wraps the retrieval server                               |
+| `qa_em_format.py`                           | QA exact-match scoring with format validation and retrieval correctness check      |
+| `run_qwen3_4b_npu.sh`                       | Training launch script (NPU 8-card, Qwen3-4B-Instruct-2507, GRPO)                                        |
+| `local_dense_retriever/retrieval_server.py` | Dense retriever server (FAISS + E5 model)                                          |
+| `local_dense_retriever/download.py`         | Download wiki-18 index and corpus from HuggingFace                                 |
 
 ---
 
@@ -107,13 +107,13 @@ python $WORK_DIR/scripts/data_process/qa_search_test_merge.py \
 **Option A: Online Auto Download**
 
 ```bash
-hf download Qwen/Qwen2.5-3B-Instruct --local-dir /path/to/Qwen2.5-3B-Instruct
+hf download Qwen/Qwen3-4B-Instruct- --local-dir /path/to/Qwen3-4B-Instruct-2507
 ```
 
 **Option B: Offline Manual Download**
 
-- Download full model weights from Hugging Face repo: [Qwen/Qwen2.5-3B-Instruct](https://huggingface.co/Qwen/Qwen2.5-3B-Instruct)
-- Upload all downloaded model files to your target directory `MODEL_DIR=/path/to/Qwen2.5-3B-Instruct`
+- Download full model weights from Hugging Face repo: [Qwen/Qwen3-4B-Instruct-2507](https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507)
+- Upload all downloaded model files to your target directory `MODEL_DIR=/path/to/Qwen3-4B-Instruct-2507`
 
 #### 2.3 Local Retrieval Server (Optional)
 
@@ -164,7 +164,7 @@ SEARCH_R1_CONFIGS = {
     # ============== General Configuration ==============
     "max_turns": 2,
     "topk": 3,
-    "search_concurrency": 256,
+    "search_concurrency": 8,
 
     # ============== Search Backend Selection ==============
     "search_backend": "local",  # Options: "local" or "google"
@@ -232,5 +232,5 @@ python /root/vime/examples/search-r1/local_dense_retriever/retrieval_server.py \
 ```bash
 cd /root/vime
 # Replace the model and data loading/saving paths
-bash examples/search-r1/run_qwen2.5_3B.sh
+bash examples/search-r1/run_qwen3_4b_npu.sh
 ```

--- a/examples/search-r1/README.md
+++ b/examples/search-r1/README.md
@@ -1,0 +1,236 @@
+# Search-R1 lite
+
+This example **(Search-R1 lite)** demonstrates how to use vime for tool-enabled language model generation with search/retrieval capabilities, based on a minimal reproduction of [Search-R1](https://github.com/PeterGriffinJin/Search-R1).
+
+## Overview
+
+The Search-R1 example provides:
+
+- **Multi-turn conversation** with tool-calling (search/answer actions)
+- **Dual search backend support**: local dense retriever (FAISS + E5) or Google Search (serper.dev)
+- **GRPO-based RL training** with exact-match (EM) reward for QA tasks
+- **TIS (Trajectory Importance Sampling)** support for handling train/inference mismatch
+- **Format-aware reward** that evaluates both answer correctness and output structure
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `generate_with_search.py` | Main generation function with multi-turn search + answer tool-calling, and reward function |
+| `google_search_server.py` | Google Search backend via serper.dev API |
+| `local_search_server.py` | Local search backend that wraps the retrieval server |
+| `qa_em_format.py` | QA exact-match scoring with format validation and retrieval correctness check |
+| `run_qwen2.5_3B.sh` | Training launch script (NPU 8-card, Qwen2.5-3B, GRPO) |
+| `local_dense_retriever/retrieval_server.py` | Dense retriever server (FAISS + E5 model) |
+| `local_dense_retriever/download.py` | Download wiki-18 index and corpus from HuggingFace |
+
+---
+
+## Usage
+
+### 1. Setup
+
+```bash
+git clone -b ascend https://github.com/vllm-project/vime.git
+cd vime
+docker build -f docker/Dockerfile.npu -t vime-ascend:latest .
+```
+
+```bash
+# Update the vime image
+export IMAGE=vime-ascend:latest
+
+docker run -d --name vime-npu -it --net=host --shm-size=1024g \
+    --privileged=true \
+    --cap-add=SYS_PTRACE \
+    --device=/dev/davinci_manager \
+    --device=/dev/hisi_hdc \
+    --device=/dev/devmm_svm \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/sbin:/usr/local/sbin \
+    -v /home:/home \
+    -v /mnt:/mnt \
+    -v /tmp:/tmp \
+    -v /data:/data \
+    -v /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime \
+    $IMAGE
+
+docker exec -it vime-npu bash
+```
+
+```bash
+# For retriever
+pip install faiss-cpu==1.13.2
+```
+
+### 2. Download
+
+#### 2.1 Data
+
+**Option A: Online Auto Download**
+
+```bash
+# Training data (NQ + HotpotQA)
+cd /root
+git clone https://github.com/PeterGriffinJin/Search-R1.git
+cd Search-R1
+pip install -e . --no-deps
+pip install tensordict
+pip install chardet
+
+# Set your working directory
+WORK_DIR=/root/Search-R1
+LOCAL_DIR=/path/to/nq_hotpotqa_train
+
+# Process multiple dataset search format train file
+DATA=nq,hotpotqa
+python $WORK_DIR/scripts/data_process/qa_search_train_merge.py \
+    --local_dir $LOCAL_DIR \
+    --data_sources $DATA
+
+# (Optional) Process multiple dataset search format test file
+DATA=nq,triviaqa,popqa,hotpotqa,2wikimultihopqa,musique,bamboogle
+python $WORK_DIR/scripts/data_process/qa_search_test_merge.py \
+    --local_dir $LOCAL_DIR \
+    --data_sources $DATA
+```
+
+**Option B: Offline Manual Download**
+
+- Download full dataset assets from Hugging Face repo: [PeterJinGo/nq_hotpotqa_train](https://huggingface.co/datasets/PeterJinGo/nq_hotpotqa_train)
+- Upload all downloaded files to your target directory `LOCAL_DIR=/path/to/nq_hotpotqa_train`
+
+#### 2.2 Model
+
+**Option A: Online Auto Download**
+
+```bash
+hf download Qwen/Qwen2.5-3B-Instruct --local-dir /path/to/Qwen2.5-3B-Instruct
+```
+
+**Option B: Offline Manual Download**
+
+- Download full model weights from Hugging Face repo: [Qwen/Qwen2.5-3B-Instruct](https://huggingface.co/Qwen/Qwen2.5-3B-Instruct)
+- Upload all downloaded model files to your target directory `MODEL_DIR=/path/to/Qwen2.5-3B-Instruct`
+
+#### 2.3 Local Retrieval Server (Optional)
+
+> Only needed if using the local search backend instead of Google Search.
+
+**(1) Data**
+
+**Option A: Online Auto Download**
+
+```bash
+# Download index and corpus (~60-70 GB download)
+SAVE_PATH=/path/to/Index
+python /root/vime/examples/search-r1/local_dense_retriever/download.py --save_path $SAVE_PATH
+```
+
+**Option B: Offline Manual Download**
+
+- Download full index assets from Hugging Face repo: [PeterJinGo/wiki-18-e5-index](https://huggingface.co/datasets/PeterJinGo/wiki-18-e5-index) and [PeterJinGo/wiki-18-corpus](https://huggingface.co/datasets/PeterJinGo/wiki-18-corpus)
+- Upload all downloaded files to your target directory `SAVE_PATH=/path/to/Index`
+
+> No matter which download option you use (Option A or B), you must run the following commands after the download completes to merge the index shards and unpack the corpus dataset.
+
+```bash
+SAVE_PATH=/path/to/Index
+cat $SAVE_PATH/part_* > $SAVE_PATH/e5_Flat.index
+gzip -d $SAVE_PATH/wiki-18.jsonl.gz
+```
+
+**(2) Model**
+
+**Option A: Online Auto Download**
+
+```bash
+hf download intfloat/e5-base-v2 --local-dir /path/to/e5-base-v2
+```
+
+**Option B: Offline Manual Download**
+
+- Download full model weights from Hugging Face repo: [intfloat/e5-base-v2](https://huggingface.co/intfloat/e5-base-v2)
+- Upload all downloaded model files to your target directory `MODEL_DIR=/path/to/e5-base-v2`
+
+### 3. Configure Search Backend
+
+The `generate_with_search.py` file supports both **local** search and **Google** search backends. Configure via the `SEARCH_R1_CONFIGS` dictionary:
+
+```python
+SEARCH_R1_CONFIGS = {
+    # ============== General Configuration ==============
+    "max_turns": 2,
+    "topk": 3,
+    "search_concurrency": 256,
+
+    # ============== Search Backend Selection ==============
+    "search_backend": "local",  # Options: "local" or "google"
+
+    # ============== Local Search Configuration ==============
+    # (Only used when search_backend="local")
+    "local": {
+        "search_url": "http://127.0.0.1:8000/retrieve",  # URL of your local retrieval server
+        "proxy": None,
+    },
+
+    # ============== Google Search Configuration ==============
+    # (Only used when search_backend="google")
+    "google": {
+        "api_key": "your_api_key_here",  # Replace with your actual serper.dev API key
+        "snippet_only": True,
+        "proxy": None,
+    },
+
+    # ============== Log Probability Collection ==============
+    "return_logprob": True,  # Set to True to collect log probabilities (required for TIS)
+
+    # ============== Reward Model Configuration ==============
+    "format_score": 0.2,
+}
+```
+
+#### Using Local Search
+
+- Set `"search_backend": "local"`
+- Configure `"local"` section with your local retrieval server URL
+- Start your local search server before running the training script
+
+```bash
+# Set paths
+SAVE_PATH=/path/to/Index
+INDEX_FILE=$SAVE_PATH/e5_Flat.index
+CORPUS_FILE=$SAVE_PATH/wiki-18.jsonl
+RETRIEVER_NAME=e5
+RETRIEVER_PATH=/path/to/e5-base-v2
+
+# Start the retrieval server
+python /root/vime/examples/search-r1/local_dense_retriever/retrieval_server.py \
+    --index_path $INDEX_FILE\
+    --corpus_path $CORPUS_FILE\
+    --topk 3 \
+    --retriever_name $RETRIEVER_NAME \
+    --retriever_model $RETRIEVER_PATH
+```
+
+> **Note:**
+> - First startup will download the model and load the index, which may take a few minutes
+> - Normal startup time (excluding downloads): 1-2 minutes
+> - The local search engine's Python process will not terminate when the shell closes
+> - To restart the server: `lsof -i :8000` to find the PID, then kill it and restart
+
+#### Using Google Search
+
+- Set `"search_backend": "google"`
+- Configure `"google"` section with your serper.dev API key
+- Get your API key from [serper.dev](https://serper.dev/)
+
+### 4. Run Training
+
+```bash
+cd /root/vime
+# Replace the model and data loading/saving paths
+bash examples/search-r1/run_qwen2.5_3B.sh
+```

--- a/examples/search-r1/README_zh.md
+++ b/examples/search-r1/README_zh.md
@@ -14,15 +14,15 @@ Search-R1 示例提供了：
 
 ## 文件说明
 
-| 文件 | 描述 |
-|------|------|
-| `generate_with_search.py` | 主生成函数，支持多轮搜索 + 回答工具调用，以及奖励函数 |
-| `google_search_server.py` | 通过 serper.dev API 实现 Google 搜索后端 |
-| `local_search_server.py` | 本地搜索后端，封装检索服务 |
-| `qa_em_format.py` | 问答精确匹配评分，包含格式验证和检索正确性检查 |
-| `run_qwen2.5_3B.sh` | 训练启动脚本（NPU 8卡，Qwen2.5-3B，GRPO） |
+| 文件                                          | 描述 |
+|---------------------------------------------|------|
+| `generate_with_search.py`                   | 主生成函数，支持多轮搜索 + 回答工具调用，以及奖励函数 |
+| `google_search_server.py`                   | 通过 serper.dev API 实现 Google 搜索后端 |
+| `local_search_server.py`                    | 本地搜索后端，封装检索服务 |
+| `qa_em_format.py`                           | 问答精确匹配评分，包含格式验证和检索正确性检查 |
+| `run_qwen3_4b_npu.sh`                       | 训练启动脚本（NPU 8卡，Qwen3-4B-Instruct-2507，GRPO） |
 | `local_dense_retriever/retrieval_server.py` | 稠密检索服务器（FAISS + E5 模型） |
-| `local_dense_retriever/download.py` | 从 HuggingFace 下载 wiki-18 索引和语料库 |
+| `local_dense_retriever/download.py`         | 从 HuggingFace 下载 wiki-18 索引和语料库 |
 
 ---
 
@@ -105,13 +105,13 @@ python $WORK_DIR/scripts/data_process/qa_search_test_merge.py \
 **方式 A：在线自动下载**
 
 ```bash
-hf download Qwen/Qwen2.5-3B-Instruct --local-dir /path/to/Qwen2.5-3B-Instruct
+hf download Qwen/Qwen3-4B-Instruct-2507 --local-dir /path/to/Qwen3-4B-Instruct-2507
 ```
 
 **方式 B：离线手动下载**
 
-- 从 Hugging Face 仓库下载完整模型权重：[Qwen/Qwen2.5-3B-Instruct](https://huggingface.co/Qwen/Qwen2.5-3B-Instruct)
-- 将所有下载的模型文件上传到目标目录 `MODEL_DIR=/path/to/Qwen2.5-3B-Instruct`
+- 从 Hugging Face 仓库下载完整模型权重：[Qwen/Qwen3-4B-Instruct-2507](https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507)
+- 将所有下载的模型文件上传到目标目录 `MODEL_DIR=/path/to/Qwen3-4B-Instruct-2507`
 
 #### 2.3 本地检索服务器（可选）
 
@@ -162,7 +162,7 @@ SEARCH_R1_CONFIGS = {
     # ============== 通用配置 ==============
     "max_turns": 2,
     "topk": 3,
-    "search_concurrency": 256,
+    "search_concurrency": 8,
 
     # ============== 搜索后端选择 ==============
     "search_backend": "local",  # 选项："local" 或 "google"
@@ -230,5 +230,5 @@ python /root/vime/examples/search-r1/local_dense_retriever/retrieval_server.py \
 ```bash
 cd /root/vime
 # 替换模型和数据加载/保存路径
-bash examples/search-r1/run_qwen2.5_3B.sh
+bash examples/search-r1/run_qwen3_4b_npu.sh
 ```

--- a/examples/search-r1/README_zh.md
+++ b/examples/search-r1/README_zh.md
@@ -1,0 +1,234 @@
+# Search-R1 lite
+
+本示例 **(Search-R1 lite)** 演示了如何使用 vime 进行带工具调用的语言模型生成，具备搜索/检索能力，是基于 [Search-R1](https://github.com/PeterGriffinJin/Search-R1) 的最小复现。
+
+## 概述
+
+Search-R1 示例提供了：
+
+- **多轮对话**：支持工具调用（搜索/回答）
+- **双搜索后端支持**：本地稠密检索器（FAISS + E5）或 Google 搜索（serper.dev）
+- **基于 GRPO 的强化学习训练**：使用精确匹配（EM）计算问答任务奖励
+- **TIS（轨迹重要性采样）**：用于处理训推不一致问题
+- **格式感知奖励**：同时评估答案正确性和输出结构
+
+## 文件说明
+
+| 文件 | 描述 |
+|------|------|
+| `generate_with_search.py` | 主生成函数，支持多轮搜索 + 回答工具调用，以及奖励函数 |
+| `google_search_server.py` | 通过 serper.dev API 实现 Google 搜索后端 |
+| `local_search_server.py` | 本地搜索后端，封装检索服务 |
+| `qa_em_format.py` | 问答精确匹配评分，包含格式验证和检索正确性检查 |
+| `run_qwen2.5_3B.sh` | 训练启动脚本（NPU 8卡，Qwen2.5-3B，GRPO） |
+| `local_dense_retriever/retrieval_server.py` | 稠密检索服务器（FAISS + E5 模型） |
+| `local_dense_retriever/download.py` | 从 HuggingFace 下载 wiki-18 索引和语料库 |
+
+---
+
+## 使用方法
+
+### 1. 环境搭建
+
+```bash
+git clone -b ascend https://github.com/vllm-project/vime.git
+cd vime
+docker build -f docker/Dockerfile.npu -t vime-ascend:latest .
+```
+
+```bash
+export IMAGE=vime-ascend:latest
+
+docker run -d --name vime-npu -it --net=host --shm-size=1024g \
+    --privileged=true \
+    --cap-add=SYS_PTRACE \
+    --device=/dev/davinci_manager \
+    --device=/dev/hisi_hdc \
+    --device=/dev/devmm_svm \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/sbin:/usr/local/sbin \
+    -v /home:/home \
+    -v /mnt:/mnt \
+    -v /tmp:/tmp \
+    -v /data:/data \
+    -v /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime \
+    $IMAGE
+
+docker exec -it vime-npu bash
+```
+
+```bash
+# 检索依赖
+pip install faiss-cpu==1.13.2
+```
+
+### 2. 下载
+
+#### 2.1 数据
+
+**方式 A：在线自动下载**
+
+```bash
+cd /root
+git clone https://github.com/PeterGriffinJin/Search-R1.git
+cd Search-R1
+pip install -e . --no-deps
+pip install tensordict
+pip install chardet
+
+# 设置工作目录
+WORK_DIR=/root/Search-R1
+LOCAL_DIR=/path/to/nq_hotpotqa_train
+
+# 处理多数据集搜索格式训练文件
+DATA=nq,hotpotqa
+python $WORK_DIR/scripts/data_process/qa_search_train_merge.py \
+    --local_dir $LOCAL_DIR \
+    --data_sources $DATA
+
+# （可选）处理多数据集搜索格式测试文件
+DATA=nq,triviaqa,popqa,hotpotqa,2wikimultihopqa,musique,bamboogle
+python $WORK_DIR/scripts/data_process/qa_search_test_merge.py \
+    --local_dir $LOCAL_DIR \
+    --data_sources $DATA
+```
+
+**方式 B：离线手动下载**
+
+- 从 Hugging Face 仓库下载完整数据集资源：[PeterJinGo/nq_hotpotqa_train](https://huggingface.co/datasets/PeterJinGo/nq_hotpotqa_train)
+- 将所有下载的文件上传到目标目录 `LOCAL_DIR=/path/to/nq_hotpotqa_train`
+
+#### 2.2 模型
+
+**方式 A：在线自动下载**
+
+```bash
+hf download Qwen/Qwen2.5-3B-Instruct --local-dir /path/to/Qwen2.5-3B-Instruct
+```
+
+**方式 B：离线手动下载**
+
+- 从 Hugging Face 仓库下载完整模型权重：[Qwen/Qwen2.5-3B-Instruct](https://huggingface.co/Qwen/Qwen2.5-3B-Instruct)
+- 将所有下载的模型文件上传到目标目录 `MODEL_DIR=/path/to/Qwen2.5-3B-Instruct`
+
+#### 2.3 本地检索服务器（可选）
+
+> 仅在使用本地搜索后端而非 Google 搜索时需要。
+
+**(1) 数据**
+
+**方式 A：在线自动下载**
+
+```bash
+# 下载索引和语料库（约 60-70 GB 下载量）
+SAVE_PATH=/path/to/Index
+python /root/vime/examples/search-r1/local_dense_retriever/download.py --save_path $SAVE_PATH
+```
+
+**方式 B：离线手动下载**
+
+- 从 Hugging Face 仓库下载完整索引资源：[PeterJinGo/wiki-18-e5-index](https://huggingface.co/datasets/PeterJinGo/wiki-18-e5-index) 和 [PeterJinGo/wiki-18-corpus](https://huggingface.co/datasets/PeterJinGo/wiki-18-corpus)
+- 将所有下载的文件上传到目标目录 `SAVE_PATH=/path/to/Index`
+
+> **注意：**无论采用上述哪种下载方式（方案 A 或方案 B），在数据下载完成后，均须执行以下命令以完成索引分片的合并以及语料库的解压。
+
+```bash
+SAVE_PATH=/path/to/Index
+cat $SAVE_PATH/part_* > $SAVE_PATH/e5_Flat.index
+gzip -d $SAVE_PATH/wiki-18.jsonl.gz
+```
+
+**(2) 模型**
+
+**方式 A：在线自动下载**
+
+```bash
+hf download intfloat/e5-base-v2 --local-dir /path/to/e5-base-v2
+```
+
+**方式 B：离线手动下载**
+
+- 从 Hugging Face 仓库下载完整模型权重：[intfloat/e5-base-v2](https://huggingface.co/intfloat/e5-base-v2)
+- 将所有下载的模型文件上传到目标目录 `MODEL_DIR=/path/to/e5-base-v2`
+
+### 3. 配置搜索后端
+
+`generate_with_search.py` 文件同时支持**本地**搜索和 **Google** 搜索后端。通过 `SEARCH_R1_CONFIGS` 字典进行配置：
+
+```python
+SEARCH_R1_CONFIGS = {
+    # ============== 通用配置 ==============
+    "max_turns": 2,
+    "topk": 3,
+    "search_concurrency": 256,
+
+    # ============== 搜索后端选择 ==============
+    "search_backend": "local",  # 选项："local" 或 "google"
+
+    # ============== 本地搜索配置 ==============
+    # （仅在 search_backend="local" 时使用）
+    "local": {
+        "search_url": "http://127.0.0.1:8000/retrieve",  # 本地检索服务器 URL
+        "proxy": None,
+    },
+
+    # ============== Google 搜索配置 ==============
+    # （仅在 search_backend="google" 时使用）
+    "google": {
+        "api_key": "your_api_key_here",  # 替换为你的 serper.dev API 密钥
+        "snippet_only": True,
+        "proxy": None,
+    },
+
+    # ============== 对数概率收集 ==============
+    "return_logprob": True,  # 设为 True 以收集对数概率（TIS 所需）
+
+    # ============== 奖励模型配置 ==============
+    "format_score": 0.2,
+}
+```
+
+#### 使用本地搜索
+
+- 设置 `"search_backend": "local"`
+- 在 `"local"` 部分配置本地检索服务器 URL
+- 在运行训练脚本之前启动本地搜索服务器
+
+```bash
+# 设置路径
+SAVE_PATH=/path/to/Index
+INDEX_FILE=$SAVE_PATH/e5_Flat.index
+CORPUS_FILE=$SAVE_PATH/wiki-18.jsonl
+RETRIEVER_NAME=e5
+RETRIEVER_PATH=/path/to/e5-base-v2
+
+# 启动检索服务器
+python /root/vime/examples/search-r1/local_dense_retriever/retrieval_server.py \
+    --index_path $INDEX_FILE\
+    --corpus_path $CORPUS_FILE\
+    --topk 3 \
+    --retriever_name $RETRIEVER_NAME \
+    --retriever_model $RETRIEVER_PATH
+```
+
+> **注意：**
+> - 首次启动将下载模型并加载索引，可能需要几分钟
+> - 正常启动时间（不含下载）：1-2 分钟
+> - 本地搜索引擎的 Python 进程不会在 Shell 关闭时终止
+> - 重启服务器：使用 `lsof -i :8000` 查找进程 PID，然后终止并重启
+
+#### 使用 Google 搜索
+
+- 设置 `"search_backend": "google"`
+- 在 `"google"` 部分配置你的 serper.dev API 密钥
+- 从 [serper.dev](https://serper.dev/) 获取你的 API 密钥
+
+### 4. 运行训练
+
+```bash
+cd /root/vime
+# 替换模型和数据加载/保存路径
+bash examples/search-r1/run_qwen2.5_3B.sh
+```

--- a/examples/search-r1/generate_with_search.py
+++ b/examples/search-r1/generate_with_search.py
@@ -16,7 +16,7 @@ SEARCH_R1_CONFIGS = {
     # ============== General Configuration ==============
     "max_turns": 2,
     "topk": 3,
-    "search_concurrency": 8,
+    "search_concurrency": 8,  # TODO: temporarily lowered for CPU-based Faiss retrieval; restore to 256 once NPU-accelerated Faiss is available
     # ============== Search Backend Selection ==============
     "search_backend": "local",  # Options: "local" or "google"
     # ============== Local Search Configuration ==============

--- a/examples/search-r1/generate_with_search.py
+++ b/examples/search-r1/generate_with_search.py
@@ -1,0 +1,327 @@
+# Adapted from https://github.com/PeterGriffinJin/Search-R1/blob/ceee7b89655ed52f205b9beb98e1190c3eedcfb0/search_r1/llm_agent/generation.py
+# This is a unified version supporting both local search and Google search, with optional log probability collection
+# Adapted for vLLM /inference/v1/generate endpoint (disagg API)
+
+import asyncio
+import re
+
+from qa_em_format import compute_score_em
+
+from vime.rollout.vllm_rollout import GenerateState
+from vime.utils.http_utils import post
+from vime.utils.types import Sample
+
+# Configuration for Search-R1
+SEARCH_R1_CONFIGS = {
+    # ============== General Configuration ==============
+    "max_turns": 2,
+    "topk": 3,
+    "search_concurrency": 256,
+    # ============== Search Backend Selection ==============
+    "search_backend": "local",  # Options: "local" or "google"
+    # ============== Local Search Configuration ==============
+    # (Only used when search_backend="local")
+    "local": {
+        "search_url": "http://127.0.0.1:8000/retrieve",  # URL of your local retrieval server
+        "proxy": None,  # Set to your proxy if needed
+    },
+    # ============== Google Search Configuration ==============
+    # (Only used when search_backend="google")
+    "google": {
+        "api_key": "your_api_key_here",  # Replace with your actual API key
+        "snippet_only": True,  # Set to True to only return snippets
+        "proxy": None,  # Set to your proxy if needed
+    },
+    # ============== Log Probability Collection ==============
+    "return_logprob": True,  # Set to True to collect log probabilities for TIS metrics
+    # ============== Reward Model Configuration ==============
+    "format_score": 0.2,
+}
+
+
+SEMAPHORE = asyncio.Semaphore(SEARCH_R1_CONFIGS["search_concurrency"])
+
+
+def _build_inference_sampling_params(sampling_params: dict) -> dict:
+    """Map vllm-style sampling_params to vLLM /inference/v1/generate format."""
+    sp: dict = {
+        "max_tokens": sampling_params["max_new_tokens"],
+        "temperature": sampling_params["temperature"],
+        "top_p": sampling_params["top_p"],
+        "logprobs": 1,
+    }
+    tk = sampling_params.get("top_k")
+    if tk is not None and (tk > 0 or tk == -1):
+        sp["top_k"] = tk
+    if sampling_params.get("stop"):
+        sp["stop"] = sampling_params["stop"]
+        if sampling_params.get("no_stop_trim"):
+            sp["include_stop_str_in_output"] = True
+    if sampling_params.get("stop_token_ids"):
+        sp["stop_token_ids"] = sampling_params["stop_token_ids"]
+    if sampling_params.get("seed") is not None:
+        sp["seed"] = sampling_params["seed"]
+    if sampling_params.get("skip_special_tokens") is not None:
+        sp["skip_special_tokens"] = bool(sampling_params["skip_special_tokens"])
+    return sp
+
+
+def _passages2string(retrieval_result):
+    """
+    Convert retrieval results to a formatted string.
+    This function works with both google_search and local_search results.
+    """
+    format_reference = ""
+    for idx, doc_item in enumerate(retrieval_result):
+        content = doc_item["document"]["contents"]
+        title = content.split("\n")[0]
+        text = "\n".join(content.split("\n")[1:])
+        format_reference += f"Doc {idx+1}(Title: {title}) {text}\n"
+
+    return format_reference
+
+
+async def search(query: str) -> str:
+    """
+    Perform search using either local search engine or Google search.
+    The search backend is determined by SEARCH_R1_CONFIGS["search_backend"].
+    """
+    backend = SEARCH_R1_CONFIGS["search_backend"]
+
+    if backend == "local":
+        from local_search_server import local_search
+
+        local_config = SEARCH_R1_CONFIGS["local"]
+        result = await local_search(
+            local_config["search_url"],
+            query,
+            SEARCH_R1_CONFIGS["topk"],
+            proxy=local_config["proxy"],
+        )
+    elif backend == "google":
+        from google_search_server import google_search
+
+        google_config = SEARCH_R1_CONFIGS["google"]
+        result = await google_search(
+            google_config["api_key"],
+            query,
+            SEARCH_R1_CONFIGS["topk"],
+            snippet_only=google_config["snippet_only"],
+            proxy=google_config["proxy"],
+        )
+    else:
+        raise ValueError(f"Unknown search backend: {backend}. " f"Must be either 'local' or 'google'.")
+
+    return _passages2string(result)
+
+
+# IMPORTANT: When we need to collect log probabilities (logp), we CANNOT do any postprocessing
+# on the strings decoded from token_ids. This is because:
+# 1. We don't know how to truncate the corresponding tokens/logp arrays to match the modified string
+# 2. Re-tokenizing the postprocessed string may produce different tokens than what the engine generated,
+#    leading to misalignment between tokens and their log probabilities
+# Therefore, postprocess_responses is only used when return_logprob=False.
+def postprocess_responses(resp: str) -> str:
+    """
+    Post-process response to ensure tag completeness.
+    Only used when SEARCH_R1_CONFIGS["return_logprob"] is False.
+    """
+    return (
+        resp.split("</search>")[0] + "</search>"
+        if "</search>" in resp
+        else resp.split("</answer>")[0] + "</answer>" if "</answer>" in resp else resp
+    )
+
+
+def postprocess_predictions(prediction: str):
+    pattern = r"<(search|answer)>(.*?)</\1>"
+    match = re.search(pattern, prediction, re.DOTALL)
+    if match:
+        content = match.group(2).strip()  # Return only the content inside the tags
+        action = match.group(1)
+    else:
+        content = ""
+        action = None
+
+    return action, content
+
+
+async def execute_predictions(prediction: str) -> str:
+    action, content = postprocess_predictions(prediction)
+
+    if action == "search":
+        search_query = content
+        async with SEMAPHORE:
+            search_results = await search(search_query)
+        next_obs = f"\n\n<information>{search_results.strip()}</information>\n\n"
+        done = False
+    elif action == "answer":
+        next_obs = ""
+        done = True
+    else:
+        next_obs = "\nMy previous action is invalid. \
+If I want to search, I should put the query between <search> and </search>. \
+If I want to give the final answer, I should put the answer between <answer> and </answer>. Let me try again.\n"
+        done = False
+
+    return next_obs, done
+
+
+async def generate(args, sample: Sample, sampling_params) -> Sample:
+    assert not args.partial_rollout, "Partial rollout is not supported for this function at the moment."
+
+    state = GenerateState(args)
+
+    router_ip = args.vllm_router_ip
+    router_port = args.vllm_router_port
+    url = f"http://{router_ip}:{router_port}/inference/v1/generate"
+
+    # Handle partial rollout samples: continue generation from existing response
+    prompt_text = sample.prompt
+    prompt_tokens_ids = state.tokenizer(prompt_text, add_special_tokens=False)["input_ids"]
+    sample.tokens = list(prompt_tokens_ids)
+    sample.loss_mask = []
+    response = ""
+    response_token_ids = []
+    loss_mask = []
+    rollout_log_probs = [] if SEARCH_R1_CONFIGS["return_logprob"] else None
+    sample.rollout_top_p_token_ids = None
+    sample.rollout_top_p_token_offsets = None
+
+    # BUGFIX: make the inference engine STOP at the tool/answer boundary.
+    # Without a stop, the engine keeps emitting tokens after </search> / </answer>
+    # (junk, even fabricated new "Question:"s). The example only trimmed that junk
+    # via postprocess_responses when return_logprob=False; with return_logprob=True
+    # (TIS) trimming is disabled to keep token/logp aligned, so the junk stayed in
+    # the trajectory and got trained on (loss_mask=1) AND broke is_valid_sequence
+    # (trailing content after </answer> -> format invalid -> lower reward).
+    # Stopping at the tag avoids all of that and keeps token/logp aligned natively.
+    _stop_tags = ["</search>", "</answer>"]
+    _existing_stop = sampling_params.get("stop") or []
+    if isinstance(_existing_stop, str):
+        _existing_stop = [_existing_stop]
+    sampling_params = {**sampling_params, "stop": list(dict.fromkeys([*_existing_stop, *_stop_tags]))}
+
+    # Build vLLM-style sampling params (maps max_new_tokens -> max_tokens, adds logprobs, etc.)
+    inference_sampling_params = _build_inference_sampling_params(sampling_params)
+
+    for _turn_idx in range(SEARCH_R1_CONFIGS["max_turns"]):
+        # vLLM /inference/v1/generate requires token_ids instead of text.
+        # For multi-turn, re-tokenize the full context each time.
+        full_text = prompt_text + response
+        full_token_ids = state.tokenizer(full_text, add_special_tokens=False)["input_ids"]
+
+        payload = {
+            "token_ids": full_token_ids,
+            "sampling_params": inference_sampling_params,
+        }
+        if hasattr(args, 'hf_checkpoint'):
+            payload["model"] = args.hf_checkpoint
+
+        output = await post(url, payload)
+
+        # Parse vLLM GenerateResponse: {"choices": [{"token_ids": [...], "logprobs": ..., "finish_reason": "stop"}]}
+        choice = output["choices"][0]
+        finish_reason = choice.get("finish_reason", "stop")
+
+        # abort
+        if finish_reason == "abort":
+            sample.status = Sample.Status.ABORTED
+            return sample
+
+        # Extract token IDs from vLLM response
+        cur_response_token_ids = choice.get("token_ids") or []
+
+        # Decode text from token_ids
+        skip_sp = inference_sampling_params.get("skip_special_tokens")
+        skip_decode = True if skip_sp is None else bool(skip_sp)
+        cur_response = state.tokenizer.decode(cur_response_token_ids, skip_special_tokens=skip_decode) if cur_response_token_ids else ""
+
+        # Extract log probs if enabled
+        if SEARCH_R1_CONFIGS["return_logprob"]:
+            cur_response_log_probs: list[float] = []
+            lp = choice.get("logprobs")
+            if isinstance(lp, dict):
+                content_items = lp.get("content") or []
+                cur_response_log_probs = [
+                    float(item.get("logprob", 0.0)) if isinstance(item, dict) else 0.0 for item in content_items
+                ]
+            if not cur_response_log_probs:
+                cur_response_log_probs = [0.0] * len(cur_response_token_ids)
+        else:
+            # When not collecting log probs, we can safely postprocess the response
+            cur_response = postprocess_responses(cur_response)
+            # Re-tokenize after postprocessing
+            cur_response_token_ids = state.tokenizer(cur_response, add_special_tokens=False)["input_ids"]
+            cur_response_log_probs = None
+
+        response += cur_response
+        response_token_ids += cur_response_token_ids
+        loss_mask += [1] * len(cur_response_token_ids)
+
+        # Add log probs if enabled
+        if SEARCH_R1_CONFIGS["return_logprob"]:
+            rollout_log_probs += cur_response_log_probs
+
+        if finish_reason == "length":
+            break
+
+        next_obs, done = await execute_predictions(cur_response)
+        if done:
+            break
+
+        assert next_obs != "", "Next observation should not be empty."
+        obs_tokens_ids = state.tokenizer(next_obs, add_special_tokens=False)["input_ids"]
+        response += next_obs
+        response_token_ids += obs_tokens_ids
+        loss_mask += [0] * len(obs_tokens_ids)
+
+        # Add dummy log probs for observation tokens if enabled (they won't be used due to loss_mask=0)
+        if SEARCH_R1_CONFIGS["return_logprob"]:
+            rollout_log_probs += [0.0] * len(obs_tokens_ids)
+
+            # Verify alignment when collecting log probs
+            assert len(response_token_ids) == len(
+                rollout_log_probs
+            ), f"Token/logp length mismatch: {len(response_token_ids)} tokens vs {len(rollout_log_probs)} logps"
+
+    # Store statistics for wandb logging
+    sample.tokens = prompt_tokens_ids + response_token_ids
+    sample.response_length = len(response_token_ids)
+    sample.response = response
+    sample.loss_mask = loss_mask
+    sample.prompt = prompt_text
+
+    # Store log probs if enabled
+    if SEARCH_R1_CONFIGS["return_logprob"]:
+        sample.rollout_log_probs = rollout_log_probs if rollout_log_probs else None
+
+    # vLLM finish_reason is a string: "stop", "length", or "abort"
+    match finish_reason:
+        case "length":
+            sample.status = Sample.Status.TRUNCATED
+        case "abort":
+            sample.status = Sample.Status.ABORTED
+        case "stop":
+            sample.status = Sample.Status.COMPLETED
+
+    return sample
+
+
+async def reward_func(args, sample, **kwargs):
+    """The reward function for retrieval-based question answering.
+
+    Args:
+        args: the arguments
+        sample: the sample to evaluate
+    """
+    if not isinstance(sample, Sample):
+        raise TypeError("Sample must be an instance of Sample class.")
+
+    score = compute_score_em(
+        solution_str=sample.prompt + sample.response,
+        ground_truth=sample.label["ground_truth"],
+        format_score=SEARCH_R1_CONFIGS["format_score"],
+    )
+
+    return score

--- a/examples/search-r1/generate_with_search.py
+++ b/examples/search-r1/generate_with_search.py
@@ -191,7 +191,7 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
             "token_ids": full_token_ids,
             "sampling_params": inference_sampling_params,
         }
-        if hasattr(args, 'hf_checkpoint'):
+        if hasattr(args, "hf_checkpoint"):
             payload["model"] = args.hf_checkpoint
 
         output = await post(url, payload)
@@ -211,7 +211,11 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
         # Decode text from token_ids
         skip_sp = inference_sampling_params.get("skip_special_tokens")
         skip_decode = True if skip_sp is None else bool(skip_sp)
-        cur_response = state.tokenizer.decode(cur_response_token_ids, skip_special_tokens=skip_decode) if cur_response_token_ids else ""
+        cur_response = (
+            state.tokenizer.decode(cur_response_token_ids, skip_special_tokens=skip_decode)
+            if cur_response_token_ids
+            else ""
+        )
 
         # Extract log probs if enabled
         if SEARCH_R1_CONFIGS["return_logprob"]:

--- a/examples/search-r1/generate_with_search.py
+++ b/examples/search-r1/generate_with_search.py
@@ -7,7 +7,7 @@ import re
 
 from qa_em_format import compute_score_em
 
-from vime.rollout.vllm_rollout import GenerateState
+from vime.rollout.vllm_rollout import GenerateState, _build_inference_sampling_params
 from vime.utils.http_utils import post
 from vime.utils.types import Sample
 
@@ -16,7 +16,7 @@ SEARCH_R1_CONFIGS = {
     # ============== General Configuration ==============
     "max_turns": 2,
     "topk": 3,
-    "search_concurrency": 256,
+    "search_concurrency": 8,
     # ============== Search Backend Selection ==============
     "search_backend": "local",  # Options: "local" or "google"
     # ============== Local Search Configuration ==============
@@ -40,30 +40,6 @@ SEARCH_R1_CONFIGS = {
 
 
 SEMAPHORE = asyncio.Semaphore(SEARCH_R1_CONFIGS["search_concurrency"])
-
-
-def _build_inference_sampling_params(sampling_params: dict) -> dict:
-    """Map vllm-style sampling_params to vLLM /inference/v1/generate format."""
-    sp: dict = {
-        "max_tokens": sampling_params["max_new_tokens"],
-        "temperature": sampling_params["temperature"],
-        "top_p": sampling_params["top_p"],
-        "logprobs": 1,
-    }
-    tk = sampling_params.get("top_k")
-    if tk is not None and (tk > 0 or tk == -1):
-        sp["top_k"] = tk
-    if sampling_params.get("stop"):
-        sp["stop"] = sampling_params["stop"]
-        if sampling_params.get("no_stop_trim"):
-            sp["include_stop_str_in_output"] = True
-    if sampling_params.get("stop_token_ids"):
-        sp["stop_token_ids"] = sampling_params["stop_token_ids"]
-    if sampling_params.get("seed") is not None:
-        sp["seed"] = sampling_params["seed"]
-    if sampling_params.get("skip_special_tokens") is not None:
-        sp["skip_special_tokens"] = bool(sampling_params["skip_special_tokens"])
-    return sp
 
 
 def _passages2string(retrieval_result):
@@ -146,7 +122,7 @@ def postprocess_predictions(prediction: str):
     return action, content
 
 
-async def execute_predictions(prediction: str) -> str:
+async def execute_predictions(prediction: str) -> tuple[str, bool]:
     action, content = postprocess_predictions(prediction)
 
     if action == "search":

--- a/examples/search-r1/google_search_server.py
+++ b/examples/search-r1/google_search_server.py
@@ -1,0 +1,149 @@
+import asyncio
+import os
+import random
+import re
+
+import aiohttp
+import chardet
+
+
+# --- Utilities ---
+def parse_snippet(snippet: str) -> list[str]:
+    segments = snippet.split("...")
+    return [s.strip() for s in segments if len(s.strip().split()) > 5]
+
+
+def sanitize_search_query(query: str) -> str:
+    # Remove or replace special characters that might cause issues.
+    # This is a basic example; you might need to add more characters or patterns.
+    sanitized_query = re.sub(r"[^\w\s]", " ", query)  # Replace non-alphanumeric and non-whitespace with spaces.
+    sanitized_query = re.sub(
+        r"[\t\r\f\v\n]", " ", sanitized_query
+    )  # replace tab, return, formfeed, vertical tab with spaces.
+    sanitized_query = re.sub(
+        r"\s+", " ", sanitized_query
+    ).strip()  # remove duplicate spaces, and trailing/leading spaces.
+
+    return sanitized_query
+
+
+def filter_links(search_results: list[dict]) -> list[str]:
+    links = []
+    for result in search_results:
+        for item in result.get("items", []):
+            if "mime" in item:
+                continue
+            ext = os.path.splitext(item["link"])[1]
+            if ext in ["", ".html", ".htm", ".shtml"]:
+                links.append(item["link"])
+    return links
+
+
+async def fetch(session: aiohttp.ClientSession, url: str, semaphore: asyncio.Semaphore) -> str:
+    if url == "":
+        return ""
+    user_agents = [
+        "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P)...",
+        "Mozilla/5.0 AppleWebKit/537.36...",
+        "Mozilla/5.0 (compatible; Googlebot/2.1; +https://www.google.com/bot.html)",
+    ]
+    headers = {"User-Agent": random.choice(user_agents)}
+
+    async with semaphore:
+        try:
+            async with session.get(url, headers=headers) as response:
+                raw = await response.read()
+                detected = chardet.detect(raw)
+                encoding = detected["encoding"] or "utf-8"
+                return raw.decode(encoding, errors="ignore")
+        except (aiohttp.ClientError, asyncio.TimeoutError):
+            return ""
+
+
+async def fetch_all(urls: list[str], limit: int = 8) -> list[str]:
+    semaphore = asyncio.Semaphore(limit)
+    timeout = aiohttp.ClientTimeout(total=5)
+    connector = aiohttp.TCPConnector(limit_per_host=limit, force_close=True)
+
+    async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
+        tasks = [fetch(session, url, semaphore) for url in urls]
+        return await asyncio.gather(*tasks)
+
+
+def collect_context(snippet: str, doc: str) -> str:
+    snippets = parse_snippet(snippet)
+    ctx_paras = []
+
+    for s in snippets:
+        pos = doc.replace("\n", " ").find(s)
+        if pos == -1:
+            continue
+        sta = pos
+        while sta > 0 and doc[sta] != "\n":
+            sta -= 1
+        end = pos + len(s)
+        while end < len(doc) and doc[end] != "\n":
+            end += 1
+        para = doc[sta:end].strip()
+        if para not in ctx_paras:
+            ctx_paras.append(para)
+
+    return "\n".join(ctx_paras)
+
+
+async def google_search(api_key, query, top_k=5, timeout: int = 60, proxy=None, snippet_only=False) -> list[dict]:
+    timeout_obj = aiohttp.ClientTimeout(total=timeout)
+    session_kwargs = {}
+    if proxy:
+        session_kwargs["proxy"] = proxy
+    async with aiohttp.ClientSession(**session_kwargs) as session:
+        async with session.post(
+            "https://google.serper.dev/search",
+            json={
+                "q": query,
+                "num": top_k,
+                "gl": "us",
+                "hl": "en",
+            },
+            headers={
+                "Content-Type": "application/json",
+                "X-API-KEY": api_key,
+            },
+            timeout=timeout_obj,
+        ) as resp:
+            resp.raise_for_status()
+            response = await resp.json()
+            items = response.get("organic", [])
+
+    contexts = []
+    if snippet_only:
+        for item in items:
+            title = item.get("title", "")
+            context = " ".join(parse_snippet(item.get("snippet", "")))
+            if title != "" or context != "":
+                title = "No title." if not title else title
+                context = "No snippet available." if not context else context
+                contexts.append(
+                    {
+                        "document": {"contents": f'"{title}"\n{context}'},
+                    }
+                )
+    else:
+        links = [item.get("link", "") for item in items if "link" in item]
+        web_contents = await fetch_all(links)
+        contexts = []
+        for i, item in enumerate(items):
+            title = item.get("title", "")
+            snippet = item.get("snippet", "")
+
+            context = collect_context(snippet, web_contents[i])
+            if title != "" or context != "":
+                title = "No title." if not title else title
+                context = "No snippet available." if not context else context
+                contexts.append(
+                    {
+                        "document": {"contents": f'"{title}"\n{context}'},
+                    }
+                )
+
+    return contexts

--- a/examples/search-r1/google_search_server.py
+++ b/examples/search-r1/google_search_server.py
@@ -129,7 +129,7 @@ async def google_search(api_key, query, top_k=5, timeout: int = 60, proxy=None, 
                     }
                 )
     else:
-        links = [item.get("link", "") for item in items if "link" in item]
+        links = [item.get("link", "") for item in items]
         web_contents = await fetch_all(links)
         contexts = []
         for i, item in enumerate(items):

--- a/examples/search-r1/local_dense_retriever/download.py
+++ b/examples/search-r1/local_dense_retriever/download.py
@@ -1,0 +1,44 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+# Copyright 2023-2024 SGLang Team
+# Copyright 2025 Search-R1 Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Adapted from https://github.com/PeterGriffinJin/Search-R1/blob/main/scripts/download.py
+
+
+import argparse
+
+from huggingface_hub import hf_hub_download
+
+parser = argparse.ArgumentParser(description="Download files from a Hugging Face dataset repository.")
+parser.add_argument("--repo_id", type=str, default="PeterJinGo/wiki-18-e5-index", help="Hugging Face repository ID")
+parser.add_argument("--save_path", type=str, required=True, help="Local directory to save files")
+
+args = parser.parse_args()
+
+repo_id = "PeterJinGo/wiki-18-e5-index"
+for file in ["part_aa", "part_ab"]:
+    hf_hub_download(
+        repo_id=repo_id,
+        filename=file,  # e.g., "e5_Flat.index"
+        repo_type="dataset",
+        local_dir=args.save_path,
+    )
+
+repo_id = "PeterJinGo/wiki-18-corpus"
+hf_hub_download(
+    repo_id=repo_id,
+    filename="wiki-18.jsonl.gz",
+    repo_type="dataset",
+    local_dir=args.save_path,
+)

--- a/examples/search-r1/local_dense_retriever/retrieval_server.py
+++ b/examples/search-r1/local_dense_retriever/retrieval_server.py
@@ -1,0 +1,435 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+# Copyright 2023-2024 SGLang Team
+# Copyright 2025 Search-R1 Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Adapted from https://github.com/PeterGriffinJin/Search-R1/blob/main/search_r1/search/retrieval_server.py
+
+import argparse
+import json
+import warnings
+
+import datasets
+import faiss
+import numpy as np
+import torch
+import uvicorn
+from fastapi import FastAPI
+from pydantic import BaseModel
+from tqdm import tqdm
+from transformers import AutoModel, AutoTokenizer
+
+
+def load_corpus(corpus_path: str):
+    corpus = datasets.load_dataset("json", data_files=corpus_path, split="train", num_proc=4)
+    return corpus
+
+
+def load_docs(corpus, doc_idxs):
+    results = [corpus[int(idx)] for idx in doc_idxs]
+    return results
+
+
+def load_model(model_path: str, use_fp16: bool = False, device: torch.device | None = None):
+    """Load transformer model and tokenizer."""
+    if device is None:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    model = AutoModel.from_pretrained(model_path, trust_remote_code=True)
+    model.eval()
+    model.to(device)
+
+    if use_fp16 and device.type == "cuda":
+        model = model.half()
+    elif use_fp16 and device.type != "cuda":
+        warnings.warn("FP16 requested but CUDA is not available; running in FP32 on CPU.", stacklevel=2)
+
+    tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=True, trust_remote_code=True)
+    return model, tokenizer
+
+
+def pooling(pooler_output, last_hidden_state, attention_mask=None, pooling_method="mean"):
+    if pooling_method == "mean":
+        last_hidden = last_hidden_state.masked_fill(~attention_mask[..., None].bool(), 0.0)
+        return last_hidden.sum(dim=1) / attention_mask.sum(dim=1)[..., None]
+    elif pooling_method == "cls":
+        return last_hidden_state[:, 0]
+    elif pooling_method == "pooler":
+        return pooler_output
+    else:
+        raise NotImplementedError("Pooling method not implemented!")
+
+
+class Encoder:
+    def __init__(self, model_name, model_path, pooling_method, max_length, use_fp16):
+        self.model_name = model_name
+        self.model_path = model_path
+        self.pooling_method = pooling_method
+        self.max_length = max_length
+        self.use_fp16 = use_fp16
+        # Set the device
+        if torch.cuda.is_available():
+            self.device = torch.device("cuda")
+        else:
+            self.device = torch.device("cpu")
+        self.model, self.tokenizer = load_model(model_path=model_path, use_fp16=use_fp16, device=self.device)
+        self.model.eval()
+
+    @torch.no_grad()
+    def encode(self, query_list: list[str], is_query=True) -> np.ndarray:
+        # processing query for different encoders
+        if isinstance(query_list, str):
+            query_list = [query_list]
+
+        if "e5" in self.model_name.lower():
+            if is_query:
+                query_list = [f"query: {query}" for query in query_list]
+            else:
+                query_list = [f"passage: {query}" for query in query_list]
+
+        if "bge" in self.model_name.lower():
+            if is_query:
+                query_list = [
+                    f"Represent this sentence for searching relevant passages: {query}" for query in query_list
+                ]
+
+        inputs = self.tokenizer(
+            query_list, max_length=self.max_length, padding=True, truncation=True, return_tensors="pt"
+        )
+        inputs = {k: v.to(self.device) for k, v in inputs.items()}
+
+        if "T5" in type(self.model).__name__:
+            # T5-based retrieval model
+            decoder_input_ids = torch.zeros((inputs["input_ids"].shape[0], 1), dtype=torch.long).to(
+                inputs["input_ids"].device
+            )
+            output = self.model(**inputs, decoder_input_ids=decoder_input_ids, return_dict=True)
+            query_emb = output.last_hidden_state[:, 0, :]
+        else:
+            output = self.model(**inputs, return_dict=True)
+            query_emb = pooling(
+                output.pooler_output, output.last_hidden_state, inputs["attention_mask"], self.pooling_method
+            )
+            if "dpr" not in self.model_name.lower():
+                query_emb = torch.nn.functional.normalize(query_emb, dim=-1)
+
+        query_emb = query_emb.detach().cpu().numpy()
+        query_emb = query_emb.astype(np.float32, order="C")
+
+        del inputs, output
+        if self.device.type == "cuda":
+            torch.cuda.empty_cache()
+
+        return query_emb
+
+
+class BaseRetriever:
+    def __init__(self, config):
+        self.config = config
+        self.retrieval_method = config.retrieval_method
+        self.topk = config.retrieval_topk
+
+        self.index_path = config.index_path
+        self.corpus_path = config.corpus_path
+
+    def _search(self, query: str, num: int, return_score: bool):
+        raise NotImplementedError
+
+    def _batch_search(self, query_list: list[str], num: int, return_score: bool):
+        raise NotImplementedError
+
+    def search(self, query: str, num: int = None, return_score: bool = False):
+        return self._search(query, num, return_score)
+
+    def batch_search(self, query_list: list[str], num: int = None, return_score: bool = False):
+        return self._batch_search(query_list, num, return_score)
+
+
+class BM25Retriever(BaseRetriever):
+    def __init__(self, config):
+        super().__init__(config)
+        from pyserini.search.lucene import LuceneSearcher
+
+        self.searcher = LuceneSearcher(self.index_path)
+        self.contain_doc = self._check_contain_doc()
+        if not self.contain_doc:
+            self.corpus = load_corpus(self.corpus_path)
+        self.max_process_num = 8
+
+    def _check_contain_doc(self):
+        return self.searcher.doc(0).raw() is not None
+
+    def _search(self, query: str, num: int = None, return_score: bool = False):
+        if num is None:
+            num = self.topk
+        hits = self.searcher.search(query, num)
+        if len(hits) < 1:
+            if return_score:
+                return [], []
+            else:
+                return []
+        scores = [hit.score for hit in hits]
+        if len(hits) < num:
+            warnings.warn("Not enough documents retrieved!", stacklevel=2)
+        else:
+            hits = hits[:num]
+
+        if self.contain_doc:
+            all_contents = [json.loads(self.searcher.doc(hit.docid).raw())["contents"] for hit in hits]
+            results = [
+                {
+                    "title": content.split("\n")[0].strip('"'),
+                    "text": "\n".join(content.split("\n")[1:]),
+                    "contents": content,
+                }
+                for content in all_contents
+            ]
+        else:
+            results = load_docs(self.corpus, [hit.docid for hit in hits])
+
+        if return_score:
+            return results, scores
+        else:
+            return results
+
+    def _batch_search(self, query_list: list[str], num: int = None, return_score: bool = False):
+        results = []
+        scores = []
+        for query in query_list:
+            item_result, item_score = self._search(query, num, True)
+            results.append(item_result)
+            scores.append(item_score)
+        if return_score:
+            return results, scores
+        else:
+            return results
+
+
+class DenseRetriever(BaseRetriever):
+    def __init__(self, config):
+        super().__init__(config)
+        self.index = faiss.read_index(self.index_path)
+        if config.faiss_gpu:
+            co = faiss.GpuMultipleClonerOptions()
+            co.useFloat16 = True
+            co.shard = True
+            self.index = faiss.index_cpu_to_all_gpus(self.index, co=co)
+
+        self.corpus = load_corpus(self.corpus_path)
+        self.encoder = Encoder(
+            model_name=self.retrieval_method,
+            model_path=config.retrieval_model_path,
+            pooling_method=config.retrieval_pooling_method,
+            max_length=config.retrieval_query_max_length,
+            use_fp16=config.retrieval_use_fp16,
+        )
+        self.topk = config.retrieval_topk
+        self.batch_size = config.retrieval_batch_size
+
+    def _search(self, query: str, num: int = None, return_score: bool = False):
+        if num is None:
+            num = self.topk
+        query_emb = self.encoder.encode(query)
+        scores, idxs = self.index.search(query_emb, k=num)
+        idxs = idxs[0]
+        scores = scores[0]
+        results = load_docs(self.corpus, idxs)
+        if return_score:
+            return results, scores.tolist()
+        else:
+            return results
+
+    def _batch_search(self, query_list: list[str], num: int = None, return_score: bool = False):
+        if isinstance(query_list, str):
+            query_list = [query_list]
+        if num is None:
+            num = self.topk
+
+        results = []
+        scores = []
+        for start_idx in tqdm(range(0, len(query_list), self.batch_size), desc="Retrieval process: "):
+            query_batch = query_list[start_idx : start_idx + self.batch_size]
+            batch_emb = self.encoder.encode(query_batch)
+            batch_scores, batch_idxs = self.index.search(batch_emb, k=num)
+            batch_scores = batch_scores.tolist()
+            batch_idxs = batch_idxs.tolist()
+
+            # load_docs is not vectorized, but is a python list approach
+            flat_idxs = sum(batch_idxs, [])
+            batch_results = load_docs(self.corpus, flat_idxs)
+            # chunk them back
+            batch_results = [batch_results[i * num : (i + 1) * num] for i in range(len(batch_idxs))]
+
+            results.extend(batch_results)
+            scores.extend(batch_scores)
+
+            del batch_emb, batch_scores, batch_idxs, query_batch, flat_idxs, batch_results
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+        if return_score:
+            return results, scores
+        else:
+            return results
+
+
+def get_retriever(config):
+    if config.retrieval_method == "bm25":
+        return BM25Retriever(config)
+    else:
+        return DenseRetriever(config)
+
+
+#####################################
+# FastAPI server below
+#####################################
+
+
+class Config:
+    """
+    Minimal config class (simulating your argparse)
+    Replace this with your real arguments or load them dynamically.
+    """
+
+    def __init__(
+        self,
+        retrieval_method: str = "bm25",
+        retrieval_topk: int = 10,
+        index_path: str = "./index/bm25",
+        corpus_path: str = "./data/corpus.jsonl",
+        dataset_path: str = "./data",
+        data_split: str = "train",
+        faiss_gpu: bool = True,
+        retrieval_model_path: str = "./model",
+        retrieval_pooling_method: str = "mean",
+        retrieval_query_max_length: int = 256,
+        retrieval_use_fp16: bool = False,
+        retrieval_batch_size: int = 128,
+    ):
+        self.retrieval_method = retrieval_method
+        self.retrieval_topk = retrieval_topk
+        self.index_path = index_path
+        self.corpus_path = corpus_path
+        self.dataset_path = dataset_path
+        self.data_split = data_split
+        self.faiss_gpu = faiss_gpu
+        self.retrieval_model_path = retrieval_model_path
+        self.retrieval_pooling_method = retrieval_pooling_method
+        self.retrieval_query_max_length = retrieval_query_max_length
+        self.retrieval_use_fp16 = retrieval_use_fp16
+        self.retrieval_batch_size = retrieval_batch_size
+
+
+class QueryRequest(BaseModel):
+    queries: list[str]
+    topk: int | None = None
+    return_scores: bool = False
+
+
+app = FastAPI()
+
+
+@app.post("/retrieve")
+def retrieve_endpoint(request: QueryRequest):
+    """
+    Endpoint that accepts queries and performs retrieval.
+
+    Input format:
+    {
+      "queries": ["What is Python?", "Tell me about neural networks."],
+      "topk": 3,
+      "return_scores": true
+    }
+
+    Output format (when return_scores=True，similarity scores are returned):
+    {
+        "result": [
+            [   # Results for each query
+                {
+                    {"document": doc, "score": score}
+                },
+                # ... more documents
+            ],
+            # ... results for other queries
+        ]
+    }
+    """
+    if not request.topk:
+        request.topk = config.retrieval_topk  # fallback to default
+
+    # Perform batch retrieval
+    tmp = retriever.batch_search(query_list=request.queries, num=request.topk, return_score=request.return_scores)
+
+    scores = []
+    try:
+        results, scores = tmp
+    except ValueError:
+        results = tmp
+
+    # Format response
+    resp = []
+    for i, single_result in enumerate(results):
+        if scores:
+            # If scores are returned, combine them with results
+            combined = []
+            for doc, score in zip(single_result, scores[i], strict=True):
+                combined.append({"document": doc, "score": score})
+            resp.append(combined)
+        else:
+            resp.append(single_result)
+    return {"result": resp}
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Launch the local faiss retriever.")
+    parser.add_argument(
+        "--index_path",
+        type=str,
+        default="./e5_Flat.index",
+        help="Corpus indexing file.",
+    )
+    parser.add_argument(
+        "--corpus_path",
+        type=str,
+        default="./wiki-18.jsonl",
+        help="Local corpus file.",
+    )
+    parser.add_argument("--topk", type=int, default=3, help="Number of retrieved passages for one query.")
+    parser.add_argument("--retriever_name", type=str, default="e5", help="Name of the retriever model.")
+    parser.add_argument(
+        "--retriever_model", type=str, default="intfloat/e5-base-v2", help="Path of the retriever model."
+    )
+    parser.add_argument("--faiss_gpu", action="store_true", help="Use GPU for computation")
+
+    args = parser.parse_args()
+
+    # 1) Build a config (could also parse from arguments).
+    #    In real usage, you'd parse your CLI arguments or environment variables.
+    config = Config(
+        retrieval_method=args.retriever_name,  # or "dense"
+        index_path=args.index_path,
+        corpus_path=args.corpus_path,
+        retrieval_topk=args.topk,
+        faiss_gpu=args.faiss_gpu,
+        retrieval_model_path=args.retriever_model,
+        retrieval_pooling_method="mean",
+        retrieval_query_max_length=256,
+        retrieval_use_fp16=True,
+        retrieval_batch_size=512,
+    )
+
+    # 2) Instantiate a global retriever so it is loaded once and reused.
+    retriever = get_retriever(config)
+
+    # 3) Launch the server. By default, it listens on http://127.0.0.1:8000
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/examples/search-r1/local_search_server.py
+++ b/examples/search-r1/local_search_server.py
@@ -26,7 +26,7 @@ async def local_search(
     search_url: str,
     query: str,
     top_k: int = 5,
-    timeout: int = 600,
+    timeout: int = 1200,
     proxy: str | None = None,
 ) -> list[dict]:
     """

--- a/examples/search-r1/local_search_server.py
+++ b/examples/search-r1/local_search_server.py
@@ -1,0 +1,97 @@
+"""
+Local Search Server for Search-R1
+
+This module provides a local search engine interface that mimics the google_search_server.py API.
+It sends requests to a local retrieval server (e.g., running retrieval_server.py from Search-R1)
+and formats the results to match the expected output format.
+
+Usage:
+    In your generate_with_search.py, replace:
+        from google_search_server import google_search
+    with:
+        from local_search_server import local_search as google_search
+
+    And update SEARCH_R1_CONFIGS:
+        SEARCH_R1_CONFIGS = {
+            "search_url": "http://127.0.0.1:8000/retrieve",  # URL of local retrieval server
+            "topk": 3,
+            ...
+        }
+"""
+
+import aiohttp
+
+
+async def local_search(
+    search_url: str,
+    query: str,
+    top_k: int = 5,
+    timeout: int = 600,
+    proxy: str | None = None,
+) -> list[dict]:
+    """
+    Call local search engine server and format results to match google_search_server.py output.
+
+    This function provides the same interface as google_search() from google_search_server.py,
+    making it a drop-in replacement. The only difference is that instead of using an API key,
+    it uses a search_url parameter.
+
+    Args:
+        search_url: URL of the local retrieval server (e.g., "http://127.0.0.1:8000/retrieve")
+        query: Search query string
+        top_k: Number of results to retrieve
+        timeout: Request timeout in seconds (default: 60)
+        proxy: Proxy URL if needed (not used for local retrieval, kept for API compatibility)
+        snippet_only: If True, only return snippet (kept for API compatibility with google_search)
+
+    Returns:
+        List of dictionaries with format: [{"document": {"contents": '"<title>"\n<text>'}}]
+        This matches the output format of google_search() from google_search_server.py
+    """
+    # Prepare request payload for local retrieval server
+    payload = {
+        "queries": [query],
+        "topk": top_k,
+        "return_scores": False,  # We don't need scores for compatibility with google_search_server
+    }
+
+    # Send async request to local retrieval server
+    timeout_obj = aiohttp.ClientTimeout(total=timeout)
+    session_kwargs = {}
+    # Note: proxy parameter is kept for API compatibility but typically not needed for local server
+    if proxy:
+        session_kwargs["proxy"] = proxy
+
+    try:
+        async with aiohttp.ClientSession(**session_kwargs) as session:
+            async with session.post(search_url, json=payload, timeout=timeout_obj) as resp:
+                resp.raise_for_status()
+                result = await resp.json()
+    except Exception as e:
+        print(f"Error calling local search engine at {search_url}: {repr(e)}")
+        return []
+
+    # Parse retrieval results
+    # Format from retrieval_server.py: {"result": [[{"document": {"id": "...", "contents": "..."}}]]}
+    retrieval_results = result.get("result", [[]])[0]
+    # Format to match google_search_server.py output
+    # Google format: [{"document": {"contents": '"<title>"\n<context>'}}]
+    contexts = []
+
+    for item in retrieval_results:
+        # Extract contents from retrieval result
+        # retrieval_server returns: {"document": {"id": "...", "contents": '"Title"\nText...'}}
+        if isinstance(item, dict):
+            # Access the document dict first, then get contents
+            content = item.get("contents", "")
+
+            if content:
+                # The contents are already in the correct format: '"Title"\nText content...'
+                # Just pass through as-is to match google_search format
+                contexts.append({"document": {"contents": content}})
+            else:
+                # Empty content case - provide default values
+                contexts.append({"document": {"contents": '"No title."\nNo snippet available.'}})
+
+    # If no results found, return empty list (consistent with google_search_server.py)
+    return contexts

--- a/examples/search-r1/qa_em_format.py
+++ b/examples/search-r1/qa_em_format.py
@@ -1,0 +1,208 @@
+# Adapt from https://github.com/PeterGriffinJin/Search-R1/blob/ceee7b89655ed52f205b9beb98e1190c3eedcfb0/verl/utils/reward_score/qa_em_format.py
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import re
+import string
+
+
+def normalize_answer(s):
+    def remove_articles(text):
+        return re.sub(r"\b(a|an|the)\b", " ", text)
+
+    def white_space_fix(text):
+        return " ".join(text.split())
+
+    def remove_punc(text):
+        exclude = set(string.punctuation)
+        return "".join(ch for ch in text if ch not in exclude)
+
+    def lower(text):
+        return text.lower()
+
+    return white_space_fix(remove_articles(remove_punc(lower(s))))
+
+
+def em_check(prediction, golden_answers):
+    if isinstance(golden_answers, str):
+        golden_answers = [golden_answers]
+    normalized_prediction = normalize_answer(prediction)
+    score = 0
+    for golden_answer in golden_answers:
+        golden_answer = normalize_answer(golden_answer)
+        if golden_answer == normalized_prediction:
+            score = 1
+            break
+    return score
+
+
+def is_valid_sequence(text):
+    # Find the position of "<|im_start|>assistant" with potential whitespace
+    assistant_pattern = r"<\|im_start\|>assistant\s*"
+    assistant_match = re.search(assistant_pattern, text)
+
+    if not assistant_match:
+        return False, "Missing assistant marker"
+
+    # Extract the content after the assistant marker
+    start_pos = assistant_match.end()
+    content = text[start_pos:]
+
+    # Check for balanced tags
+    tags_to_check = ["think", "search", "information", "answer"]
+    for tag in tags_to_check:
+        opening_count = len(re.findall(f"<{tag}>", content))
+        closing_count = len(re.findall(f"</{tag}>", content))
+        if opening_count != closing_count:
+            return False, f"Mismatch in {tag} tags: {opening_count} opening vs {closing_count} closing tags"
+
+    # Now check for proper sequence pattern and no extraneous content
+
+    # 1. First split the content by any tags we recognize
+    split_pattern = r"(</?(?:think|search|information|answer)>)"
+    parts = re.split(split_pattern, content)
+
+    # 2. Keep track of the current position in the expected sequence
+    state = "start"  # start -> think -> search -> information -> think -> ... -> answer -> end
+
+    # 3. Check each part
+    for _i, part in enumerate(parts):
+        # Skip empty parts
+        if not part.strip():
+            continue
+
+        # Check if this is a tag
+        if re.match(r"</?(?:think|search|information|answer)>", part):
+            # This is a tag, check if it's valid in the current state
+            if part == "<think>" and state in ["start", "information"]:
+                state = "in_think"
+            elif part == "</think>" and state == "in_think":
+                state = "after_think"
+            elif part == "<search>" and state == "after_think":
+                state = "in_search"
+            elif part == "</search>" and state == "in_search":
+                state = "after_search"
+            elif part == "<information>" and state == "after_search":
+                state = "in_information"
+            elif part == "</information>" and state == "in_information":
+                state = "information"
+            elif part == "<answer>" and state == "after_think":
+                state = "in_answer"
+            elif part == "</answer>" and state == "in_answer":
+                state = "end"
+            else:
+                return False, f"Unexpected tag {part} in state {state}"
+        else:
+            # This is content, check if it's valid in the current state
+            if state in ["in_think", "in_search", "in_information", "in_answer"]:
+                # Content is allowed inside tags
+                pass
+            elif state in ["start", "after_think", "after_search", "information"]:
+                # Only whitespace is allowed between tags
+                if part.strip():
+                    return False, f"Unexpected content '{part.strip()}' between tags (state: {state})"
+            else:
+                return False, f"Unexpected content in state {state}"
+
+    # Check final state
+    if state != "end":
+        return False, f"Incomplete sequence, ended in state {state}"
+
+    return True, "Valid sequence format"
+
+
+def extract_solution(solution_str):
+    """Extract the equation from the solution string."""
+
+    answer_pattern = r"<answer>(.*?)</answer>"
+    match = re.finditer(answer_pattern, solution_str, re.DOTALL)
+    matches = list(match)
+
+    # If there are 0 or exactly 1 matches, return None
+    if len(matches) <= 1:
+        return None
+
+    # If there are 2 or more matches, return the last one
+    return matches[-1].group(1).strip()
+
+
+def extract_information_blocks(text: str) -> list[str]:
+    pattern = r"<information>(.*?)</information>"
+    matches = re.findall(pattern, text, re.DOTALL)
+    return [match.strip() for match in matches]
+
+
+def is_retrieval_correct(text: str, golden_answers: list[str]) -> list[str]:
+    seqs = extract_information_blocks(text)
+    for seq in seqs:
+        for golden_answer in golden_answers:
+            if normalize_answer(golden_answer) in normalize_answer(seq):
+                return True
+    return False
+
+
+def compute_score_em(
+    solution_str,
+    ground_truth,
+    method="strict",
+    structure_format_score=0,
+    final_format_score=0,
+    retrieval_score=0,
+    format_score=0,
+    score=1.0,
+):
+    """The scoring function for exact match (EM).
+
+    Args:
+        solution_str: the solution text
+        ground_truth: the ground truth
+        method: the method to extract the solution, choices are 'strict' and 'flexible'
+        format_score: the score for the format
+        score: the score for the correct answer
+    """
+    is_valid_format, _ = is_valid_sequence(solution_str)
+    retrieval_correct = False
+    if is_valid_format:
+        retrieval_correct = is_retrieval_correct(solution_str, ground_truth["target"])
+    answer = extract_solution(solution_str=solution_str)
+    do_print = random.randint(1, 64) == 1
+
+    if do_print:
+        print("--------------------------------")
+        print(f"Golden answers: {ground_truth['target']}")
+        print(f"Extracted answer: {answer}")
+        print(f"Solution string: {solution_str}")
+
+    if answer is None:
+        if is_valid_format:
+            if retrieval_correct:
+                return structure_format_score + retrieval_score  # 0.3
+            else:
+                return structure_format_score  # 0.2
+        else:
+            return 0
+    else:
+        if em_check(answer, ground_truth["target"]):
+            if is_valid_format:
+                return score  # 1
+            else:
+                return score - structure_format_score  # 0.8
+        elif is_valid_format:
+            if retrieval_correct:
+                return structure_format_score + retrieval_score  # 0.3
+            else:
+                return structure_format_score  # 0.2
+        else:
+            return final_format_score  # 0.1

--- a/examples/search-r1/qa_em_format.py
+++ b/examples/search-r1/qa_em_format.py
@@ -144,7 +144,7 @@ def extract_information_blocks(text: str) -> list[str]:
     return [match.strip() for match in matches]
 
 
-def is_retrieval_correct(text: str, golden_answers: list[str]) -> list[str]:
+def is_retrieval_correct(text: str, golden_answers: list[str]) -> bool:
     seqs = extract_information_blocks(text)
     for seq in seqs:
         for golden_answer in golden_answers:

--- a/examples/search-r1/run_qwen2.5_3B.sh
+++ b/examples/search-r1/run_qwen2.5_3B.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+set -ex
+
+# cleanup
+pkill -9 -f "vllm serve" 2>/dev/null || true
+sleep 2
+npu-smi info 2>/dev/null | grep rayWorker | awk '{print $4}' | xargs -r kill -9 2>/dev/null || true
+sleep 3
+
+# Ray isolation: independent temp-dir, ports, and cleanup
+export RAY_TMPDIR=/tmp/ray_vime_npu_search_r1
+export RAY_PORT=6379
+export RAY_DASHBOARD_PORT=8265
+export RAY_AGENT_PORT=52378
+unset RAY_ADDRESS RAY_REDIS_ADDRESS
+
+ray stop --force 2>/dev/null || true
+rm -rf "${RAY_TMPDIR}"
+sleep 2
+
+project_name="vime"
+exp_name="qwen2.5-3B-search-r1"
+RAY_DATA_HOME=${RAY_DATA_HOME:-"/root/logs"}
+start_time=$(date +"%Y%m%d_%H%M%S")
+LOG_DIR=${LOG_DIR:-"${RAY_DATA_HOME}/${project_name}/${exp_name}"}
+mkdir -p "${LOG_DIR}"
+LOG_FILE="${LOG_DIR}/${start_time}.log"
+
+echo "Experiment Log will be saved to: ${LOG_FILE}"
+VIME_DIR="/root/vime"
+
+# NPU environment
+source /usr/local/Ascend/driver/bin/setenv.bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+export PYTHONPATH="${VIME_DIR}/examples/search-r1:/root/Megatron-LM:/root/vllm:/root/vllm-ascend:${VIME_DIR}:/root/Megatron-Bridge:/root/mbridge:/root/MindSpeed:/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:/usr/local/Ascend/ascend-toolkit/latest/tools/ms_fmk_transplt/torch_npu_bridge:${PYTHONPATH}"
+export PYTHONUNBUFFERED=1
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:False
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+export HCCL_HOST_SOCKET_PORT_RANGE=60000-60050
+export HCCL_NPU_SOCKET_PORT_RANGE=61000-61050
+export HCCL_CONNECT_TIMEOUT=7200
+export HCCL_DETERMINISTIC=true
+export VLLM_ASCEND_ENABLE_NZ=0
+export ASCEND_COREDUMP_SIGNAL=None
+export ATB_MATMUL_SHUFFLE_K_ENABLE=0
+export ATB_LLM_LCOC_ENABLE=0
+export TASK_QUEUE_ENABLE=1
+export RAY_DISABLE_SIGINT_OVERRIDE=1
+export RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1
+export RAY_DEDUP_LOGS=0
+export LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64:/usr/local/Ascend/ascend-toolkit/latest/lib64:/usr/local/Ascend/nnal/atb/latest/atb/cxx_abi_1/lib:/usr/local/Ascend/cann/lib64:${LD_LIBRARY_PATH}
+export VLLM_USE_AOT_COMPILE=0
+
+NUM_NPUS=8
+source "${VIME_DIR}/scripts/models/qwen2.5-3B.sh"
+
+CKPT_ARGS=(
+   --hf-checkpoint /path/to/Qwen2.5-3B-Instruct
+   --ref-load  /path/to/Qwen2.5-3B-Instruct
+   # --load /path/to/Qwen2.5-3B-Instruct_vime_npu/
+   # --save /path/to/Qwen2.5-3B-Instruct_vime_npu/
+   # --save-interval 100
+   --no-load-optim
+   --megatron-to-hf-mode bridge
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data /path/to/nq_hotpotqa_train/train.parquet
+   --input-key prompt
+   --label-key reward_model
+   --apply-chat-template
+   --rollout-shuffle
+   --num-rollout 300
+   --rollout-batch-size 64
+   --n-samples-per-prompt 4
+   --rollout-max-response-len 512
+   --rollout-temperature 1
+   --global-batch-size 256
+   --balance-data
+)
+
+EVAL_ARGS=(
+   #--eval-interval 20
+   #--eval-prompt-data nq_test /path/to/nq_hotpotqa_train/test.parquet
+   #--n-samples-per-eval-prompt 16
+   #--eval-max-response-len 2048
+   #--eval-top-p 1
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 2
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+   # --micro-batch-size 1
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 9216
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --use-kl-loss
+   --kl-loss-coef 0.001
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+
+   # TIS (Trajectory Importance Sampling)
+   --use-tis
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --lr-warmup-fraction 0.1
+   --weight-decay 0.01
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+VLLM_ARGS=(
+   --rollout-num-gpus-per-engine 2
+   --vllm-gpu-memory-utilization 0.7
+   --vllm-enable-sleep-mode
+   --vllm-weight-sync-mode native
+)
+
+MISC_ARGS=(
+   # --transformer-impl local
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+   --use-flash-attn
+)
+
+CUSTOM_ARGS=(
+   --custom-generate-function-path generate_with_search.generate
+   --custom-rm-path generate_with_search.reward_func
+
+   # TIS (Trajectory Importance Sampling)
+   --custom-config-path examples/train_infer_mismatch_helper/mis.yaml
+   --custom-tis-function-path examples.train_infer_mismatch_helper.mis.compute_mis_weights_with_cp
+)
+
+# launch the master node of ray in container
+unset https_proxy http_proxy proxy
+ray start --head \
+    --temp-dir="${RAY_TMPDIR}" \
+    --port="${RAY_PORT}" \
+    --dashboard-port="${RAY_DASHBOARD_PORT}" \
+    --dashboard-agent-listen-port="${RAY_AGENT_PORT}" \
+    --node-ip-address 127.0.0.1 \
+    --num-gpus 0 \
+    --resources "{\"NPU\": ${NUM_NPUS}}" \
+    --disable-usage-stats \
+    --dashboard-host=0.0.0.0
+
+# Build the runtime environment JSON with proper variable substitution
+RUNTIME_ENV_JSON=$(cat << 'EOF'
+{
+  "env_vars": {
+    "PYTHONPATH": "/root/vime/examples/search-r1:/root/Megatron-LM:/root/vllm:/root/vllm-ascend:/root/vime:/root/Megatron-Bridge:/root/mbridge:/root/MindSpeed:/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:/usr/local/Ascend/ascend-toolkit/latest/tools/ms_fmk_transplt/torch_npu_bridge",
+    "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+    "HCCL_HOST_SOCKET_PORT_RANGE": "60000-60050",
+    "HCCL_NPU_SOCKET_PORT_RANGE": "61000-61050",
+    "HCCL_CONNECT_TIMEOUT": "7200",
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:False",
+    "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES": "1",
+    "LD_LIBRARY_PATH": "/usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64/driver:/usr/local/Ascend/driver/lib64/common:/usr/local/Ascend/ascend-toolkit/latest/lib64:/usr/local/Ascend/ascend-toolkit/latest/compiler/lib64/plugin/opskernel:/usr/local/Ascend/ascend-toolkit/latest/compiler/lib64/plugin/nnengine:/usr/local/Ascend/ascend-toolkit/latest/opp/built-in/op_impl/ai_core/tbe/op_tiling/lib/:/usr/local/Ascend/nnal/atb/latest/atb/cxx_abi_1/lib:/usr/local/Ascend/cann/lib64:/usr/local/Ascend/cann/aarch64-linux/devlib"
+  }
+}
+EOF
+)
+
+ray job submit --address="http://127.0.0.1:${RAY_DASHBOARD_PORT}" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   --working-dir="/root/vime" \
+   -- python3 train.py \
+   --train-backend megatron \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node 4 \
+   --rollout-num-gpus 4 \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${VLLM_ARGS[@]} \
+   ${MISC_ARGS[@]} \
+   ${CUSTOM_ARGS[@]} \
+   2>&1 | grep --line-buffered -vE "(Accessing \`.*\` from \`.*\`. Returning|CONSISTENT_HASH)" | tee "${LOG_FILE}"

--- a/examples/search-r1/run_qwen3_4b_npu.sh
+++ b/examples/search-r1/run_qwen3_4b_npu.sh
@@ -57,7 +57,7 @@ export TRANSFORMERS_VERBOSITY=error
 export RUST_LOG=vllm_router_rs=warn
 
 NUM_NPUS=16
-source "${VIME_DIR}/scripts/models/qwen2.5-3B.sh"
+source "${VIME_DIR}/scripts/models/qwen3-4B-Instruct-2507.sh"
 
 CKPT_ARGS=(
    --hf-checkpoint /path/to/Qwen3-4B-Instruct-2507

--- a/examples/search-r1/run_qwen3_4b_npu.sh
+++ b/examples/search-r1/run_qwen3_4b_npu.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -ex
+ulimit -u 65535
 
 # cleanup
 pkill -9 -f "vllm serve" 2>/dev/null || true
@@ -19,7 +20,7 @@ rm -rf "${RAY_TMPDIR}"
 sleep 2
 
 project_name="vime"
-exp_name="qwen2.5-3B-search-r1"
+exp_name="qwen3-4b-search-r1"
 RAY_DATA_HOME=${RAY_DATA_HOME:-"/root/logs"}
 start_time=$(date +"%Y%m%d_%H%M%S")
 LOG_DIR=${LOG_DIR:-"${RAY_DATA_HOME}/${project_name}/${exp_name}"}
@@ -37,7 +38,7 @@ export PYTHONPATH="${VIME_DIR}/examples/search-r1:/root/Megatron-LM:/root/vllm:/
 export PYTHONUNBUFFERED=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:False
 export CUDA_DEVICE_MAX_CONNECTIONS=1
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
 export HCCL_HOST_SOCKET_PORT_RANGE=60000-60050
 export HCCL_NPU_SOCKET_PORT_RANGE=61000-61050
 export HCCL_CONNECT_TIMEOUT=7200
@@ -49,19 +50,21 @@ export ATB_LLM_LCOC_ENABLE=0
 export TASK_QUEUE_ENABLE=1
 export RAY_DISABLE_SIGINT_OVERRIDE=1
 export RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1
-export RAY_DEDUP_LOGS=0
 export LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64:/usr/local/Ascend/ascend-toolkit/latest/lib64:/usr/local/Ascend/nnal/atb/latest/atb/cxx_abi_1/lib:/usr/local/Ascend/cann/lib64:${LD_LIBRARY_PATH}
 export VLLM_USE_AOT_COMPILE=0
+export VLLM_DISABLE_COMPILE_CACHE=1
+export TRANSFORMERS_VERBOSITY=error
+export RUST_LOG=vllm_router_rs=warn
 
-NUM_NPUS=8
+NUM_NPUS=16
 source "${VIME_DIR}/scripts/models/qwen2.5-3B.sh"
 
 CKPT_ARGS=(
-   --hf-checkpoint /path/to/Qwen2.5-3B-Instruct
-   --ref-load  /path/to/Qwen2.5-3B-Instruct
-   # --load /path/to/Qwen2.5-3B-Instruct_vime_npu/
-   # --save /path/to/Qwen2.5-3B-Instruct_vime_npu/
-   # --save-interval 100
+   --hf-checkpoint /path/to/Qwen3-4B-Instruct-2507
+   --ref-load  /path/to/Qwen3-4B-Instruct-2507
+   --load /path/to/Qwen3-4B-Instruct-2507_vime_npu/
+   --save /path/to/Qwen3-4B-Instruct-2507_vime_npu/
+   --save-interval 100
    --no-load-optim
    --megatron-to-hf-mode bridge
 )
@@ -72,9 +75,9 @@ ROLLOUT_ARGS=(
    --label-key reward_model
    --apply-chat-template
    --rollout-shuffle
-   --num-rollout 300
-   --rollout-batch-size 64
-   --n-samples-per-prompt 4
+   --num-rollout 200
+   --rollout-batch-size 32
+   --n-samples-per-prompt 8
    --rollout-max-response-len 512
    --rollout-temperature 1
    --global-batch-size 256
@@ -82,24 +85,26 @@ ROLLOUT_ARGS=(
 )
 
 EVAL_ARGS=(
-   #--eval-interval 20
-   #--eval-prompt-data nq_test /path/to/nq_hotpotqa_train/test.parquet
-   #--n-samples-per-eval-prompt 16
-   #--eval-max-response-len 2048
-   #--eval-top-p 1
+   --eval-interval 50
+   --eval-prompt-data nq_test /path/to/nq_hotpotqa_train/test.parquet@[0:500]
+   --n-samples-per-eval-prompt 1
+   --eval-input-key prompt
+   --eval-label-key reward_model
+   --eval-top-p 1
 )
 
 PERF_ARGS=(
-   --tensor-model-parallel-size 2
-   --sequence-parallel
+   --tensor-model-parallel-size 4
    --pipeline-model-parallel-size 1
    --context-parallel-size 1
    --expert-model-parallel-size 1
    --expert-tensor-parallel-size 1
+
    --recompute-granularity full
    --recompute-method uniform
    --recompute-num-layers 1
-   # --micro-batch-size 1
+
+   --micro-batch-size 1
    --use-dynamic-batch-size
    --max-tokens-per-gpu 9216
 )
@@ -114,15 +119,14 @@ GRPO_ARGS=(
    --eps-clip-high 0.28
 
    # TIS (Trajectory Importance Sampling)
-   --use-tis
+   # --use-tis
 )
 
 OPTIMIZER_ARGS=(
    --optimizer adam
    --lr 1e-6
    --lr-decay-style constant
-   --lr-warmup-fraction 0.1
-   --weight-decay 0.01
+   --weight-decay 0.1
    --adam-beta1 0.9
    --adam-beta2 0.98
    --optimizer-cpu-offload
@@ -131,14 +135,13 @@ OPTIMIZER_ARGS=(
 )
 
 VLLM_ARGS=(
-   --rollout-num-gpus-per-engine 2
+   --rollout-num-gpus-per-engine 4
    --vllm-gpu-memory-utilization 0.7
    --vllm-enable-sleep-mode
    --vllm-weight-sync-mode native
 )
 
 MISC_ARGS=(
-   # --transformer-impl local
    --attention-dropout 0.0
    --hidden-dropout 0.0
    --accumulate-allreduce-grads-in-fp32
@@ -152,8 +155,8 @@ CUSTOM_ARGS=(
    --custom-rm-path generate_with_search.reward_func
 
    # TIS (Trajectory Importance Sampling)
-   --custom-config-path examples/train_infer_mismatch_helper/mis.yaml
-   --custom-tis-function-path examples.train_infer_mismatch_helper.mis.compute_mis_weights_with_cp
+   # --custom-config-path examples/train_infer_mismatch_helper/mis.yaml
+   # --custom-tis-function-path examples.train_infer_mismatch_helper.mis.compute_mis_weights_with_cp
 )
 
 # launch the master node of ray in container
@@ -165,7 +168,7 @@ ray start --head \
     --dashboard-agent-listen-port="${RAY_AGENT_PORT}" \
     --node-ip-address 127.0.0.1 \
     --num-gpus 0 \
-    --resources "{\"NPU\": ${NUM_NPUS}}" \
+    --resources "{\"NPU\": $NUM_NPUS}" \
     --disable-usage-stats \
     --dashboard-host=0.0.0.0
 
@@ -173,13 +176,16 @@ ray start --head \
 RUNTIME_ENV_JSON=$(cat << 'EOF'
 {
   "env_vars": {
-    "PYTHONPATH": "/root/vime/examples/search-r1:/root/Megatron-LM:/root/vllm:/root/vllm-ascend:/root/vime:/root/Megatron-Bridge:/root/mbridge:/root/MindSpeed:/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:/usr/local/Ascend/ascend-toolkit/latest/tools/ms_fmk_transplt/torch_npu_bridge",
+    "PYTHONPATH": "${VIME_DIR}/examples/search-r1:/root/Megatron-LM:/root/vllm:/root/vllm-ascend:${VIME_DIR}:/root/Megatron-Bridge:/root/mbridge:/root/MindSpeed:/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:/usr/local/Ascend/ascend-toolkit/latest/tools/ms_fmk_transplt/torch_npu_bridge",
     "CUDA_DEVICE_MAX_CONNECTIONS": "1",
     "HCCL_HOST_SOCKET_PORT_RANGE": "60000-60050",
     "HCCL_NPU_SOCKET_PORT_RANGE": "61000-61050",
     "HCCL_CONNECT_TIMEOUT": "7200",
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:False",
     "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES": "1",
+    "VLLM_DISABLE_COMPILE_CACHE": "1",
+    "TRANSFORMERS_VERBOSITY": "error",
+    "RUST_LOG": "vllm_router_rs=warn",
     "LD_LIBRARY_PATH": "/usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64/driver:/usr/local/Ascend/driver/lib64/common:/usr/local/Ascend/ascend-toolkit/latest/lib64:/usr/local/Ascend/ascend-toolkit/latest/compiler/lib64/plugin/opskernel:/usr/local/Ascend/ascend-toolkit/latest/compiler/lib64/plugin/nnengine:/usr/local/Ascend/ascend-toolkit/latest/opp/built-in/op_impl/ai_core/tbe/op_tiling/lib/:/usr/local/Ascend/nnal/atb/latest/atb/cxx_abi_1/lib:/usr/local/Ascend/cann/lib64:/usr/local/Ascend/cann/aarch64-linux/devlib"
   }
 }
@@ -188,12 +194,12 @@ EOF
 
 ray job submit --address="http://127.0.0.1:${RAY_DASHBOARD_PORT}" \
    --runtime-env-json="${RUNTIME_ENV_JSON}" \
-   --working-dir="/root/vime" \
-   -- python3 train.py \
+   --working-dir="${VIME_DIR}" \
+   -- python3 -u train.py \
    --train-backend megatron \
    --actor-num-nodes 1 \
-   --actor-num-gpus-per-node 4 \
-   --rollout-num-gpus 4 \
+   --actor-num-gpus-per-node 8 \
+   --rollout-num-gpus 8 \
    ${MODEL_ARGS[@]} \
    ${CKPT_ARGS[@]} \
    ${ROLLOUT_ARGS[@]} \
@@ -204,4 +210,4 @@ ray job submit --address="http://127.0.0.1:${RAY_DASHBOARD_PORT}" \
    ${VLLM_ARGS[@]} \
    ${MISC_ARGS[@]} \
    ${CUSTOM_ARGS[@]} \
-   2>&1 | grep --line-buffered -vE "(Accessing \`.*\` from \`.*\`. Returning|CONSISTENT_HASH)" | tee "${LOG_FILE}"
+   2>&1 | tee "${LOG_FILE}"


### PR DESCRIPTION
# Search-R1 lite

This example is ported from [slime](https://github.com/THUDM/slime) (Megatron + SGLang) and adapted for vime (Megatron + vLLM). It provides minimal reproduction of [Search-R1](https://github.com/PeterGriffinJin/Search-R1), demonstrating multi-turn conversation and tool-calling workflows in vime.

## Overview

The Search-R1 example provides:

- **Multi-turn conversation** with tool-calling (search/answer actions)
- **Dual search backend support**: local dense retriever (FAISS + E5) or Google Search (serper.dev)
- **GRPO-based RL training** with exact-match (EM) reward for QA tasks
- **TIS (Trajectory Importance Sampling)** support for handling train/inference mismatch
- **Format-aware reward** that evaluates both answer correctness and output structure

## Files

| File | Description |
|------|-------------|
| `generate_with_search.py` | Main generation function with multi-turn search + answer tool-calling, and reward function |
| `google_search_server.py` | Google Search backend via serper.dev API |
| `local_search_server.py` | Local search backend that wraps the retrieval server |
| `qa_em_format.py` | QA exact-match scoring with format validation and retrieval correctness check |
| `run_qwen3_4b_npu.sh` | Training launch script (NPU 8-card, Qwen2.5-3B, GRPO) |
| `local_dense_retriever/retrieval_server.py` | Dense retriever server (FAISS + E5 model, FastAPI) |
| `local_dense_retriever/download.py` | Download wiki-18 index and corpus from HuggingFace |

## Results

<img width="647" height="351" alt="reward" src="https://github.com/user-attachments/assets/e9d41b54-f7ad-4277-a162-c79d725eee73" />
<img width="647" height="351" alt="diff" src="https://github.com/user-attachments/assets/a9e49975-606e-4ce6-8b6c-397496c2eae9" />
<img width="647" height="351" alt="eval" src="https://github.com/user-attachments/assets/6e84a9e6-224e-47ce-8b39-49d69b318a39" />

Closes #302 
