### PR TITLE
feat(rollout): add TransferQueue trajectory ingestion for closed-loop VIME training

### DIFF
--- a/scripts/transfer_queue/README.md
+++ b/scripts/transfer_queue/README.md
@@ -1,0 +1,51 @@
+# TransferQueue Artifact Training
+
+This directory contains helper scripts for running VIME against rollout artifacts published through TransferQueue. The intended closed-loop path is:
+
+1. Start or reuse the shared Ray and TransferQueue service.
+2. Dispatch prompts to a VIME-managed vLLM rollout server with `artifact_transfer_params`.
+3. Consume the resulting `vllm.trajectory/v1alpha1` artifacts in VIME with `--trajectory-source transfer_queue`.
+4. Keep policy updates on VIME's normal rollout-engine update path by also passing `--tq-manage-rollout-servers`.
+
+TransferQueue is used for rollout artifacts in this flow. Policy weights are not sent through the TransferQueue policy-deployment helpers; closed-loop training should let `actor_model.update_weights()` update the VIME-managed rollout engines as it does in non-artifact-transfer training.
+
+## Service Scripts
+
+- `start_services.sh`: starts Ray if needed, starts the TransferQueue controller, and exports a client config.
+- `tq_service.py`: long-running TransferQueue controller process.
+- `export_config.py`: writes the resolved TransferQueue client config for jobs that should not attach to the service Ray cluster directly.
+- `health_check.py`: non-destructive health check for the Ray and TransferQueue service.
+
+## Rollout Dispatch
+
+- `dispatch_rollouts.py`: sends JSONL prompts to an OpenAI-compatible vLLM completions endpoint and includes artifact metadata so vLLM can publish trajectory artifacts.
+- `phase6_prompts.jsonl`: tiny smoke-test prompts for end-to-end validation.
+
+Example dispatch shape:
+
+```bash
+python scripts/transfer_queue/dispatch_rollouts.py \
+  --endpoint http://<vime-managed-router>/v1/completions \
+  --model <served-model-name> \
+  --run-id <run-id> \
+  --policy-version <policy-version> \
+  --prompts scripts/transfer_queue/phase6_prompts.jsonl \
+  --n-samples-per-prompt 2 \
+  --max-tokens 32 \
+  --output /tmp/dispatched_rollouts.jsonl
+```
+
+## VIME Training Flags
+
+Use these flags for closed-loop artifact-transfer training:
+
+```text
+--trajectory-source transfer_queue
+--tq-manage-rollout-servers
+--tq-ray-address ray://<transfer-queue-host>:20001
+--tq-run-id <run-id>
+--tq-policy-version <policy-version>
+--num-rollout <explicit-count>
+```
+
+`--tq-manage-rollout-servers` is the important distinction from offline artifact consumption. It keeps VIME in charge of rollout server lifecycle and weight updates while only replacing the sample source with TransferQueue artifacts.

--- a/scripts/transfer_queue/dispatch_rollouts.py
+++ b/scripts/transfer_queue/dispatch_rollouts.py
@@ -1,0 +1,74 @@
+"""Dispatch JSONL prompts to an external vLLM completions endpoint."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+
+from vime.rollout.rollout_dispatcher import (
+    ExternalVllmRolloutDispatcher,
+    RolloutDispatcherConfig,
+    RolloutPrompt,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--policy-version", required=True)
+    parser.add_argument("--prompts", required=True)
+    parser.add_argument("--n-samples-per-prompt", type=int, required=True)
+    parser.add_argument("--max-tokens", type=int, required=True)
+    parser.add_argument("--temperature", type=float, default=1.0)
+    parser.add_argument("--concurrency", type=int, default=32)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    prompts = []
+    with Path(args.prompts).open() as file:
+        for line in file:
+            row = json.loads(line)
+            prompts.append(
+                RolloutPrompt(
+                    group_id=str(row["group_id"]),
+                    prompt=row["prompt"],
+                    reward_context=row.get("reward_context", {}),
+                )
+            )
+
+    dispatcher = ExternalVllmRolloutDispatcher(
+        RolloutDispatcherConfig(
+            endpoint=args.endpoint,
+            model=args.model,
+            run_id=args.run_id,
+            policy_version=args.policy_version,
+            n_samples_per_prompt=args.n_samples_per_prompt,
+            max_tokens=args.max_tokens,
+            temperature=args.temperature,
+            concurrency=args.concurrency,
+        )
+    )
+    results = asyncio.run(dispatcher.dispatch(prompts))
+    with Path(args.output).open("w") as file:
+        for result in results:
+            file.write(
+                json.dumps(
+                    {
+                        "request_id": result.request_id,
+                        "group_id": result.group_id,
+                        "sample_index": result.sample_index,
+                        "reward_context": result.reward_context,
+                        "response": result.response,
+                    }
+                )
+                + "\n"
+            )
+    print(f"ROLLOUT_DISPATCH_COMPLETE samples={len(results)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/transfer_queue/export_config.py
+++ b/scripts/transfer_queue/export_config.py
@@ -1,0 +1,37 @@
+"""Export resolved TransferQueue client configuration for non-service Ray jobs."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pickle
+from pathlib import Path
+
+import ray
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ray-address", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    ray.init(address=args.ray_address)
+    controller = ray.get_actor(
+        "TransferQueueController",
+        namespace="transfer_queue",
+    )
+    config = ray.get(controller.get_config.remote())
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_suffix(output.suffix + ".tmp")
+    with temporary.open("wb") as file:
+        pickle.dump(config, file)
+    os.replace(temporary, output)
+    print(f"TRANSFER_QUEUE_CONFIG_EXPORTED path={output}")
+    ray.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/transfer_queue/health_check.py
+++ b/scripts/transfer_queue/health_check.py
@@ -1,0 +1,30 @@
+"""Non-destructive health check for the shared Ray and TransferQueue services."""
+
+from __future__ import annotations
+
+import argparse
+
+import ray
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ray-address", required=True)
+    args = parser.parse_args()
+
+    ray.init(address=args.ray_address)
+    controller = ray.get_actor(
+        "TransferQueueController",
+        namespace="transfer_queue",
+    )
+    config = ray.get(controller.get_config.remote())
+    print(
+        "TRANSFER_QUEUE_HEALTHY "
+        f"backend={config.backend.storage_backend} "
+        f"ray_address={args.ray_address}"
+    )
+    ray.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/transfer_queue/phase6_prompts.jsonl
+++ b/scripts/transfer_queue/phase6_prompts.jsonl
@@ -1,0 +1,2 @@
+{"group_id":"phase6-group-0","prompt":"tok4 tok5","reward_context":{"expected":"tok"}}
+{"group_id":"phase6-group-1","prompt":"tok6 tok7","reward_context":{"expected":"tok"}}

