### PR TITLE
[Bugfix][Rollout] Validate batched RM reward lengths

### DIFF
--- a/tests/test_vllm_rollout.py
+++ b/tests/test_vllm_rollout.py
@@ -542,6 +542,56 @@ def test_generate_and_rm_rejects_batched_rm_length_mismatch_without_partial_assi
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "invalid_rewards,type_name",
+    [
+        ({"first": 0.25, "second": 0.75}, "dict"),
+        ("ab", "str"),
+        (b"ab", "bytes"),
+    ],
+)
+def test_generate_and_rm_rejects_deceptive_batched_rm_result_types_without_partial_assignment(
+    patch_generate_state, monkeypatch, invalid_rewards, type_name
+):
+    from vime.rollout import rm_hub
+
+    generated_samples: list[Sample] = []
+
+    async def fake_generate(args, sample, sampling_params):
+        sample.response = "a"
+        sample.response_length = 1
+        sample.tokens = [1]
+        sample.reward = None
+        sample.status = Sample.Status.COMPLETED
+
+        sibling = Sample(index=1, prompt="p1", status=Sample.Status.COMPLETED)
+        sibling.response = "b"
+        sibling.response_length = 1
+        sibling.tokens = [2]
+        sibling.reward = None
+        generated_samples[:] = [sample, sibling]
+        return generated_samples
+
+    async def invalid_batched_rm(args, samples, **kwargs):
+        assert len(samples) == 2
+        return invalid_rewards
+
+    monkeypatch.setattr(mod, "generate", fake_generate)
+    monkeypatch.setattr(rm_hub, "load_function", lambda _path: invalid_batched_rm)
+
+    with pytest.raises(TypeError, match=f"returned {type_name} instead of an iterable of rewards"):
+        asyncio.run(
+            mod.generate_and_rm(
+                _rollout_args(custom_rm_path="fake.rm"),
+                Sample(index=0, prompt="p0"),
+                _default_sampling_params(),
+            )
+        )
+
+    assert [sample.reward for sample in generated_samples] == [None, None]
+
+
+@pytest.mark.unit
 def test_generate_and_rm_group_assigns_session_ids(patch_generate_state, monkeypatch):
     async def fake_generate_and_rm(args, sample, sampling_params, evaluation=False):
         sample.response = "ok"

--- a/tests/test_vllm_rollout.py
+++ b/tests/test_vllm_rollout.py
@@ -500,6 +500,48 @@ def test_generate_and_rm_custom_generate_path(patch_generate_state, monkeypatch)
 
 
 @pytest.mark.unit
+def test_generate_and_rm_rejects_batched_rm_length_mismatch_without_partial_assignment(
+    patch_generate_state, monkeypatch
+):
+    from vime.rollout import rm_hub
+
+    generated_samples: list[Sample] = []
+
+    async def fake_generate(args, sample, sampling_params):
+        sample.response = "a"
+        sample.response_length = 1
+        sample.tokens = [1]
+        sample.reward = None
+        sample.status = Sample.Status.COMPLETED
+
+        sibling = Sample(index=1, prompt="p1", status=Sample.Status.COMPLETED)
+        sibling.response = "b"
+        sibling.response_length = 1
+        sibling.tokens = [2]
+        sibling.reward = None
+        generated_samples[:] = [sample, sibling]
+        return generated_samples
+
+    async def short_batched_rm(args, samples, **kwargs):
+        assert len(samples) == 2
+        return [0.25]
+
+    monkeypatch.setattr(mod, "generate", fake_generate)
+    monkeypatch.setattr(rm_hub, "load_function", lambda _path: short_batched_rm)
+
+    with pytest.raises(ValueError, match="returned 1 rewards for 2 samples"):
+        asyncio.run(
+            mod.generate_and_rm(
+                _rollout_args(custom_rm_path="fake.rm"),
+                Sample(index=0, prompt="p0"),
+                _default_sampling_params(),
+            )
+        )
+
+    assert [sample.reward for sample in generated_samples] == [None, None]
+
+
+@pytest.mark.unit
 def test_generate_and_rm_group_assigns_session_ids(patch_generate_state, monkeypatch):
     async def fake_generate_and_rm(args, sample, sampling_params, evaluation=False):
         sample.response = "ok"
