### PR TITLE
fix(npu): adapt colocate patch for vllm-ascend and vllm version upgrade

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.patch text eol=lf

--- a/docker/npu_patch/vllm-ascend.patch
+++ b/docker/npu_patch/vllm-ascend.patch
@@ -1,5 +1,5 @@
 diff --git a/vllm_ascend/worker/worker.py b/vllm_ascend/worker/worker.py
-index 63ee94c..4e81943 100644
+index 062b3ecd..dd87affb 100644
 --- a/vllm_ascend/worker/worker.py
 +++ b/vllm_ascend/worker/worker.py
 @@ -404,7 +404,7 @@ class NPUWorker(WorkerBase):
@@ -25,30 +25,15 @@ index 63ee94c..4e81943 100644
 -            "isolate vLLM in its own container."
 -        )
 +        # colocate: skip memory profiling assert
-+# assert self.init_snapshot.free_memory > free_gpu_memory, (
-+#             "Error in memory profiling. "
-+#             f"Initial free memory {GiB(self.init_snapshot.free_memory)} GiB, "
-+#             f"current free memory {GiB(free_gpu_memory)} GiB. "
-+#             "This happens when other processes sharing the same container "
-+#             "release GPU memory while vLLM is profiling during initialization. "
-+#             "To fix this, ensure consistent GPU memory allocation or "
-+#             "isolate vLLM in its own container."
-+#         )
++        # assert self.init_snapshot.free_memory > free_gpu_memory, (
++        #     "Error in memory profiling. "
++        #     f"Initial free memory {GiB(self.init_snapshot.free_memory)} GiB, "
++        #     f"current free memory {GiB(free_gpu_memory)} GiB. "
++        #     "This happens when other processes sharing the same container "
++        #     "release GPU memory while vLLM is profiling during initialization. "
++        #     "To fix this, ensure consistent GPU memory allocation or "
++        #     "isolate vLLM in its own container."
++        # )
          self.available_kv_cache_memory_bytes = (
              self.requested_memory - profile_result.non_kv_cache_memory - npugraph_memory_estimate_applied
          )