--- a/scripts/transfer_queue/start_services.sh
+++ b/scripts/transfer_queue/start_services.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VENV="${VIME_VENV:-/mnt/data1/yibo/vime-workspace/.venv}"
+SERVICE_DIR="${TQ_SERVICE_DIR:-/mnt/data1/yibo/vime-workspace/services/transfer_queue}"
+RAY_NODE_IP="${RAY_NODE_IP:-172.16.1.248}"
+RAY_GCS_PORT="${RAY_GCS_PORT:-6380}"
+RAY_CLIENT_PORT="${RAY_CLIENT_PORT:-20001}"
+RAY_ADDRESS="${RAY_NODE_IP}:${RAY_GCS_PORT}"
+PID_FILE="${SERVICE_DIR}/transfer_queue.pid"
+LOG_FILE="${SERVICE_DIR}/transfer_queue.log"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVICE_SCRIPT="${SCRIPT_DIR}/tq_service.py"
+EXPORT_SCRIPT="${SCRIPT_DIR}/export_config.py"
+CLIENT_CONFIG="${SERVICE_DIR}/client_config.pkl"
+
+mkdir -p "${SERVICE_DIR}"
+
+if ! "${VENV}/bin/ray" status --address="${RAY_ADDRESS}" >/dev/null 2>&1; then
+  ray_args=(
+    start
+    --head
+    "--node-ip-address=${RAY_NODE_IP}"
+    "--port=${RAY_GCS_PORT}"
+    "--ray-client-server-port=${RAY_CLIENT_PORT}"
+    --dashboard-port=8266
+    --include-dashboard=false
+    --num-cpus=8
+    --num-gpus=0
+    --min-worker-port=21000
+    --max-worker-port=22000
+    --disable-usage-stats
+  )
+  "${VENV}/bin/ray" "${ray_args[@]}"
+fi
+
+if [[ -f "${PID_FILE}" ]] && kill -0 "$(cat "${PID_FILE}")" 2>/dev/null; then
+  echo "TransferQueue service already running with PID $(cat "${PID_FILE}")"
+else
+  service_args=(
+    -u
+    "${SERVICE_SCRIPT}"
+    "--ray-address=${RAY_ADDRESS}"
+    --polling-mode
+  )
+  nohup "${VENV}/bin/python" "${service_args[@]}" >"${LOG_FILE}" 2>&1 &
+  echo "$!" >"${PID_FILE}"
+fi
+
+for _ in $(seq 1 30); do
+  if grep -q "TRANSFER_QUEUE_SERVICE_READY" "${LOG_FILE}" 2>/dev/null; then
+    "${VENV}/bin/python" "${EXPORT_SCRIPT}"       --ray-address="${RAY_ADDRESS}"       --output="${CLIENT_CONFIG}"
+    echo "Ray GCS: ${RAY_ADDRESS}"
+    echo "Ray Client: ray://${RAY_NODE_IP}:${RAY_CLIENT_PORT}"
+    echo "TransferQueue PID: $(cat "${PID_FILE}")"
+    exit 0
+  fi
+  if ! kill -0 "$(cat "${PID_FILE}")" 2>/dev/null; then
+    cat "${LOG_FILE}"
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "TransferQueue service did not become ready within 30 seconds"
+cat "${LOG_FILE}"
+exit 1

--- a/scripts/transfer_queue/tq_service.py
+++ b/scripts/transfer_queue/tq_service.py
@@ -1,0 +1,57 @@
+"""Long-running TransferQueue service driver for the shared training cluster."""
+
+from __future__ import annotations
+
+import argparse
+import signal
+import threading
+
+import ray
+import transfer_queue as tq
+from omegaconf import OmegaConf
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ray-address", required=True)
+    parser.add_argument(
+        "--polling-mode",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Return empty fetches instead of blocking the TQ controller request loop.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    ray.init(address=args.ray_address)
+    config = tq.init(
+        OmegaConf.create(
+            {"controller": {"polling_mode": args.polling_mode}},
+            flags={"allow_objects": True},
+        )
+    )
+    backend = config.backend.storage_backend if config is not None else "existing"
+    print(
+        f"TRANSFER_QUEUE_SERVICE_READY backend={backend} "
+        f"polling_mode={args.polling_mode}",
+        flush=True,
+    )
+
+    stopped = threading.Event()
+
+    def request_stop(*_args) -> None:
+        stopped.set()
+
+    signal.signal(signal.SIGTERM, request_stop)
+    signal.signal(signal.SIGINT, request_stop)
+    stopped.wait()
+
+    # Close this process's client only. tq.close() would destroy shared actors.
+    tq.get_client().close()
+    ray.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_exported_tq_config.py
+++ b/tests/test_exported_tq_config.py
@@ -1,0 +1,28 @@
+import pickle
+from pathlib import Path
+
+from transfer_queue import StreamingDataset
+
+
+def test_exported_config_supports_direct_streaming_dataset():
+    config_path = Path(
+        "/mnt/data1/yibo/vime-workspace/services/"
+        "transfer_queue/client_config.pkl"
+    )
+    with config_path.open("rb") as file:
+        config = pickle.load(file)
+
+    dataset = StreamingDataset(
+        config=config,
+        batch_size=1,
+        micro_batch_size=1,
+        data_fields=[
+            "prompt_token_ids",
+            "response_token_ids",
+            "response_logprobs",
+        ],
+        partition_id="phase5-config-smoke",
+        task_name="phase5-config-smoke",
+        dp_rank=0,
+    )
+    assert dataset.config.backend.storage_backend == "SimpleStorage"

--- a/tests/test_rollout_dispatcher.py
+++ b/tests/test_rollout_dispatcher.py
@@ -1,0 +1,64 @@
+import asyncio
+import json
+
+import httpx
+
+from vime.rollout.rollout_dispatcher import (
+    ExternalVllmRolloutDispatcher,
+    RolloutDispatcherConfig,
+    RolloutPrompt,
+)
+
+
+def test_grouped_dispatch_sets_stable_artifact_metadata():
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={"id": request.headers["X-Request-Id"], "choices": []},
+        )
+
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://vllm",
+    )
+    dispatcher = ExternalVllmRolloutDispatcher(
+        RolloutDispatcherConfig(
+            endpoint="/v1/completions",
+            model="model-a",
+            run_id="run-a",
+            policy_version=3,
+            n_samples_per_prompt=2,
+            max_tokens=16,
+        ),
+        client=client,
+    )
+    results = asyncio.run(
+        dispatcher.dispatch(
+            [
+                RolloutPrompt(
+                    group_id="group-a",
+                    prompt="hello",
+                    reward_context={"label": "answer"},
+                ),
+                RolloutPrompt(group_id="group-b", prompt=[1, 2]),
+            ]
+        )
+    )
+    asyncio.run(client.aclose())
+
+    assert len(results) == 4
+    assert [item.sample_index for item in results] == [0, 1, 0, 1]
+    assert results[0].reward_context == {"label": "answer"}
+    first_payload = json.loads(requests[0].content)
+    assert first_payload["logprobs"] == 0
+    assert first_payload["artifact_transfer_params"] == {
+        "run_id": "run-a",
+        "policy_version": 3,
+        "model_id": "model-a",
+        "group_id": "group-a",
+        "sample_index": 0,
+    }
+    assert requests[0].headers["X-Request-Id"] == "run-a-3-group-a-0"

--- a/tests/test_trajectory_artifact.py
+++ b/tests/test_trajectory_artifact.py
@@ -1,0 +1,90 @@
+import pytest
+import torch
+
+from vime.rollout.trajectory_artifact import TrajectoryArtifactV1Alpha1
+
+
+def make_tag(**overrides):
+    tag = {
+        "schema_name": "vllm.trajectory",
+        "schema_version": "v1alpha1",
+        "status": "complete",
+        "run_id": "run-a",
+        "request_id": "request-a",
+        "group_id": "group-a",
+        "sample_index": 2,
+        "engine_id": "engine-a",
+        "model_id": "model-a",
+        "policy_version": 7,
+        "created_at_ns": 123,
+        "finish_reason": "stop",
+    }
+    tag.update(overrides)
+    return tag
+
+
+def make_fields(**overrides):
+    fields = {
+        "prompt_token_ids": torch.tensor([[1, 2, 3]]),
+        "response_token_ids": torch.tensor([[4, 5]]),
+        "response_logprobs": torch.tensor([[-0.1, -0.2]]),
+    }
+    fields.update(overrides)
+    return fields
+
+
+def test_decode_vllm_trajectory():
+    artifact = TrajectoryArtifactV1Alpha1.from_transfer_queue(
+        make_fields(
+            rewards=torch.tensor([1.5]),
+            loss_mask=torch.tensor([[1.0, 0.0]]),
+        ),
+        make_tag(),
+    )
+
+    assert artifact.prompt_token_ids.tolist() == [1, 2, 3]
+    assert artifact.response_token_ids.tolist() == [4, 5]
+    assert artifact.response_logprobs.tolist() == pytest.approx([-0.1, -0.2])
+    assert artifact.rewards.item() == pytest.approx(1.5)
+    assert artifact.loss_mask.tolist() == [1.0, 0.0]
+    assert artifact.group_id == "group-a"
+    assert artifact.sample_index == 2
+
+
+@pytest.mark.parametrize(
+    ("tag_update", "error"),
+    [
+        ({"schema_name": "other"}, "Unsupported trajectory schema"),
+        ({"schema_version": "v2"}, "Unsupported trajectory schema version"),
+        ({"status": "writing"}, "Trajectory is not complete"),
+    ],
+)
+def test_rejects_incompatible_tags(tag_update, error):
+    with pytest.raises(ValueError, match=error):
+        TrajectoryArtifactV1Alpha1.from_transfer_queue(
+            make_fields(),
+            make_tag(**tag_update),
+        )
+
+
+def test_rejects_token_logprob_length_mismatch():
+    with pytest.raises(ValueError, match="must have equal length"):
+        TrajectoryArtifactV1Alpha1.from_transfer_queue(
+            make_fields(response_logprobs=torch.tensor([[-0.1]])),
+            make_tag(),
+        )
+
+
+def test_decodes_single_nested_tensor_sample():
+    artifact = TrajectoryArtifactV1Alpha1.from_transfer_queue(
+        make_fields(
+            response_token_ids=torch.nested.nested_tensor(
+                [torch.tensor([4, 5])]
+            ),
+            response_logprobs=torch.nested.nested_tensor(
+                [torch.tensor([-0.1, -0.2])]
+            ),
+        ),
+        make_tag(),
+    )
+    assert artifact.response_token_ids.tolist() == [4, 5]