@@ -512,6 +554,40 @@ def test_generate_and_rm_group_assigns_session_ids(patch_generate_state, monkeyp
     result = asyncio.run(mod.generate_and_rm_group(_rollout_args(), group, _default_sampling_params()))
     assert all(s.session_id for s in result)
     assert result[0].session_id != result[1].session_id
+
+
+@pytest.mark.unit
+def test_generate_and_rm_group_rejects_batched_rm_length_mismatch_without_partial_assignment(
+    patch_generate_state, monkeypatch
+):
+    from vime.rollout import rm_hub
+
+    async def fake_generate(args, sample, sampling_params):
+        sample.response = "ok"
+        sample.response_length = 1
+        sample.tokens = [sample.index or 0]
+        sample.reward = None
+        sample.status = Sample.Status.COMPLETED
+        return sample
+
+    async def long_batched_rm(args, samples, **kwargs):
+        assert len(samples) == 2
+        return [0.25, 0.75, 1.0]
+
+    monkeypatch.setattr(mod, "generate", fake_generate)
+    monkeypatch.setattr(rm_hub, "load_function", lambda _path: long_batched_rm)
+
+    group = [Sample(index=0, prompt="p0"), Sample(index=1, prompt="p1")]
+    with pytest.raises(ValueError, match="returned 3 rewards for 2 samples"):
+        asyncio.run(
+            mod.generate_and_rm_group(
+                _rollout_args(group_rm=True, custom_rm_path="fake.rm"),
+                group,
+                _default_sampling_params(),
+            )
+        )
+
+    assert [sample.reward for sample in group] == [None, None]
 
 
 @pytest.mark.unit

--- a/vime/rollout/rm_hub/__init__.py
+++ b/vime/rollout/rm_hub/__init__.py
@@ -106,21 +106,14 @@ async def batched_async_rm(
         rm_function = load_function(args.custom_rm_path)
         rewards = await rm_function(args, samples, **kwargs)
     else:
-        tasks = [async_rm(args, sample, **kwargs) for sample in samples]
-        rewards = await asyncio.gather(*tasks)
-    rm_name = getattr(args, "custom_rm_path", None) or getattr(args, "rm_type", None) or "batched_async_rm"
-    if rewards is None:
-        raise TypeError(f"batched reward model {rm_name!r} returned None instead of an iterable of rewards")
-    if isinstance(rewards, (str, bytes, bytearray, dict)):
+        rewards = await asyncio.gather(*(async_rm(args, sample, **kwargs) for sample in samples))
+
+    rm_name = args.custom_rm_path or args.rm_type or "batched_async_rm"
+    if rewards is None or isinstance(rewards, (str, bytes, bytearray, dict)):
         raise TypeError(
             f"batched reward model {rm_name!r} returned {type(rewards).__name__} instead of an iterable of rewards"
         )
-    try:
-        rewards = list(rewards)
-    except TypeError as exc:
-        raise TypeError(
-            f"batched reward model {rm_name!r} returned {type(rewards).__name__} instead of an iterable of rewards"
-        ) from exc
+    rewards = list(rewards)
     if len(rewards) != len(samples):
         raise ValueError(
             f"batched reward model {rm_name!r} returned {len(rewards)} rewards for {len(samples)} samples"

--- a/vime/rollout/rm_hub/__init__.py
+++ b/vime/rollout/rm_hub/__init__.py
@@ -108,9 +108,20 @@ async def batched_async_rm(
     else:
         tasks = [async_rm(args, sample, **kwargs) for sample in samples]
         rewards = await asyncio.gather(*tasks)
-    rewards = list(rewards)
+    rm_name = getattr(args, "custom_rm_path", None) or getattr(args, "rm_type", None) or "batched_async_rm"
+    if rewards is None:
+        raise TypeError(f"batched reward model {rm_name!r} returned None instead of an iterable of rewards")
+    if isinstance(rewards, (str, bytes, bytearray, dict)):
+        raise TypeError(
+            f"batched reward model {rm_name!r} returned {type(rewards).__name__} instead of an iterable of rewards"
+        )
+    try:
+        rewards = list(rewards)
+    except TypeError as exc:
+        raise TypeError(
+            f"batched reward model {rm_name!r} returned {type(rewards).__name__} instead of an iterable of rewards"
+        ) from exc
     if len(rewards) != len(samples):
-        rm_name = getattr(args, "custom_rm_path", None) or getattr(args, "rm_type", None) or "batched_async_rm"
         raise ValueError(
             f"batched reward model {rm_name!r} returned {len(rewards)} rewards for {len(samples)} samples"
         )

--- a/vime/rollout/rm_hub/__init__.py
+++ b/vime/rollout/rm_hub/__init__.py
@@ -104,7 +104,14 @@ async def batched_async_rm(
     if args.custom_rm_path is not None:
         # Ensure the custom reward function is implemented in batch mode
         rm_function = load_function(args.custom_rm_path)
-        return await rm_function(args, samples, **kwargs)
-    tasks = [async_rm(args, sample, **kwargs) for sample in samples]
-    rewards = await asyncio.gather(*tasks)
+        rewards = await rm_function(args, samples, **kwargs)
+    else:
+        tasks = [async_rm(args, sample, **kwargs) for sample in samples]
+        rewards = await asyncio.gather(*tasks)
+    rewards = list(rewards)
+    if len(rewards) != len(samples):
+        rm_name = getattr(args, "custom_rm_path", None) or getattr(args, "rm_type", None) or "batched_async_rm"
+        raise ValueError(
+            f"batched reward model {rm_name!r} returned {len(rewards)} rewards for {len(samples)} samples"
+        )
     return rewards

--- a/vime/rollout/vllm_rollout.py
+++ b/vime/rollout/vllm_rollout.py
@@ -461,7 +461,7 @@ async def generate_and_rm(
         samples_need_reward = [sample for sample in samples if sample.reward is None]
         with trace_span(samples_need_reward, "reward_model"):
             rewards = await batched_async_rm(args, samples_need_reward)
-        for sample, reward in zip(samples_need_reward, rewards, strict=False):
+        for sample, reward in zip(samples_need_reward, rewards, strict=True):
             sample.reward = reward
         return samples
     else:
@@ -516,7 +516,7 @@ async def generate_and_rm_group(
     if not state.aborted and args.group_rm:
         with trace_span(group, "group_reward_model"):
             rewards = await batched_async_rm(args, group)
-        for sample, reward in zip(group, rewards, strict=False):
+        for sample, reward in zip(group, rewards, strict=True):
             sample.reward = reward
 
     return group


### PR DESCRIPTION
Fixes #312

## Summary
During our own usage, we found that batched Reward Model return values were not validated before assignment; this PR adds return-value validation so malformed batched RM outputs fail before rewards are written.

## Root Cause
The rollout code assigned batched rewards with . When a custom batched RM returned too few rewards, later samples kept ; when it returned too many rewards, the extra values were silently dropped. Also, blindly calling  could convert a top-level , , or  result into keys, characters, or integers whose length happened to match the sample count.

## User Impact
Custom batched RM plugins now fail fast with a clear error instead of producing partially rewarded rollout data or assigning invalid values to . Successful batched RM paths keep the same API and ordering behavior.

## Testing
- 
- ============================= test session starts ==============================
platform darwin -- Python 3.13.13, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/bytedance/opensource/vime
configfile: pyproject.toml
plugins: anyio-4.12.1, mock-3.15.1, cov-7.1.0, asyncio-1.4.0, forked-1.6.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 14 items / 12 deselected / 2 selected

tests/plugin_contracts/test_plugin_path_loading_contracts.py ..          [100%]

============================== slowest durations ===============================

(6 durations < 0.005s hidden.  Use -vv to show these durations.)
======================= 2 passed, 12 deselected in 4.55s =======================
- 
- All checks passed!
- 