-diff --git a/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py b/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
-index 0000000..0000000 100644
---- a/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
-+++ b/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
-@@ -116,8 +116,8 @@ class NPUIPCWeightTransferEngine(WeightTransferEngine[NPUIPCWeightTransferInitIn
-     init_info_cls = NPUIPCWeightTransferInitInfo
-     update_info_cls = NPUIPCWeightTransferUpdateInfo
- 
--    def __init__(self, config: WeightTransferConfig, parallel_config: ParallelConfig) -> None:
--        super().__init__(config, parallel_config)
-+    def __init__(self, config: WeightTransferConfig, parallel_config: ParallelConfig, model: torch.nn.Module = None) -> None:
-+        super().__init__(config, parallel_config, model)
- 
-     def parse_update_info(self, update_dict: dict[str, Any]) -> NPUIPCWeightTransferUpdateInfo:
-         """Parse update dict, deserializing pickled IPC handles if present.

--- a/docker/npu_patch/vllm.patch
+++ b/docker/npu_patch/vllm.patch
@@ -1,5 +1,18 @@
+diff --git a/vllm/model_executor/layers/rotary_embedding/common.py b/vllm/model_executor/layers/rotary_embedding/common.py
+index 2e407ae..5e4c5de 100644
+--- a/vllm/model_executor/layers/rotary_embedding/common.py
++++ b/vllm/model_executor/layers/rotary_embedding/common.py
+@@ -135,7 +135,7 @@ class ApplyRotaryEmb(CustomOp):
+         self.enable_fp32_compute = enable_fp32_compute
+ 
+         self.apply_rotary_emb_flash_attn = None
+-        if not current_platform.is_cpu() and find_spec("flash_attn") is not None:
++        if not current_platform.is_cpu() and find_spec("flash_attn") is not None and not hasattr(current_platform, "is_npu"):
+             from flash_attn.ops.triton.rotary import apply_rotary
+ 
+             self.apply_rotary_emb_flash_attn = apply_rotary
 diff --git a/vllm/v1/core/sched/async_scheduler.py b/vllm/v1/core/sched/async_scheduler.py
-index cb61bcabd..5c076d521 100644
+index cb61bca..5c076d5 100644
 --- a/vllm/v1/core/sched/async_scheduler.py
 +++ b/vllm/v1/core/sched/async_scheduler.py
 @@ -51,7 +51,7 @@ class AsyncScheduler(Scheduler):
@@ -11,16 +24,3 @@ index cb61bcabd..5c076d521 100644
  
          # Cache the new tokens. Preempted requests should be skipped.
          if status_before_update == RequestStatus.RUNNING:
-diff --git a/vllm/model_executor/layers/rotary_embedding/common.py b/vllm/model_executor/layers/rotary_embedding/common.py
-index 0000000..0000000 100644
---- a/vllm/model_executor/layers/rotary_embedding/common.py
-+++ b/vllm/model_executor/layers/rotary_embedding/common.py
-@@ -135,7 +135,9 @@ class ApplyRotaryEmb(CustomOp):
-         self.enable_fp32_compute = enable_fp32_compute
- 
-         self.apply_rotary_emb_flash_attn = None
--        if not current_platform.is_cpu() and find_spec("flash_attn") is not None:
-+        if not current_platform.is_cpu() and find_spec("flash_attn") is not None and not hasattr(current_platform, "is_npu"):
-             from flash_attn.ops.triton.rotary import apply_rotary
- 
-             self.apply_rotary_emb_flash_attn = apply_rotary

--- a/scripts/run-qwen3-4B-npu.sh
+++ b/scripts/run-qwen3-4B-npu.sh
@@ -41,6 +41,8 @@ export RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1
 export LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64:/usr/local/Ascend/ascend-toolkit/latest/lib64:/usr/local/Ascend/nnal/atb/latest/atb/cxx_abi_1/lib:/usr/local/Ascend/cann/lib64:${LD_LIBRARY_PATH}
 export VLLM_DISABLE_COMPILE_CACHE=1
 export ASCEND_VISIBLE_DEVICES="${ASCEND_VISIBLE_DEVICES:-$ASCEND_RT_VISIBLE_DEVICES}"
+export TRANSFORMERS_VERBOSITY=error
+
 # Sort NPU devices
 if [ -n "$ASCEND_VISIBLE_DEVICES" ]; then
     SORTED_DEVICES=$(echo "$ASCEND_VISIBLE_DEVICES" | tr ',' '\n' | sort -n | tr '\n' ',')
@@ -151,9 +153,11 @@ RUNTIME_ENV_JSON=$(cat << 'EOF'
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:False",
     "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES": "1",
     "LD_LIBRARY_PATH": "/usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64/driver:/usr/local/Ascend/driver/lib64/common:/usr/local/Ascend/ascend-toolkit/latest/lib64:/usr/local/Ascend/ascend-toolkit/latest/compiler/lib64/plugin/opskernel:/usr/local/Ascend/ascend-toolkit/latest/compiler/lib64/plugin/nnengine:/usr/local/Ascend/ascend-toolkit/latest/opp/built-in/op_impl/ai_core/tbe/op_tiling/lib/:/usr/local/Ascend/nnal/atb/latest/atb/cxx_abi_1/lib:/usr/local/Ascend/cann/lib64:/usr/local/Ascend/cann/aarch64-linux/devlib",
-    "VLLM_DISABLE_COMPILE_CACHE": "1"
+    "VLLM_DISABLE_COMPILE_CACHE": "1",
+    "TRANSFORMERS_VERBOSITY": "error"
   }
 }
+
 EOF
 )
 


### PR DESCRIPTION
# Summary
- Update the NPU colocate patches for 0.22.1rc1 vLLM and vllm-ascend versions.
- Reduce transformers log noise in the NPU Qwen3-4B run script.

# Test
- [x] Tested Qwen3-4B colocate on the A2 machine
- [x] Rebuild image from docker/Dockerfile.npu
<img width="586" height="314" alt="image" src="https://github.com/user-attachments/assets/52866cec-48b0-45b4-a50a-ba2a98985924" />
<img width="586" height="324" alt="image" src="https://github.com/user-attachments/assets/b296f9ed-0ef3-4be1-a1a0-827c56220e91" />