--- a/tests/test_trajectory_sample.py
+++ b/tests/test_trajectory_sample.py
@@ -1,0 +1,76 @@
+import pytest
+import torch
+
+from vime.rollout.trajectory_artifact import TrajectoryArtifactV1Alpha1
+from vime.rollout.trajectory_sample import trajectory_to_sample
+from vime.utils.types import Sample
+
+
+def make_artifact(**overrides):
+    values = {
+        "run_id": "run-a",
+        "request_id": "request-a",
+        "engine_id": "engine-a",
+        "model_id": "model-a",
+        "policy_version": 3,
+        "created_at_ns": 123,
+        "sample_index": 2,
+        "group_id": "group-a",
+        "finish_reason": "stop",
+        "prompt_token_ids": torch.tensor([1, 2]),
+        "response_token_ids": torch.tensor([3, 4]),
+        "response_logprobs": torch.tensor([-0.1, -0.2]),
+        "rewards": torch.tensor(1.5),
+        "loss_mask": None,
+    }
+    values.update(overrides)
+    return TrajectoryArtifactV1Alpha1(**values)
+
+
+def test_converts_artifact_to_vime_sample():
+    sample = trajectory_to_sample(make_artifact())
+
+    assert sample.tokens == [1, 2, 3, 4]
+    assert sample.response_length == 2
+    assert sample.rollout_log_probs == pytest.approx([-0.1, -0.2])
+    assert sample.loss_mask == [1, 1]
+    assert sample.reward == pytest.approx(1.5)
+    assert sample.status is Sample.Status.COMPLETED
+    assert sample.metadata["request_id"] == "request-a"
+    assert sample.weight_versions == ["3"]
+
+
+def test_group_members_share_group_index_but_not_rollout_id_or_sample_index():
+    first = trajectory_to_sample(make_artifact(request_id="request-a"))
+    second = trajectory_to_sample(make_artifact(request_id="request-b"))
+    assert first.group_index == second.group_index
+    assert first.rollout_id != second.rollout_id
+    assert first.index != second.index
+
+
+def test_missing_reward_has_explicit_policy():
+    artifact = make_artifact(rewards=None)
+    with pytest.raises(ValueError, match="rewards are missing"):
+        trajectory_to_sample(artifact)
+    assert trajectory_to_sample(artifact, require_reward=False).reward is None
+
+
+def test_rejects_vector_rewards_without_reducer():
+    with pytest.raises(ValueError, match="one scalar reward"):
+        trajectory_to_sample(make_artifact(rewards=torch.tensor([1.0, 2.0])))
+
+
+def test_maps_finish_status_and_loss_mask():
+    sample = trajectory_to_sample(
+        make_artifact(
+            finish_reason="length",
+            loss_mask=torch.tensor([1.0, 0.0]),
+        )
+    )
+    assert sample.status is Sample.Status.TRUNCATED
+    assert sample.loss_mask == [1, 0]
+
+
+def test_maps_legacy_numeric_length_finish_reason():
+    sample = trajectory_to_sample(make_artifact(finish_reason="1"))
+    assert sample.status is Sample.Status.TRUNCATED

--- a/tests/test_trajectory_source.py
+++ b/tests/test_trajectory_source.py
@@ -1,0 +1,154 @@
+from types import SimpleNamespace
+
+import torch
+
+from vime.rollout.trajectory_artifact import TrajectoryArtifactV1Alpha1
+from vime.rollout.trajectory_source import TransferQueueSampleSource
+from vime.ray.rollout import RolloutManager
+
+
+def make_artifact(request_id, reward=1.0):
+    return TrajectoryArtifactV1Alpha1(
+        run_id="run-a",
+        request_id=request_id,
+        engine_id="engine-a",
+        model_id="model-a",
+        policy_version=1,
+        created_at_ns=123,
+        prompt_token_ids=torch.tensor([1, 2]),
+        response_token_ids=torch.tensor([3]),
+        response_logprobs=torch.tensor([-0.5]),
+        rewards=None if reward is None else torch.tensor(reward),
+    )
+
+
+class FakeConsumer:
+    def __init__(self, artifacts):
+        self.artifacts = artifacts
+        self.closed = False
+
+    def iter_artifacts(self):
+        yield from self.artifacts
+
+    def close(self):
+        self.closed = True
+
+
+def test_takes_exact_native_sample_batch():
+    consumer = FakeConsumer(
+        [make_artifact("a"), make_artifact("b"), make_artifact("c")]
+    )
+    source = TransferQueueSampleSource(consumer, require_reward=True)
+    samples = source.take(2)
+
+    assert [sample.metadata["request_id"] for sample in samples] == ["a", "b"]
+    assert all(sample.tokens == [1, 2, 3] for sample in samples)
+    assert source.take(1)[0].metadata["request_id"] == "c"
+    source.close()
+    assert consumer.closed
+
+
+def test_from_args_selects_train_ready_fields(monkeypatch):
+    captured = {}
+
+    class FakeTrajectoryConsumer:
+        def __init__(self, config):
+            captured["config"] = config
+
+    monkeypatch.setattr(
+        "vime.rollout.trajectory_source.TransferQueueTrajectoryConsumer",
+        FakeTrajectoryConsumer,
+    )
+    args = SimpleNamespace(
+        tq_ray_address="ray://trainer:20001",
+        tq_run_id="run-a",
+        tq_policy_version="1",
+        tq_consumer_batch_size=8,
+        tq_consumer_micro_batch_size=2,
+        tq_task_name="trainer-a",
+        tq_dp_rank=0,
+        tq_poll_interval=0.1,
+        tq_require_rewards=True,
+        tq_include_loss_mask=True,
+        tq_include_routed_experts=False,
+    )
+    source = TransferQueueSampleSource.from_args(args)
+
+    assert source.require_reward
+    assert captured["config"].data_fields == [
+        "prompt_token_ids",
+        "response_token_ids",
+        "response_logprobs",
+        "rewards",
+        "loss_mask",
+    ]
+
+
+def test_rollout_manager_reads_transfer_queue_batch():
+    class FakeSource:
+        def take(self, count):
+            assert count == 2
+            return ["sample-a", "sample-b"]
+
+    manager_cls = RolloutManager.__ray_metadata__.modified_class
+    manager = object.__new__(manager_cls)
+    manager.args = SimpleNamespace(
+        load_debug_rollout_data=None,
+        trajectory_source="transfer_queue",
+        rollout_batch_size=2,
+        n_samples_per_prompt=1,
+    )
+    manager.trajectory_sample_source = FakeSource()
+
+    samples, metrics = manager._get_rollout_data(rollout_id=4)
+    assert samples == ["sample-a", "sample-b"]
+    assert metrics == {"transfer_queue/samples": 2}
+
+
+def test_transfer_queue_can_keep_managed_rollout_servers(monkeypatch):
+    # Closed-loop artifact-transfer training still relies on VIME's normal
+    # rollout-engine ownership so actor_model.update_weights() has engines to update.
+    manager_cls = RolloutManager.__ray_metadata__.modified_class
+    started = {}
+
+    monkeypatch.setattr(
+        "vime.ray.rollout.TransferQueueSampleSource.from_args",
+        lambda args: object(),
+    )
+    monkeypatch.setattr(
+        "vime.ray.rollout.init_http_client",
+        lambda args: started.setdefault("http", True),
+    )
+    monkeypatch.setattr(
+        "vime.ray.rollout.start_rollout_servers",
+        lambda args, pg: started.setdefault("servers", {"actor": object()}),
+    )
+    monkeypatch.setattr(
+        "vime.ray.rollout.init_tracking",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "vime.ray.rollout.Lock",
+        SimpleNamespace(
+            options=lambda **kwargs: SimpleNamespace(remote=lambda: object())
+        ),
+    )
+
+    manager = manager_cls.__new__(manager_cls)
+    manager_cls.__init__(
+        manager,
+        SimpleNamespace(
+            trajectory_source="transfer_queue",
+            tq_manage_rollout_servers=True,
+            debug_train_only=False,
+            custom_reward_post_process_path=None,
+            custom_convert_samples_to_train_data_path=None,
+            use_fault_tolerance=False,
+            ci_test=False,
+        ),
+        pg=object(),
+    )
+
+    assert started["http"]
+    assert manager.servers == {"actor": started["servers"]["actor"]}
+

