### PR TITLE
fix(docker): /abort_requests abort-all fix + cu13 image variant

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,19 +6,30 @@ FROM ${BASE_IMAGE}
 ARG PATCH_VERSION=latest
 ARG MEGATRON_COMMIT=1dcf0dafa884ad52ffb243625717a3471643e087
 
+ARG ENABLE_CUDA_13=0
+
 # ======================================== Setup =============================================
 
 WORKDIR /root/
 
 # ======================================== Apt dependencies =============================================
 
-# vllm/vllm-openai base is an inference image — add cu12 dev headers + cmake/git
+# vllm/vllm-openai base is an inference image — add CUDA dev headers + cmake/git
 # so TE / apex / flash-attn source builds find cusparse.h etc.
+# Dev packages must match the base toolkit: -12-9 for cu129, -13-0 for cu130.
 RUN apt-get update && apt-get install -y \
-    nvtop rsync dnsutils prometheus git cmake \
-    cuda-nvrtc-dev-12-9 cuda-nvml-dev-12-9 cuda-profiler-api-12-9 cuda-nvtx-12-9 \
-    libcusparse-dev-12-9 libcusolver-dev-12-9 libcufft-dev-12-9 libcurand-dev-12-9 \
-    libcudnn9-dev-cuda-12 && \
+    nvtop rsync dnsutils prometheus git cmake && \
+    if [ "${ENABLE_CUDA_13}" = "1" ]; then \
+      apt-get install -y \
+        cuda-nvrtc-dev-13-0 cuda-nvml-dev-13-0 cuda-profiler-api-13-0 cuda-nvtx-13-0 \
+        libcusparse-dev-13-0 libcusolver-dev-13-0 libcufft-dev-13-0 libcurand-dev-13-0 \
+        libcudnn9-dev-cuda-13; \
+    else \
+      apt-get install -y \
+        cuda-nvrtc-dev-12-9 cuda-nvml-dev-12-9 cuda-profiler-api-12-9 cuda-nvtx-12-9 \
+        libcusparse-dev-12-9 libcusolver-dev-12-9 libcufft-dev-12-9 libcurand-dev-12-9 \
+        libcudnn9-dev-cuda-12; \
+    fi && \
     rm -rf /var/lib/apt/lists/*
 
 # vllm/vllm-openai base only ships python3; subsequent source builds invoke `python`.
@@ -52,9 +63,22 @@ RUN if [ "${INSTALL_FLASHQLA}" = "1" ]; then \
 RUN pip install tilelang -f https://tile-ai.github.io/whl/nightly/cu128/
 
 # cublas dev header for TE CMake (arm64 base ships runtime .so but not the header).
-RUN apt-get update && apt-get install -y libcublas-dev-12-9 && rm -rf /var/lib/apt/lists/*
+# cu13 also needs the -13-0 headers that TE's nvcc build expects.
+RUN apt-get update && \
+    if [ "${ENABLE_CUDA_13}" = "1" ]; then \
+      apt-get install -y libcublas-dev-13-0; \
+    else \
+      apt-get install -y libcublas-dev-12-9; \
+    fi && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN pip -v install --no-build-isolation "transformer_engine[pytorch]==2.10.0"
+# TE does not publish a cu13 wheel; build from source when ENABLE_CUDA_13=1.
+RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
+      pip install nvidia-mathdx pybind11 ninja wheel packaging && \
+      pip -v install --no-build-isolation git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.10; \
+    else \
+      pip -v install --no-build-isolation "transformer_engine[pytorch]==2.10.0"; \
+    fi
 
 RUN NVCC_APPEND_FLAGS="--threads 4" \
   pip -v install --disable-pip-version-check --no-cache-dir \
@@ -65,8 +89,11 @@ RUN git clone https://github.com/NVIDIA/Megatron-LM.git --recursive && \
     cd Megatron-LM && git checkout ${MEGATRON_COMMIT}
 
 # torch_memory_saver pinned to a193d9dd (upstream slime #1916).
-# TMS_CUDA_MAJOR is required by this pin's build backend for CUDA wheels; base is cu129 -> 12.
-RUN TMS_CUDA_MAJOR=12 pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@a193d9dd1b877d33c64a41cfb3db9f867df2d926 --no-cache-dir --force-reinstall
+# TMS_CUDA_MAJOR is required by this pin's build backend for CUDA wheels;
+# auto-detect from the running torch's CUDA major (12 for cu129, 13 for cu130).
+RUN TMS_CUDA_MAJOR="$(python -c 'import torch; print(torch.version.cuda.split(".")[0])')" && \
+    export TMS_CUDA_MAJOR && \
+    pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@a193d9dd1b877d33c64a41cfb3db9f867df2d926 --no-cache-dir --force-reinstall
 RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@bridge --no-deps --no-build-isolation
 RUN pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation
 
@@ -75,7 +102,10 @@ RUN pip install --ignore-installed PyJWT && \
     pip install -r /tmp/requirements.txt
 
 # https://github.com/pytorch/pytorch/issues/168167
-RUN pip install nvidia-cudnn-cu12==9.16.0.29
+# cu130 base already ships nvidia-cudnn-cu13 9.19.0; only cu129 needs the pin.
+RUN if [ "${ENABLE_CUDA_13}" != "1" ]; then \
+      pip install nvidia-cudnn-cu12==9.16.0.29; \
+    fi
 
 # reinstall numpy 1.x for megatron; pin scipy<1.18 alongside it. vime's vllm/vllm-openai
 # base ships NO scipy, so unpinned it pulls scipy>=1.18, which hard-requires numpy>=2 and
@@ -100,15 +130,14 @@ RUN cd Megatron-LM && \
     rm megatron.patch && \
     pip install -e .
 
-# Patch vLLM: skip execute_dummy_batch while the engine is asleep / being put to sleep, so a
-# colocate DP+EP rollout's staged sleep/wake weight-sync doesn't run a forward against freed KV
-# (illegal memory access at update_weights / the post-rollout sleep offload). vLLM PR #44483
-# lineage, broadened to guard on EngineCore.is_sleeping() (covers the cuMem offload window).
-# vLLM is a pip install (not a git checkout) so apply with plain `git apply` (no --3way).
+# Patch vLLM with vime's local fixes (see docker/patch/${PATCH_VERSION}/vllm.patch
+# for the specifics). vLLM is a pip install (not a git checkout) so apply with
+# plain `git apply` (no --3way). --allow-empty keeps the build working once every
+# fix has landed upstream and the patch is emptied.
 COPY docker/patch/${PATCH_VERSION}/vllm.patch /tmp/vllm.patch
 RUN VLLM_SITE="$(python3 -c 'import os, vllm; print(os.path.dirname(os.path.dirname(vllm.__file__)))')" && \
     cd "$VLLM_SITE" && \
-    git apply -v /tmp/vllm.patch && \
+    git apply -v --allow-empty /tmp/vllm.patch && \
     rm /tmp/vllm.patch
 
 # ====================================== Install main package ============================================

--- a/docker/justfile
+++ b/docker/justfile
@@ -7,9 +7,14 @@
 # built on its own native host and pushed BY DIGEST (no tag lands in the hub),
 # then the two digests are fused into the final tag with `just manifest`.
 #
+# CUDA 12.9 is the default, so it carries NO cu marker in the tag. Only the
+# non-default cu13 variant is suffixed.
+#
 # Tag scheme:
-#   vllm/vime:<version>        immutable, multi-arch
-#   vllm/vime:latest           rolling,   multi-arch
+#   vllm/vime:<version>             immutable, multi-arch (cu12.9)
+#   vllm/vime:latest                rolling,   multi-arch (cu12.9)
+#   vllm/vime:cu13-<version>        immutable, multi-arch (cu13 variant)
+#   vllm/vime:cu13-latest           rolling,   multi-arch (cu13 variant)
 # <version> comes from docker/version.txt.
 
 IMAGE := "vllm/vime"
@@ -17,8 +22,14 @@ BUILDER := "vime-builder"
 
 # ---- per-arch build, pushed BY DIGEST (run once on an amd64 host, once on an arm64 host) ----
 
+# Default — cu12.9 base.
 build:
     ARG_TAG_SUFFIX="" ARG_BUILD_EXTRA_ARGS="--build-arg INSTALL_FLASHQLA=1" just _build-digest
+
+# cu13 variant — vLLM latest (cu130) base; ENABLE_CUDA_13 builds TE from source
+# and installs the cu13 Triton fork on top.
+build-cu13:
+    ARG_TAG_SUFFIX="-cu13" ARG_BUILD_EXTRA_ARGS='--build-arg BASE_IMAGE=vllm/vllm-openai:latest-ubuntu2404 --build-arg ENABLE_CUDA_13=1' just _build-digest
 
 _build-digest:
     #!/bin/bash
@@ -37,15 +48,19 @@ _build-digest:
     jq -r '."containerimage.digest"' "$META"
 
 # ---- fuse the two per-arch digests into one multi-arch tag ----
-# Run once after `build` has pushed on BOTH hosts, passing the digests it printed:
-#   just manifest sha256:<amd64> sha256:<arm64>     -> vime-<version> + vime-latest
-manifest AMD_DIGEST ARM_DIGEST:
+# Run once after `build` (or `build-cu13`) has pushed on BOTH hosts, passing the
+# digests it printed. For the default cu12.9 image leave VARIANT empty:
+#   just manifest "" sha256:<amd64> sha256:<arm64>     -> vime:<version> + vime:latest
+#   just manifest cu13 sha256:<amd64> sha256:<arm64>   -> vime:cu13-<version> + vime:cu13-latest
+manifest VARIANT AMD_DIGEST ARM_DIGEST:
     #!/bin/bash
     set -euxo pipefail
     cd ..
 
     VERSION="$(cat docker/version.txt | tr -d '\n')"
-    docker buildx imagetools create -t "{{IMAGE}}:${VERSION}" -t "{{IMAGE}}:latest" "{{IMAGE}}@{{AMD_DIGEST}}" "{{IMAGE}}@{{ARM_DIGEST}}"
+    PREFIX=""
+    [ -n "{{VARIANT}}" ] && PREFIX="{{VARIANT}}-"
+    docker buildx imagetools create -t "{{IMAGE}}:${PREFIX}${VERSION}" -t "{{IMAGE}}:${PREFIX}latest" "{{IMAGE}}@{{AMD_DIGEST}}" "{{IMAGE}}@{{ARM_DIGEST}}"
 
 # ---- single-arch test/debug image for the run-ci-image validation job ----
 # The e2e-test-image runner is x86, so this is amd64-only and

--- a/docker/patch/latest/vllm.patch
+++ b/docker/patch/latest/vllm.patch
@@ -71,8 +71,8 @@ diff --git a/vllm/entrypoints/serve/dev/rlhf/api_router.py b/vllm/entrypoints/se
 +
 +    try:
 +        body = await raw_request.json()
-+    except json.JSONDecodeError:
-+        body = {}
++    except json.JSONDecodeError as e:
++        raise HTTPException(status_code=400, detail="Invalid JSON format") from e  # noqa: B904
 +
 +    request_ids = body.get("request_ids")
 +

--- a/docker/patch/latest/vllm.patch
+++ b/docker/patch/latest/vllm.patch
@@ -56,7 +56,7 @@ diff --git a/vllm/model_executor/layers/fused_moe/all2all_utils.py b/vllm/model_
 diff --git a/vllm/entrypoints/serve/dev/rlhf/api_router.py b/vllm/entrypoints/serve/dev/rlhf/api_router.py
 --- a/vllm/entrypoints/serve/dev/rlhf/api_router.py
 +++ b/vllm/entrypoints/serve/dev/rlhf/api_router.py
-@@ -91,6 +91,46 @@ async def resume_generation(raw_request: Request) -> JSONResponse:
+@@ -91,6 +91,51 @@ async def resume_generation(raw_request: Request) -> JSONResponse:
          )
  
  
@@ -82,11 +82,16 @@ diff --git a/vllm/entrypoints/serve/dev/rlhf/api_router.py b/vllm/entrypoints/se
 +            await engine.abort(request_ids)
 +        else:
 +            # The dev RL server runs AsyncLLM; abort everything it is tracking.
-+            # request_states is keyed by internal ids, so abort as internal.
++            # request_states is keyed by internal ids; parent_requests holds
++            # parallel-sampling parents. Abort both as internal ids.
 +            from vllm.v1.engine.async_llm import AsyncLLM
 +
 +            assert isinstance(engine, AsyncLLM)
-+            request_ids = list(engine.output_processor.request_states.keys())
++            op = engine.output_processor
++            request_ids = [
++                *op.request_states.keys(),
++                *op.parent_requests.keys(),
++            ]
 +            await engine.abort(request_ids, internal=True)
 +        return JSONResponse(
 +            content={"status": "aborted", "aborted": len(request_ids)},

--- a/docker/patch/latest/vllm.patch
+++ b/docker/patch/latest/vllm.patch
@@ -56,7 +56,7 @@ diff --git a/vllm/model_executor/layers/fused_moe/all2all_utils.py b/vllm/model_
 diff --git a/vllm/entrypoints/serve/dev/rlhf/api_router.py b/vllm/entrypoints/serve/dev/rlhf/api_router.py
 --- a/vllm/entrypoints/serve/dev/rlhf/api_router.py
 +++ b/vllm/entrypoints/serve/dev/rlhf/api_router.py
-@@ -91,6 +91,38 @@ async def resume_generation(raw_request: Request) -> JSONResponse:
+@@ -91,6 +91,46 @@ async def resume_generation(raw_request: Request) -> JSONResponse:
          )
  
  
@@ -75,11 +75,19 @@ diff --git a/vllm/entrypoints/serve/dev/rlhf/api_router.py b/vllm/entrypoints/se
 +        body = {}
 +
 +    request_ids = body.get("request_ids")
-+    if not request_ids:
-+        request_ids = list(engine.output_processor.request_states.keys())
 +
 +    try:
-+        await engine.abort(request_ids)
++        if request_ids:
++            # Body ids are external (user-supplied) request ids.
++            await engine.abort(request_ids)
++        else:
++            # The dev RL server runs AsyncLLM; abort everything it is tracking.
++            # request_states is keyed by internal ids, so abort as internal.
++            from vllm.v1.engine.async_llm import AsyncLLM
++
++            assert isinstance(engine, AsyncLLM)
++            request_ids = list(engine.output_processor.request_states.keys())
++            await engine.abort(request_ids, internal=True)
 +        return JSONResponse(
 +            content={"status": "aborted", "aborted": len(request_ids)},
 +            status_code=HTTPStatus.OK.value,

--- a/vime/ray/actor_group.py
+++ b/vime/ray/actor_group.py
@@ -65,6 +65,7 @@ class RayTrainGroup:
             import torch_memory_saver
 
             for path in [
+                "torch_memory_saver_hook_mode_preload_cu13.abi3.so",
                 "torch_memory_saver_hook_mode_preload_cu12.abi3.so",
                 "torch_memory_saver_hook_mode_preload.abi3.so",
             ]:


### PR DESCRIPTION
## What

Fix the bundled vLLM `/abort_requests` endpoint in `docker/patch/latest/vllm.patch` so that **abort-all actually aborts**, and add a **cu13 Docker image variant** (partial port of #307).

## The bug

The endpoint (added in #296) handles an empty/missing `request_ids` by enumerating `engine.output_processor.request_states.keys()` and calling `engine.abort(request_ids)`.

But `request_states` is keyed by **internal** request ids, while `EngineClient.abort()` defaults to `internal=False` (treats ids as **external**, resolving them through the external→internal map). Under the default request-id randomization (`internal = f"{external}-{8 random}"`), the internal ids are not external keys, so the lookup matches nothing — `POST /abort_requests {}` returns **200 while aborting nothing**.

This was flagged by Codex on the upstream endpoint PR (vllm-project/vllm#47173, review r3516626381); the same code shipped here in the docker patch.

## The fix

Abort the all-in-flight list as **internal** (`internal=True`); keep external semantics for explicitly-passed `request_ids`. Also include `parent_requests` keys (parallel-sampling parents) and return **400** on malformed JSON. Mirrors vllm-project/vllm#47173.

## cu13 image variant

Partial port from #307 — excludes the NCCL_CUMEM default flip and glm5.2 scripts:

- `ENABLE_CUDA_13` build arg: cu13 dev headers, TE from source, skip cu12 cudnn pin
- `just build-cu13` + `cu13-*` tags via `just manifest cu13 ...`
- `TMS_CUDA_MAJOR` auto-detect from torch's CUDA version
- `git apply --allow-empty` so builds survive once the vllm patch is emptied upstream
- `actor_group`: preload `torch_memory_saver_hook_mode_preload_cu13.abi3.so`

## Testing

- Verified the patched `api_router.py` hunk applies cleanly to a pristine vLLM (`git apply --check`).
- The other patch sections (core.py, all2all_utils.py, disagg/protocol.py) are untouched.
- Full image build / runtime abort behaviour: via CI (Buildkite #430).

## AI assistance

Drafted with AI assistance (Claude); reviewed by a human before submission.
