### PR TITLE
fix: initialize delta update weight metrics

### DIFF
--- a/vime/backends/megatron_utils/update_weight/update_weight_from_distributed_delta.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_distributed_delta.py
@@ -503,6 +503,7 @@ class UpdateWeightFromDistributedDelta(UpdateWeightFromDistributed):
         self.encoding = DeltaEncoding(args.update_weight_encoding)
         self.delta_state = DeltaState()
         self._snapshot_seeded = False
+        self.update_weight_metrics: dict[str, float] = {}
         # DELTAS_ZSTD shares the gap encoder; zstd is applied at file-write time.
         self._encode = encode_indices if self.encoding is DeltaEncoding.INDICES else encode_deltas
 


### PR DESCRIPTION
## Summary

Fixes the delta updater metrics initialization issue called out in https://github.com/vllm-project/vime/pull/278#issuecomment-4904111448.

`UpdateWeightFromDistributedDelta._record_metrics()` writes density and wire-size counters to `self.update_weight_metrics`. This PR initializes that dictionary in `UpdateWeightFromDistributedDelta.__init__` so the first delta weight sync has metrics storage available.

## Validation

- `/home/aoshen/vime/.venv/bin/python -m py_compile vime/backends/megatron_utils/update_weight/update_weight_from_distributed_delta.py`
- `git diff --check`