--- a/tests/test_transfer_queue_arguments.py
+++ b/tests/test_transfer_queue_arguments.py
@@ -1,0 +1,42 @@
+import argparse
+
+from vime.utils.arguments import get_vime_extra_args_provider
+
+
+def test_transfer_queue_arguments_are_opt_in():
+    parser = argparse.ArgumentParser()
+    parser = get_vime_extra_args_provider()(parser)
+    args = parser.parse_args(["--rollout-batch-size", "1"])
+
+    assert args.trajectory_source == "generated"
+    assert args.tq_ray_address == "ray://172.16.1.248:20001"
+    assert args.tq_require_rewards
+    assert not args.tq_manage_rollout_servers
+
+
+def test_transfer_queue_argument_values():
+    parser = argparse.ArgumentParser()
+    parser = get_vime_extra_args_provider()(parser)
+    args = parser.parse_args(
+        [
+            "--rollout-batch-size",
+            "1",
+            "--trajectory-source",
+            "transfer_queue",
+            "--tq-run-id",
+            "run-a",
+            "--tq-policy-version",
+            "7",
+            "--tq-consumer-batch-size",
+            "8",
+            "--tq-allow-missing-rewards",
+            "--tq-manage-rollout-servers",
+        ]
+    )
+
+    assert args.trajectory_source == "transfer_queue"
+    assert args.tq_run_id == "run-a"
+    assert args.tq_policy_version == "7"
+    assert args.tq_consumer_batch_size == 8
+    assert not args.tq_require_rewards
+    assert args.tq_manage_rollout_servers

--- a/tests/test_transfer_queue_consumer.py
+++ b/tests/test_transfer_queue_consumer.py
@@ -1,0 +1,167 @@
+import sys
+from types import SimpleNamespace
+
+import numpy
+import torch
+
+from vime.rollout.transfer_queue_consumer import (
+    TransferQueueConsumerConfig,
+    TransferQueueTrajectoryConsumer,
+    _install_numpy2_pickle_compat,
+    build_trajectory_partition_id,
+)
+
+
+def make_tag(request_id="request-a"):
+    return {
+        "schema_name": "vllm.trajectory",
+        "schema_version": "v1alpha1",
+        "status": "complete",
+        "run_id": "run-a",
+        "request_id": request_id,
+        "engine_id": "engine-a",
+        "model_id": "model-a",
+        "policy_version": 1,
+        "created_at_ns": 123,
+    }
+
+
+def make_fields():
+    return {
+        "prompt_token_ids": torch.tensor([[1, 2]]),
+        "response_token_ids": torch.tensor([[3]]),
+        "response_logprobs": torch.tensor([[-0.5]]),
+    }
+
+
+class FakeRay:
+    def __init__(self):
+        self.initialized = False
+        self.shutdown_count = 0
+        self.controller = SimpleNamespace(
+            get_config=SimpleNamespace(remote=lambda: "tq-config")
+        )
+
+    def is_initialized(self):
+        return self.initialized
+
+    def init(self, **kwargs):
+        self.initialized = True
+        self.init_kwargs = kwargs
+
+    def get_actor(self, *args, **kwargs):
+        return self.controller
+
+    def get(self, value):
+        return value
+
+    def shutdown(self):
+        self.shutdown_count += 1
+        self.initialized = False
+
+
+class FakeTQ:
+    def __init__(self):
+        self.fields = make_fields()
+        self.tags = {
+            "rollout-run-a-1": {"request-a": make_tag()},
+        }
+        self.client = SimpleNamespace(close=lambda: None)
+
+    def init(self):
+        return None
+
+    def kv_batch_get(self, **kwargs):
+        return self.fields
+
+    def kv_list(self, partition_id):
+        return self.tags
+
+    def get_client(self):
+        return self.client
+
+
+def make_consumer(**kwargs):
+    ray = FakeRay()
+    tq = FakeTQ()
+    consumer = TransferQueueTrajectoryConsumer(
+        TransferQueueConsumerConfig(
+            ray_address="ray://trainer:20001",
+            run_id="run-a",
+            policy_version=1,
+            **kwargs,
+        ),
+        ray_module=ray,
+        transfer_queue_module=tq,
+    )
+    return consumer, ray, tq
+
+
+def test_numpy2_pickle_compat_aliases_core_modules():
+    if int(numpy.__version__.split(".", 1)[0]) >= 2:
+        return
+    _install_numpy2_pickle_compat()
+    assert sys.modules["numpy._core"] is numpy.core
+    assert sys.modules["numpy._core.numeric"] is numpy.core.numeric
+
+
+def test_build_partition_id_escapes_components():
+    assert (
+        build_trajectory_partition_id("run/a", "policy 1")
+        == "rollout-run%2Fa-policy%201"
+    )
+
+
+def test_point_lookup_and_handle_lookup():
+    consumer, ray, _ = make_consumer()
+    artifact = consumer.get_artifact(key="request-a")
+    assert artifact.response_token_ids.tolist() == [3]
+    assert ray.init_kwargs == {"address": "ray://trainer:20001"}
+
+    handle = {
+        "backend": "transfer_queue",
+        "artifact_id": "request-a",
+        "location": {
+            "partition_id": "rollout-run-a-1",
+            "key": "request-a",
+        },
+    }
+    assert consumer.get_from_handle(handle).request_id == "request-a"
+    consumer.close()
+    assert ray.shutdown_count == 1
+
+
+def test_streaming_dataset_and_partition_step():
+    nested_fields = make_fields()
+    nested_fields["response_token_ids"] = torch.nested.nested_tensor(
+        [torch.tensor([3])]
+    )
+    nested_fields["response_logprobs"] = torch.nested.nested_tensor(
+        [torch.tensor([-0.5])]
+    )
+    batches = [
+        (
+            nested_fields,
+            SimpleNamespace(custom_meta=[make_tag()]),
+        )
+    ]
+
+    class FakeDataset:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.partitions = []
+
+        def __iter__(self):
+            return iter(batches)
+
+        def step(self, partition):
+            self.partitions.append(partition)
+
+    consumer, _, _ = make_consumer(batch_size=4, micro_batch_size=1)
+    consumer._streaming_dataset_cls = FakeDataset
+    artifact = next(consumer.iter_artifacts())
+    assert artifact.prompt_token_ids.tolist() == [1, 2]
+    assert consumer._dataset.kwargs["task_name"] == "vime-trainer"
+
+    consumer.step("run-b", 2)
+    assert consumer._dataset.partitions == ["rollout-run-b-2"]

--- a/vime/ray/rollout.py
+++ b/vime/ray/rollout.py
@@ -20,6 +20,7 @@ GPU_MEMORY_TYPE_KV_CACHE = "kv_cache"
 GPU_MEMORY_TYPE_WEIGHTS = "weights"
 GPU_MEMORY_TYPE_CUDA_GRAPH = "cuda_graph"
 from vime.rollout.base_types import call_rollout_fn
+from vime.rollout.trajectory_source import TransferQueueSampleSource
 from vime.utils import logging_utils
 from vime.utils.dp_schedule import build_dp_schedule
 from vime.utils.health_monitor import RolloutHealthMonitor
@@ -358,11 +359,23 @@ class RolloutManager:
         self.pg = pg
         self.args = args
 
-        data_source_cls = load_function(self.args.data_source_path)
-        self.data_source = data_source_cls(args)
-
-        self.generate_rollout = load_function(self.args.rollout_function_path)
-        self.eval_generate_rollout = load_function(self.args.eval_function_path)
+        self.trajectory_sample_source = None
+        if self.args.trajectory_source == "transfer_queue":
+            self.data_source = None
+            self.generate_rollout = None
+            self.eval_generate_rollout = None
+            self.trajectory_sample_source = TransferQueueSampleSource.from_args(
+                args
+            )
+        else:
+            data_source_cls = load_function(self.args.data_source_path)
+            self.data_source = data_source_cls(args)
+            self.generate_rollout = load_function(
+                self.args.rollout_function_path
+            )
+            self.eval_generate_rollout = load_function(
+                self.args.eval_function_path
+            )
         self.custom_reward_post_process_func = None
         if self.args.custom_reward_post_process_path is not None:
             self.custom_reward_post_process_func = load_function(self.args.custom_reward_post_process_path)
@@ -371,14 +384,38 @@ class RolloutManager:
             self.custom_convert_samples_to_train_data_func = load_function(
                 self.args.custom_convert_samples_to_train_data_path
             )
-        logger.info(f"import {self.args.rollout_function_path} as generate_rollout function.")
-        logger.info(f"import {self.args.eval_function_path} as eval_generate_rollout function.")
+        if self.args.trajectory_source == "generated":
+            logger.info(
+                "import %s as generate_rollout function.",
+                self.args.rollout_function_path,
+            )
+            logger.info(
+                "import %s as eval_generate_rollout function.",
+                self.args.eval_function_path,
+            )
+        else:
+            logger.info("Using TransferQueue as the trajectory source.")
 
-        if self.args.debug_train_only:
+        # TransferQueue changes the sample source, not necessarily rollout ownership.
+        # Closed-loop runs keep VIME-managed rollout servers so the existing
+        # update_weights path can push trained actor weights back into vLLM.
+        should_start_rollout_servers = (
+            not self.args.debug_train_only
+            and (
+                self.args.trajectory_source == "generated"
+                or getattr(self.args, "tq_manage_rollout_servers", False)
+            )
+        )
+        if not should_start_rollout_servers:
             self.servers: dict[str, RolloutServer] = {}
         else:
             init_http_client(args)
             self.servers = start_rollout_servers(args, pg)
+            if self.args.trajectory_source == "transfer_queue":
+                logger.info(
+                    "Started rollout servers for TransferQueue closed-loop "
+                    "training; weight updates use the normal VIME path."
+                )
 
         init_tracking(args, primary=False)
         self.rollout_engine_lock = Lock.options(num_cpus=1, num_gpus=0).remote()
@@ -436,6 +473,8 @@ class RolloutManager:
     def dispose(self):
         for monitor in self._health_monitors:
             monitor.stop()
+        if self.trajectory_sample_source is not None:
+            self.trajectory_sample_source.close()
         logging_utils.finish_tracking(self.args)
 
     @property
@@ -476,6 +515,10 @@ class RolloutManager:
         return engines, self.rollout_engine_lock, num_new, gpu_counts, gpu_offsets
 
     def get_num_rollout_per_epoch(self):
+        if self.args.trajectory_source == "transfer_queue":
+            raise ValueError(
+                "TransferQueue requires an explicit --num-rollout"
+            )
         assert self.args.rollout_global_dataset
         return len(self.data_source) // self.args.rollout_batch_size
 
@@ -495,6 +538,8 @@ class RolloutManager:
         return self._split_train_data_by_dp(data)
 
     def eval(self, rollout_id):
+        if self.args.trajectory_source == "transfer_queue":
+            return
         if self.args.debug_train_only:
             # if debug train only, we don't generate evaluation data
             return
@@ -506,9 +551,13 @@ class RolloutManager:
         _log_eval_rollout_data(rollout_id, self.args, data, result.metrics)
 
     def save(self, rollout_id):
+        if self.args.trajectory_source == "transfer_queue":
+            return
         self.data_source.save(rollout_id)
 
     def load(self, rollout_id=None):
+        if self.args.trajectory_source == "transfer_queue":
+            return
         self.data_source.load(rollout_id)
 
     def offload(self):
@@ -583,8 +632,22 @@ class RolloutManager:
                     f"Subsample loaded debug rollout data using {ratio=} and change num rows {original_num_rows} -> {len(data)}"
                 )
             metrics = None
+        elif self.args.trajectory_source == "transfer_queue":
+            assert self.trajectory_sample_source is not None
+            sample_count = (
+                self.args.rollout_batch_size
+                * self.args.n_samples_per_prompt
+            )
+            data = self.trajectory_sample_source.take(sample_count)
+            metrics = {"transfer_queue/samples": len(data)}
         else:
-            data = call_rollout_fn(self.generate_rollout, self.args, rollout_id, self.data_source, evaluation=False)
+            data = call_rollout_fn(
+                self.generate_rollout,
+                self.args,
+                rollout_id,
+                self.data_source,
+                evaluation=False,
+            )
             metrics = data.metrics
             data = data.samples
             # Enforce the rollout_id contract before flattening: any list[Sample]

--- a/vime/rollout/rollout_dispatcher.py
+++ b/vime/rollout/rollout_dispatcher.py
@@ -1,0 +1,116 @@
+"""Grouped rollout dispatch to an external artifact-producing vLLM server."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+
+@dataclass(frozen=True)
+class RolloutPrompt:
+    group_id: str
+    prompt: str | list[int]
+    reward_context: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class DispatchedRollout:
+    request_id: str
+    group_id: str
+    sample_index: int
+    response: dict[str, Any]
+    reward_context: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RolloutDispatcherConfig:
+    endpoint: str
+    model: str
+    run_id: str
+    policy_version: str | int
+    n_samples_per_prompt: int
+    max_tokens: int
+    temperature: float = 1.0
+    concurrency: int = 32
+    timeout_s: float = 300
+
+
+class ExternalVllmRolloutDispatcher:
+    def __init__(
+        self,
+        config: RolloutDispatcherConfig,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ):
+        self.config = config
+        self._client = client
+        self._owns_client = client is None
+
+    def _request_id(self, group_id: str, sample_index: int) -> str:
+        return (
+            f"{self.config.run_id}-"
+            f"{self.config.policy_version}-{group_id}-{sample_index}"
+        )
+
+    async def _dispatch_one(
+        self,
+        client: httpx.AsyncClient,
+        semaphore: asyncio.Semaphore,
+        prompt: RolloutPrompt,
+        sample_index: int,
+    ) -> DispatchedRollout:
+        request_id = self._request_id(prompt.group_id, sample_index)
+        payload = {
+            "model": self.config.model,
+            "prompt": prompt.prompt,
+            "max_tokens": self.config.max_tokens,
+            "temperature": self.config.temperature,
+            "logprobs": 0,
+            "artifact_transfer_params": {
+                "run_id": self.config.run_id,
+                "policy_version": self.config.policy_version,
+                "model_id": self.config.model,
+                "group_id": prompt.group_id,
+                "sample_index": sample_index,
+            },
+        }
+        async with semaphore:
+            response = await client.post(
+                self.config.endpoint,
+                json=payload,
+                headers={"X-Request-Id": request_id},
+            )
+            response.raise_for_status()
+        return DispatchedRollout(
+            request_id=request_id,
+            group_id=prompt.group_id,
+            sample_index=sample_index,
+            response=response.json(),
+            reward_context=dict(prompt.reward_context),
+        )
+
+    async def dispatch(
+        self,
+        prompts: list[RolloutPrompt],
+    ) -> list[DispatchedRollout]:
+        if not prompts:
+            return []
+        client = self._client
+        if client is None:
+            client = httpx.AsyncClient(timeout=self.config.timeout_s)
+            self._client = client
+        semaphore = asyncio.Semaphore(self.config.concurrency)
+        tasks = [
+            self._dispatch_one(client, semaphore, prompt, sample_index)
+            for prompt in prompts
+            for sample_index in range(self.config.n_samples_per_prompt)
+        ]
+        try:
+            return await asyncio.gather(*tasks)
+        finally:
+            if self._owns_client:
+                await client.aclose()
+                self._client = None

--- a/vime/rollout/trajectory_artifact.py
+++ b/vime/rollout/trajectory_artifact.py
@@ -1,0 +1,186 @@
+"""Consumer-side contract for vLLM rollout trajectory artifacts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+TRAJECTORY_SCHEMA_NAME = "vllm.trajectory"
+TRAJECTORY_SCHEMA_VERSION = "v1alpha1"
+TRAJECTORY_STATUS_COMPLETE = "complete"
+
+
+def _unwrap_sample(value: Any, field_name: str) -> Any:
+    if isinstance(value, torch.Tensor):
+        if value.is_nested:
+            samples = list(value.unbind())
+            if len(samples) != 1:
+                raise ValueError(
+                    f"{field_name} contains {len(samples)} samples; expected one"
+                )
+            return samples[0]
+        if value.ndim > 0 and value.shape[0] == 1:
+            return value[0]
+    return value
+
+
+def _tensor(value: Any, field_name: str) -> torch.Tensor:
+    try:
+        return torch.as_tensor(value).detach().cpu().contiguous()
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be tensor-like") from exc
+
+
+def _vector(
+    value: Any,
+    field_name: str,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    tensor = _tensor(_unwrap_sample(value, field_name), field_name)
+    if tensor.ndim != 1:
+        raise ValueError(
+            f"{field_name} must be one-dimensional, got {tuple(tensor.shape)}"
+        )
+    return tensor.to(dtype=dtype)
+
+
+@dataclass(frozen=True)
+class TrajectoryArtifactV1Alpha1:
+    run_id: str
+    request_id: str
+    engine_id: str
+    model_id: str
+    policy_version: str | int
+    created_at_ns: int
+    prompt_token_ids: torch.Tensor
+    response_token_ids: torch.Tensor
+    response_logprobs: torch.Tensor
+    sample_index: int = 0
+    group_id: str | None = None
+    finish_reason: str | None = None
+    rewards: torch.Tensor | None = None
+    values: torch.Tensor | None = None
+    loss_mask: torch.Tensor | None = None
+    routed_experts: torch.Tensor | None = None
+
+    @classmethod
+    def from_transfer_queue(
+        cls,
+        fields: Mapping[str, Any],
+        tag: Mapping[str, Any],
+    ) -> "TrajectoryArtifactV1Alpha1":
+        if tag.get("schema_name") != TRAJECTORY_SCHEMA_NAME:
+            raise ValueError(
+                f"Unsupported trajectory schema: {tag.get('schema_name')}"
+            )
+        if tag.get("schema_version") != TRAJECTORY_SCHEMA_VERSION:
+            raise ValueError(
+                "Unsupported trajectory schema version: "
+                f"{tag.get('schema_version')}"
+            )
+        if tag.get("status") != TRAJECTORY_STATUS_COMPLETE:
+            raise ValueError(
+                f"Trajectory is not complete: status={tag.get('status')}"
+            )
+
+        required_tags = (
+            "run_id",
+            "request_id",
+            "engine_id",
+            "model_id",
+            "policy_version",
+            "created_at_ns",
+        )
+        missing_tags = [name for name in required_tags if name not in tag]
+        if missing_tags:
+            raise ValueError(f"Missing required trajectory tags: {missing_tags}")
+
+        required_fields = (
+            "prompt_token_ids",
+            "response_token_ids",
+            "response_logprobs",
+        )
+        missing_fields = [name for name in required_fields if name not in fields]
+        if missing_fields:
+            raise ValueError(
+                f"Missing required trajectory fields: {missing_fields}"
+            )
+
+        prompt_token_ids = _vector(
+            fields["prompt_token_ids"],
+            "prompt_token_ids",
+            torch.int64,
+        )
+        response_token_ids = _vector(
+            fields["response_token_ids"],
+            "response_token_ids",
+            torch.int64,
+        )
+        response_logprobs = _vector(
+            fields["response_logprobs"],
+            "response_logprobs",
+            torch.float32,
+        )
+        if len(prompt_token_ids) == 0:
+            raise ValueError("prompt_token_ids must not be empty")
+        if len(response_token_ids) != len(response_logprobs):
+            raise ValueError(
+                "response_token_ids and response_logprobs must have equal length"
+            )
+
+        loss_mask = None
+        if "loss_mask" in fields:
+            loss_mask = _vector(fields["loss_mask"], "loss_mask", torch.float32)
+            if len(loss_mask) != len(response_token_ids):
+                raise ValueError(
+                    "loss_mask and response_token_ids must have equal length"
+                )
+
+        rewards = None
+        if "rewards" in fields:
+            rewards = _tensor(
+                _unwrap_sample(fields["rewards"], "rewards"),
+                "rewards",
+            ).to(dtype=torch.float32)
+
+        values = None
+        if "values" in fields:
+            values = _vector(fields["values"], "values", torch.float32)
+
+        routed_experts = None
+        if "routed_experts" in fields:
+            routed_experts = _tensor(
+                _unwrap_sample(fields["routed_experts"], "routed_experts"),
+                "routed_experts",
+            )
+
+        sample_index = int(tag.get("sample_index", 0))
+        created_at_ns = int(tag["created_at_ns"])
+        if sample_index < 0:
+            raise ValueError("sample_index must be non-negative")
+        if created_at_ns <= 0:
+            raise ValueError("created_at_ns must be positive")
+
+        return cls(
+            run_id=str(tag["run_id"]),
+            request_id=str(tag["request_id"]),
+            engine_id=str(tag["engine_id"]),
+            model_id=str(tag["model_id"]),
+            policy_version=tag["policy_version"],
+            created_at_ns=created_at_ns,
+            sample_index=sample_index,
+            group_id=(
+                None if tag.get("group_id") is None else str(tag["group_id"])
+            ),
+            finish_reason=tag.get("finish_reason"),
+            prompt_token_ids=prompt_token_ids,
+            response_token_ids=response_token_ids,
+            response_logprobs=response_logprobs,
+            rewards=rewards,
+            values=values,
+            loss_mask=loss_mask,
+            routed_experts=routed_experts,
+        )

--- a/vime/rollout/trajectory_sample.py
+++ b/vime/rollout/trajectory_sample.py
@@ -1,0 +1,115 @@
+"""Conversion from vLLM trajectory artifacts to native VIME samples."""
+
+from __future__ import annotations
+
+import hashlib
+
+import torch
+
+from vime.rollout.trajectory_artifact import TrajectoryArtifactV1Alpha1
+from vime.utils.types import Sample
+
+
+def _stable_int(*components: object) -> int:
+    value = "\x1f".join(str(component) for component in components)
+    digest = hashlib.blake2b(value.encode(), digest_size=8).digest()
+    return int.from_bytes(digest, "big") & ((1 << 63) - 1)
+
+
+def _sample_status(finish_reason: str | None) -> Sample.Status:
+    if finish_reason in (None, "stop", "eos"):
+        return Sample.Status.COMPLETED
+    if finish_reason in ("length", "1"):
+        return Sample.Status.TRUNCATED
+    if finish_reason in ("abort", "aborted"):
+        return Sample.Status.ABORTED
+    return Sample.Status.FAILED
+
+
+def _scalar_reward(
+    rewards: torch.Tensor | None,
+    *,
+    require_reward: bool,
+) -> float | None:
+    if rewards is None:
+        if require_reward:
+            raise ValueError("Trajectory is not train-ready: rewards are missing")
+        return None
+    if rewards.numel() != 1:
+        raise ValueError(
+            "VIME Sample requires one scalar reward; configure a reward reducer "
+            "before consuming vector rewards"
+        )
+    return float(rewards.reshape(-1)[0].item())
+
+
+def trajectory_to_sample(
+    artifact: TrajectoryArtifactV1Alpha1,
+    *,
+    require_reward: bool = True,
+) -> Sample:
+    response_length = len(artifact.response_token_ids)
+    if artifact.loss_mask is None:
+        loss_mask = [1] * response_length
+    else:
+        loss_values = artifact.loss_mask.tolist()
+        if any(value not in (0, 1, 0.0, 1.0) for value in loss_values):
+            raise ValueError("loss_mask values must be binary")
+        loss_mask = [int(value) for value in loss_values]
+
+    group_key = artifact.group_id or artifact.request_id
+    sample_index = _stable_int(
+        artifact.run_id,
+        artifact.request_id,
+        artifact.sample_index,
+    )
+    group_index = _stable_int(
+        artifact.run_id,
+        artifact.policy_version,
+        group_key,
+    )
+    # VIME schedules train steps by unique rollout_id. Keep group_index
+    # prompt-scoped, but make rollout_id sample-scoped so n_samples_per_prompt
+    # contributes the expected number of trainable rollouts.
+    rollout_id = sample_index
+    metadata = {
+        "artifact_schema": "vllm.trajectory/v1alpha1",
+        "run_id": artifact.run_id,
+        "request_id": artifact.request_id,
+        "group_id": group_key,
+        "sample_index": artifact.sample_index,
+        "engine_id": artifact.engine_id,
+        "model_id": artifact.model_id,
+        "policy_version": artifact.policy_version,
+        "created_at_ns": artifact.created_at_ns,
+        "finish_reason": artifact.finish_reason,
+    }
+
+    return Sample(
+        group_index=group_index,
+        index=sample_index,
+        rollout_id=rollout_id,
+        tokens=(
+            artifact.prompt_token_ids.tolist()
+            + artifact.response_token_ids.tolist()
+        ),
+        response_length=response_length,
+        reward=_scalar_reward(
+            artifact.rewards,
+            require_reward=require_reward,
+        ),
+        loss_mask=loss_mask,
+        weight_versions=[str(artifact.policy_version)],
+        rollout_log_probs=artifact.response_logprobs.tolist(),
+        rollout_routed_experts=(
+            None
+            if artifact.routed_experts is None
+            else artifact.routed_experts.tolist()
+        ),
+        status=_sample_status(artifact.finish_reason),
+        metadata=metadata,
+        train_metadata={
+            "model_id": artifact.model_id,
+            "policy_version": artifact.policy_version,
+        },
+    )

--- a/vime/rollout/trajectory_source.py
+++ b/vime/rollout/trajectory_source.py
@@ -1,0 +1,76 @@
+"""VIME rollout source backed by TransferQueue trajectory artifacts."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from vime.rollout.trajectory_sample import trajectory_to_sample
+from vime.rollout.transfer_queue_consumer import (
+    REQUIRED_TRAJECTORY_FIELDS,
+    TransferQueueConsumerConfig,
+    TransferQueueTrajectoryConsumer,
+)
+from vime.utils.types import Sample
+
+
+class TransferQueueSampleSource:
+    def __init__(
+        self,
+        consumer: TransferQueueTrajectoryConsumer,
+        *,
+        require_reward: bool,
+    ):
+        self.consumer = consumer
+        self.require_reward = require_reward
+        self._iterator: Iterator | None = None
+
+    @classmethod
+    def from_args(cls, args: Any) -> "TransferQueueSampleSource":
+        data_fields = list(REQUIRED_TRAJECTORY_FIELDS)
+        if args.tq_require_rewards:
+            data_fields.append("rewards")
+        if args.tq_include_loss_mask:
+            data_fields.append("loss_mask")
+        if args.tq_include_routed_experts:
+            data_fields.append("routed_experts")
+
+        consumer = TransferQueueTrajectoryConsumer(
+            TransferQueueConsumerConfig(
+                ray_address=args.tq_ray_address,
+                run_id=args.tq_run_id,
+                policy_version=args.tq_policy_version,
+                batch_size=args.tq_consumer_batch_size,
+                micro_batch_size=args.tq_consumer_micro_batch_size,
+                task_name=args.tq_task_name,
+                dp_rank=args.tq_dp_rank,
+                data_fields=data_fields,
+                poll_interval_s=args.tq_poll_interval,
+                service_config_path=getattr(
+                    args, "tq_service_config_path", None
+                ),
+                partition_prefix=getattr(
+                    args, "tq_partition_prefix", "train"
+                ),
+            )
+        )
+        return cls(
+            consumer,
+            require_reward=args.tq_require_rewards,
+        )
+
+    def take(self, count: int) -> list[Sample]:
+        if count < 1:
+            raise ValueError("TransferQueue sample count must be positive")
+        if self._iterator is None:
+            self._iterator = self.consumer.iter_artifacts()
+        return [
+            trajectory_to_sample(
+                next(self._iterator),
+                require_reward=self.require_reward,
+            )
+            for _ in range(count)
+        ]
+
+    def close(self) -> None:
+        self.consumer.close()

--- a/vime/rollout/transfer_queue_consumer.py
+++ b/vime/rollout/transfer_queue_consumer.py
@@ -1,0 +1,232 @@
+"""TransferQueue readers for vLLM rollout trajectory artifacts."""
+
+from __future__ import annotations
+
+import importlib
+import pickle
+import sys
+import time
+from pathlib import Path
+from dataclasses import dataclass, field
+from typing import Any, Iterator
+from urllib.parse import quote
+
+import torch
+
+from vime.rollout.trajectory_artifact import TrajectoryArtifactV1Alpha1
+
+REQUIRED_TRAJECTORY_FIELDS = [
+    "prompt_token_ids",
+    "response_token_ids",
+    "response_logprobs",
+]
+
+
+def _install_numpy2_pickle_compat() -> None:
+    """Allow NumPy 1.x consumers to unpickle payloads written by NumPy 2.x."""
+    numpy = importlib.import_module("numpy")
+    if int(numpy.__version__.split(".", 1)[0]) >= 2:
+        return
+    core = importlib.import_module("numpy.core")
+    sys.modules["numpy._core"] = core
+    for module_name in ("multiarray", "numeric"):
+        module = importlib.import_module(f"numpy.core.{module_name}")
+        sys.modules[f"numpy._core.{module_name}"] = module
+
+
+def _select_sample(value: Any, index: int) -> Any:
+    if isinstance(value, torch.Tensor) and value.is_nested:
+        return value.unbind()[index].unsqueeze(0)
+    return value[index : index + 1]
+
+
+def build_trajectory_partition_id(
+    run_id: str,
+    policy_version: str | int,
+    partition_prefix: str = "rollout",
+) -> str:
+    run = quote(str(run_id), safe="-_.")
+    policy = quote(str(policy_version), safe="-_.")
+    prefix = quote(str(partition_prefix), safe="-_.")
+    if not run or not policy or not prefix:
+        raise ValueError(
+            "run_id, policy_version, and partition_prefix must not be empty"
+        )
+    return f"{prefix}-{run}-{policy}"
+
+
+@dataclass
+class TransferQueueConsumerConfig:
+    ray_address: str
+    run_id: str
+    policy_version: str | int
+    batch_size: int = 1
+    micro_batch_size: int = 1
+    task_name: str = "vime-trainer"
+    dp_rank: int = 0
+    data_fields: list[str] = field(
+        default_factory=lambda: list(REQUIRED_TRAJECTORY_FIELDS)
+    )
+    poll_interval_s: float = 0.2
+    service_config_path: str | None = None
+    partition_prefix: str = "rollout"
+
+    @property
+    def partition_id(self) -> str:
+        return build_trajectory_partition_id(
+            self.run_id,
+            self.policy_version,
+            self.partition_prefix,
+        )
+
+
+class TransferQueueTrajectoryConsumer:
+    def __init__(
+        self,
+        config: TransferQueueConsumerConfig,
+        *,
+        ray_module: Any | None = None,
+        transfer_queue_module: Any | None = None,
+        streaming_dataset_cls: Any | None = None,
+    ):
+        self.config = config
+        self._ray = ray_module
+        self._tq = transfer_queue_module
+        self._streaming_dataset_cls = streaming_dataset_cls
+        self._tq_config: Any | None = None
+        self._dataset: Any | None = None
+        self._owns_ray = False
+
+    def initialize(self) -> None:
+        _install_numpy2_pickle_compat()
+        if self._tq_config is not None:
+            return
+        if self.config.service_config_path is not None:
+            config_path = Path(self.config.service_config_path)
+            with config_path.open("rb") as file:
+                self._tq_config = pickle.load(file)
+            return
+        if self._ray is None:
+            self._ray = importlib.import_module("ray")
+        if self._tq is None:
+            self._tq = importlib.import_module("transfer_queue")
+
+        if not self._ray.is_initialized():
+            self._ray.init(address=self.config.ray_address)
+            self._owns_ray = True
+        self._tq.init()
+
+        controller = self._ray.get_actor(
+            "TransferQueueController",
+            namespace="transfer_queue",
+        )
+        self._tq_config = self._ray.get(controller.get_config.remote())
+
+    def get_artifact(
+        self,
+        *,
+        key: str,
+        partition_id: str | None = None,
+        timeout_s: float = 0,
+    ) -> TrajectoryArtifactV1Alpha1:
+        self.initialize()
+        if self._tq is None:
+            raise RuntimeError(
+                "Point lookup requires a service-Ray connection; exported "
+                "configuration supports streaming reads only"
+            )
+        partition = partition_id or self.config.partition_id
+        deadline = time.monotonic() + timeout_s
+
+        while True:
+            try:
+                fields = self._tq.kv_batch_get(
+                    keys=key,
+                    partition_id=partition,
+                    select_fields=self.config.data_fields,
+                )
+                tags = self._tq.kv_list(partition)
+                tag = tags[partition][key]
+                return TrajectoryArtifactV1Alpha1.from_transfer_queue(
+                    fields,
+                    tag,
+                )
+            except (KeyError, ValueError):
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(self.config.poll_interval_s)
+
+    def get_from_handle(
+        self,
+        handle: dict[str, Any],
+        *,
+        timeout_s: float = 0,
+    ) -> TrajectoryArtifactV1Alpha1:
+        if handle.get("backend") != "transfer_queue":
+            raise ValueError(
+                f"Unsupported artifact backend: {handle.get('backend')}"
+            )
+        location = handle.get("location") or {}
+        key = location.get("key") or handle.get("artifact_id")
+        partition_id = location.get("partition_id")
+        if not key or not partition_id:
+            raise ValueError(
+                "TransferQueue artifact handle requires key and partition_id"
+            )
+        return self.get_artifact(
+            key=str(key),
+            partition_id=str(partition_id),
+            timeout_s=timeout_s,
+        )
+
+    def _create_dataset(self) -> Any:
+        self.initialize()
+        if self._streaming_dataset_cls is None:
+            self._streaming_dataset_cls = importlib.import_module(
+                "transfer_queue"
+            ).StreamingDataset
+        return self._streaming_dataset_cls(
+            config=self._tq_config,
+            batch_size=self.config.batch_size,
+            micro_batch_size=self.config.micro_batch_size,
+            data_fields=self.config.data_fields,
+            partition_id=self.config.partition_id,
+            task_name=self.config.task_name,
+            dp_rank=self.config.dp_rank,
+            should_check_consumption_status=False,
+        )
+
+    def iter_artifacts(self) -> Iterator[TrajectoryArtifactV1Alpha1]:
+        if self._dataset is None:
+            self._dataset = self._create_dataset()
+        for fields, batch_meta in self._dataset:
+            batch_size = len(batch_meta.custom_meta)
+            for index in range(batch_size):
+                sample_fields = {
+                    name: _select_sample(value, index)
+                    for name, value in fields.items()
+                }
+                yield TrajectoryArtifactV1Alpha1.from_transfer_queue(
+                    sample_fields,
+                    batch_meta.custom_meta[index],
+                )
+
+    def step(
+        self,
+        run_id: str,
+        policy_version: str | int,
+    ) -> None:
+        self.config.run_id = run_id
+        self.config.policy_version = policy_version
+        if self._dataset is not None:
+            self._dataset.step(self.config.partition_id)
+
+    def close(self) -> None:
+        if self._tq is not None:
+            try:
+                self._tq.get_client().close()
+            except (AssertionError, AttributeError):
+                pass
+        if self._owns_ray and self._ray is not None:
+            self._ray.shutdown()
+        self._owns_ray = False

--- a/vime/utils/arguments.py
+++ b/vime/utils/arguments.py
@@ -243,6 +243,80 @@ def get_vime_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--trajectory-source",
+                choices=["generated", "transfer_queue"],
+                default="generated",
+                help="Source of rollout samples consumed by RolloutManager.",
+            )
+            parser.add_argument(
+                "--tq-ray-address",
+                type=str,
+                default="ray://172.16.1.248:20001",
+                help="Ray Client endpoint for the shared TransferQueue service.",
+            )
+            parser.add_argument(
+                "--tq-service-config-path",
+                type=str,
+                default=(
+                    "/mnt/data1/yibo/vime-workspace/services/"
+                    "transfer_queue/client_config.pkl"
+                ),
+            )
+            parser.add_argument(
+                "--tq-partition-prefix",
+                type=str,
+                default="train",
+            )
+            parser.add_argument("--tq-run-id", type=str, default=None)
+            parser.add_argument("--tq-policy-version", type=str, default=None)
+            parser.add_argument(
+                "--tq-task-name",
+                type=str,
+                default="vime-trainer",
+            )
+            parser.add_argument("--tq-dp-rank", type=int, default=0)
+            parser.add_argument(
+                "--tq-consumer-batch-size",
+                type=int,
+                default=None,
+            )
+            parser.add_argument(
+                "--tq-consumer-micro-batch-size",
+                type=int,
+                default=1,
+            )
+            parser.add_argument(
+                "--tq-poll-interval",
+                type=float,
+                default=0.2,
+            )
+            parser.add_argument(
+                "--tq-manage-rollout-servers",
+                action="store_true",
+                default=False,
+                help=(
+                    "Start VIME-managed rollout servers while consuming "
+                    "TransferQueue trajectories, so the normal VIME "
+                    "update_weights path still updates rollout vLLM engines."
+                ),
+            )
+            parser.add_argument(
+                "--tq-allow-missing-rewards",
+                action="store_false",
+                dest="tq_require_rewards",
+                default=True,
+            )
+            parser.add_argument(
+                "--tq-include-loss-mask",
+                action="store_true",
+                default=False,
+            )
+            parser.add_argument(
+                "--tq-include-routed-experts",
+                action="store_true",
+                default=False,
+            )
+            parser.add_argument(
                 "--rollout-temperature",
                 type=float,
                 default=1.0,
@@ -1165,6 +1239,12 @@ def get_vime_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--debug-random-model-init",
+                action="store_true",
+                default=False,
+                help="Initialize training weights randomly; only valid with --debug-train-only.",
+            )
+            parser.add_argument(
                 "--dump-details",
                 type=str,
                 default=None,
@@ -1758,6 +1838,11 @@ def vime_validate_args(args):
     assert not (args.debug_rollout_only and args.debug_train_only), (
         "debug_rollout_only and debug_train_only cannot be set at the same time, " "please set only one of them."
     )
+    if args.debug_random_model_init and not args.debug_train_only:
+        raise ValueError(
+            "--debug-random-model-init requires --debug-train-only; "
+            "production training must load an explicit checkpoint."
+        )
 
     # always true on offload for colocate at the moment.
     if args.colocate:
@@ -1799,6 +1884,29 @@ def vime_validate_args(args):
 
     if args.eval_function_path is None:
         args.eval_function_path = args.rollout_function_path
+
+    if args.trajectory_source == "transfer_queue":
+        if not args.tq_run_id:
+            raise ValueError("--tq-run-id is required for TransferQueue")
+        if not args.tq_policy_version:
+            raise ValueError(
+                "--tq-policy-version is required for TransferQueue"
+            )
+        if args.num_rollout is None:
+            raise ValueError(
+                "--num-rollout must be explicit for TransferQueue sources"
+            )
+        if args.tq_consumer_batch_size is None:
+            args.tq_consumer_batch_size = (
+                args.rollout_batch_size * args.n_samples_per_prompt
+            )
+        if args.tq_manage_rollout_servers and args.debug_train_only:
+            raise ValueError(
+                "--tq-manage-rollout-servers cannot be used with "
+                "--debug-train-only"
+            )
+    elif args.tq_consumer_batch_size is None:
+        args.tq_consumer_batch_size = 1
 
     if args.num_steps_per_rollout is not None:
         global_batch_size = args.rollout_batch_size * args.n_samples_per_prompt // args.num_steps_per_rollout


### PR DESCRIPTION
## Summary
- Add TransferQueue trajectory ingestion for closed-loop VIME training.
- Thread artifact-consumer plumbing through the rollout path.
- Keep the branch authored by Yibo Huang on the forked head branch.

## Duplicate-work check
- Checked open PRs for `huangyibo:feat/tq-artifact-consumer`: none found.
- Checked open PRs for `tq artifact consumer`: none found.
- Checked open PRs for `artifact consumer`: no matching duplicate found.

## Tests
- Not run locally; this was a worktree setup and PR publish operation only.

## AI assistance
- AI assistance was used to set up the local worktree and publish the PR. The branch contents come from `huangyibo/feat/tq-artifact-consumer`.
