### PR TITLE
[Doc] Fix stale Qwen3-30B-A3B example: restore FP8-inference section + rewrite multi-node

### DIFF
--- a/docs/en/examples/qwen3-30B-A3B.md
+++ b/docs/en/examples/qwen3-30B-A3B.md
@@ -3,14 +3,11 @@
 
 ## Environment Preparation
 
-Environment setup and checkpoint conversion are the same as for the Qwen3-4B model; see [Example: Qwen3-4B Model](qwen3-4B.md) and replace mentions of Qwen3-4B with Qwen3-30B-A3B.
+Environment setup, model download, and checkpoint conversion are the same as for the Qwen3-4B model; see [Example: Qwen3-4B Model](qwen3-4B.md) and replace mentions of Qwen3-4B with Qwen3-30B-A3B.
 
-Download the model and data:
+Train and eval data (identical to Qwen3-4B):
 
 ```bash
-# hf checkpoint
-hf download Qwen/Qwen3-30B-A3B --local-dir /root/Qwen3-30B-A3B
-
 # train data
 hf download --repo-type dataset zhuzilin/dapo-math-17k \
   --local-dir /root/dapo-math-17k

--- a/docs/en/examples/qwen3-30B-A3B.md
+++ b/docs/en/examples/qwen3-30B-A3B.md
@@ -108,7 +108,7 @@ The following uses **2 nodes × 8 GPUs (16 GPUs total) in colocate mode** as the
    ray start --address=${MASTER_ADDR}:6379 --num-gpus 8
    ```
 
-   Wait until `ray status` reports 16 GPUs before submitting. Since the cluster is already up, remove the `ray start --head ...` line at the top of the script so it goes straight to `ray job submit`.
+   Wait until `ray status` reports 16 GPUs before submitting. Because you started the cluster manually, make the script skip its process-management preamble — remove (or comment out) **both** the initial cleanup block (`ray stop --force`, `pkill -9 ray`, `pkill -9 python`, `pkill -9 redis`) **and** the `ray start --head ...` line. Otherwise running the script tears down the head you just started (and orphans the workers), so `ray job submit` to `http://127.0.0.1:8265` fails. Keep the rest of the script — it still sources the model args and runs `ray job submit`.
 
 3. **Adjust script arguments** (`scripts/run-qwen3-30B-A3B.sh`):
    - Change `--actor-num-nodes` for `train.py` from `1` to `2` (keep `--actor-num-gpus-per-node` at 8). Under colocate, `--rollout-num-gpus` is auto-set to `actor_num_gpus_per_node × actor_num_nodes = 16`, so you don't set it manually.

--- a/docs/en/examples/qwen3-30B-A3B.md
+++ b/docs/en/examples/qwen3-30B-A3B.md
@@ -3,9 +3,24 @@
 
 ## Environment Preparation
 
-The environment setup, model download, data, and checkpoint conversion are the same as for the Qwen3-4B model. You can refer to [Example: Qwen3-4B Model](qwen3-4B.md), replacing mentions of Qwen3-4B with Qwen3-30B-A3B.
+Environment setup and checkpoint conversion are the same as for the Qwen3-4B model; see [Example: Qwen3-4B Model](qwen3-4B.md) and replace mentions of Qwen3-4B with Qwen3-30B-A3B.
 
-To convert huggingface checkpoint to torch_dist, please try:
+Download the model and data:
+
+```bash
+# hf checkpoint
+hf download Qwen/Qwen3-30B-A3B --local-dir /root/Qwen3-30B-A3B
+
+# train data
+hf download --repo-type dataset zhuzilin/dapo-math-17k \
+  --local-dir /root/dapo-math-17k
+
+# eval data
+hf download --repo-type dataset zhuzilin/aime-2024 \
+  --local-dir /root/aime-2024
+```
+
+To convert the huggingface checkpoint to torch_dist, please try:
 
 ```bash
 cd vime/
@@ -72,92 +87,43 @@ Here, we will briefly introduce the MoE-related parts in the [run-qwen3-30B-A3B.
     For DP on the attention block plus EP on the experts, combine
     `--vllm-data-parallel-size N` with `--vllm-enable-expert-parallel`.
 
+### BF16 Training with FP8 Inference
+
+vime also supports BF16 training with FP8 inference. For the Qwen3-30B-A3B model, just download the FP8 weights:
+
+```bash
+hf download Qwen/Qwen3-30B-A3B-FP8 --local-dir /root/Qwen3-30B-A3B-FP8
+```
+
+And replace `--hf-checkpoint` in the script with:
+
+```bash
+#--hf-checkpoint /root/Qwen3-30B-A3B
+--hf-checkpoint /root/Qwen3-30B-A3B-FP8
+```
+
+This triggers FP8 inference. Currently we directly cast the BF16 weights to FP8; more precision-friendly quantization schemes will be added over time.
+
+⚠️ The Megatron checkpoint used for training must still be the one originally converted from the BF16 huggingface weights (`--ref-load` / `--load` unchanged).
+
 ### Multi-Node Support
 
-The following uses **two machines with 8 GPUs each (16 GPUs total)** as the starting example; scripts and parameters scale to **N nodes**. Key differences from single-node:
+For a multi-node environment, the following modifications are necessary:
 
-- Place weights, checkpoints, and data on storage visible to every node (e.g. NFS).
-- Set `MASTER_ADDR` to the head **LAN IP** (not `127.0.0.1`).
-- Omit CPU Adam (multi-node uses a distributed optimizer; do not use `--optimizer-cpu-offload`).
-- `global-batch-size` must equal `rollout-batch-size × n-samples-per-prompt`.
+- Place the training model and data on storage accessible by every node (e.g. NFS).
+- Set `MASTER_ADDR` to an address reachable by all nodes (not `127.0.0.1`), start Ray on each node manually, then submit training from the head (see [Quick Start — Multi-node training](../get_started/quick_start.md#multi-node-training-for-large-scale-moe-models)).
+- Adjust `--actor-num-nodes` for `train.py` and the parallelism (TP/EP/CP) in `PERF_ARGS` to match the total GPU count.
+- Remove the CPU Adam configuration, since multi-node uses a distributed optimizer, which significantly reduces the optimizer's memory footprint.
 
-#### Topology
-
-| Component | Dual-node defaults |
-|-----------|-------------------|
-| Cluster | `ACTOR_NUM_NODES=2`, `ACTOR_NUM_GPUS_PER_NODE=8` |
-| Megatron training | TP=8, EP=8, CP=2 (experts sharded across nodes) |
-| vLLM rollout | Cross-node TP=16 (`rollout-num-gpus-per-engine = nodes × GPUs per node`) |
-| Scheduling | Ray cluster + `--colocate` mode |
-
-Convert checkpoints with Megatron parallelism matching training (dual-node: TP=8, EP=8). Checkpoint EP must match `--expert-model-parallel-size`, or `load_checkpoint` may hang or resharding may be extremely slow.
-
-#### Start the Ray Cluster
-
-Start Ray **outside** the training script on each node. Join all workers first; verify `ray status` reports the expected GPU count, then submit training from the head. Dual-node example:
+In addition, when the total number of GPUs is not a multiple or divisor of the total number of experts, you can enable vLLM's EPLB (Expert Parallelism Load Balancer) and configure redundant experts via `--vllm-eplb-config`. For example, in a 24-GPU scenario:
 
 ```bash
-# === Head node ===
-export MASTER_ADDR=<head_lan_ip>
-ray start --head --node-ip-address="${MASTER_ADDR}" --num-gpus 8 --disable-usage-stats \
-   --dashboard-host=0.0.0.0 --dashboard-port=8265
-
-# === Each worker node ===
-export MASTER_ADDR=<head_lan_ip>
-ray start --address="${MASTER_ADDR}:6379" --node-ip-address=<this_node_lan_ip> --num-gpus 8
+VLLM_ARGS=(
+   --rollout-num-gpus-per-engine 24
+   --vllm-gpu-memory-utilization 0.7
+   --vllm-data-parallel-size 3
+   --vllm-enable-expert-parallel
+   --vllm-enable-eplb
+   --vllm-eplb-config '{"num_redundant_experts": 16}'
+)
 ```
-
-See [Quick Start — Multi-node training](../get_started/quick_start.md#multi-node-training-for-large-scale-moe-models) for more details.
-
-#### Run Training
-
-After the Ray cluster is ready, on the **head node** set multi-node env vars and run the **same script as single-node** (`ACTOR_NUM_NODES>1` skips Ray startup and applies multi-node defaults):
-
-```bash
-export MASTER_ADDR=<head_lan_ip>
-export ACTOR_NUM_NODES=2
-export ACTOR_NUM_GPUS_PER_NODE=8
-cd /root/vime
-bash scripts/run-qwen3-30B-A3B.sh
-```
-
-2-step smoke test:
-
-```bash
-NUM_ROLLOUT=2 ENABLE_R3=0 bash scripts/run-qwen3-30B-A3B.sh
-```
-
-To scale to N nodes (e.g. 4×8), join all workers to Ray, set `ACTOR_NUM_NODES=4` on the head, and tune `MEGATRON_TP` / `MEGATRON_EP` / `MEGATRON_CP` / `ROLLOUT_NUM_GPUS_PER_ENGINE` for total GPU count.
-
-#### Key Multi-Node Parameters
-
-| Variable | Dual-node default | Description |
-|----------|-------------------|-------------|
-| `ACTOR_NUM_NODES` | 2 (default 1 for single-node) | Total nodes including head; script skips Ray startup when >1 |
-| `ACTOR_NUM_GPUS_PER_NODE` | 8 | GPUs per node |
-| `MEGATRON_TP` / `MEGATRON_EP` / `MEGATRON_CP` | 8 / 8 / 2 | Megatron parallelism |
-| `ROLLOUT_NUM_GPUS_PER_ENGINE` | total GPUs | vLLM engine GPU count |
-| `ENABLE_R3` | 1 | set to 0 to disable R3 |
-
-Default batch: `rollout-batch-size=4`, `n-samples-per-prompt=2`, `global-batch-size=8`; vLLM uses `--vllm-moe-backend triton`.
-
-#### Multi-Node Troubleshooting
-
-- **Worker cannot join Ray / NCCL failures**: check `MASTER_ADDR`, container `/etc/hosts` (hostname must not map to `127.0.0.1`), `NCCL_SOCKET_IFNAME` / `GLOO_SOCKET_IFNAME`.
-- **`Not enough samples X for global_batch_size Y`**: keep `global-batch-size` equal to `rollout-batch-size × n-samples-per-prompt`.
-- **GPU memory full but no processes**: restart the container or run `ray stop --force` to clear stale vLLM contexts.
-
-#### EPLB
-
-When the total number of GPUs is not a multiple or divisor of the total number of experts, enable vLLM's EPLB (Expert Parallelism Load Balancer) and configure redundant experts via `--vllm-eplb-config`. For example, in a 24-GPU scenario:
-
-   ```bash
-   VLLM_ARGS=(
-      --rollout-num-gpus-per-engine 24
-      --vllm-gpu-memory-utilization 0.7
-      --vllm-data-parallel-size 3
-      --vllm-enable-expert-parallel
-      --vllm-enable-eplb
-      --vllm-eplb-config '{"num_redundant_experts": 16}'
-   )
-   ```

--- a/docs/en/examples/qwen3-30B-A3B.md
+++ b/docs/en/examples/qwen3-30B-A3B.md
@@ -3,21 +3,9 @@
 
 ## Environment Preparation
 
-Environment setup, model download, and checkpoint conversion are the same as for the Qwen3-4B model; see [Example: Qwen3-4B Model](qwen3-4B.md) and replace mentions of Qwen3-4B with Qwen3-30B-A3B.
+The environment setup, model download, data, and checkpoint conversion are the same as for the Qwen3-4B model. You can refer to [Example: Qwen3-4B Model](qwen3-4B.md), replacing mentions of Qwen3-4B with Qwen3-30B-A3B.
 
-Train and eval data (identical to Qwen3-4B):
-
-```bash
-# train data
-hf download --repo-type dataset zhuzilin/dapo-math-17k \
-  --local-dir /root/dapo-math-17k
-
-# eval data
-hf download --repo-type dataset zhuzilin/aime-2024 \
-  --local-dir /root/aime-2024
-```
-
-To convert the huggingface checkpoint to torch_dist, please try:
+To convert huggingface checkpoint to torch_dist, please try:
 
 ```bash
 cd vime/

--- a/docs/en/examples/qwen3-30B-A3B.md
+++ b/docs/en/examples/qwen3-30B-A3B.md
@@ -108,12 +108,35 @@ This triggers FP8 inference. Currently we directly cast the BF16 weights to FP8;
 
 ### Multi-Node Support
 
-For a multi-node environment, the following modifications are necessary:
+The following uses **2 nodes × 8 GPUs (16 GPUs total) in colocate mode** as the example. The only differences from single-node are "starting Ray across nodes" and "adjusting a few resource/parallelism arguments"; the training script itself is unchanged.
 
-- Place the training model and data on storage accessible by every node (e.g. NFS).
-- Set `MASTER_ADDR` to an address reachable by all nodes (not `127.0.0.1`), start Ray on each node manually, then submit training from the head (see [Quick Start — Multi-node training](../get_started/quick_start.md#multi-node-training-for-large-scale-moe-models)).
-- Adjust `--actor-num-nodes` for `train.py` and the parallelism (TP/EP/CP) in `PERF_ARGS` to match the total GPU count.
-- Remove the CPU Adam configuration, since multi-node uses a distributed optimizer, which significantly reduces the optimizer's memory footprint.
+1. **Shared storage**: put the model, data, and checkpoints on a location that every node can access at the same path (e.g. NFS).
+
+2. **Start Ray across nodes** (outside the training script, run manually on each node; see [Quick Start — Multi-node training](../get_started/quick_start.md#multi-node-training-for-large-scale-moe-models)):
+
+   ```bash
+   # Head node (node0); MASTER_ADDR must be a LAN IP, not 127.0.0.1
+   export MASTER_ADDR=<head_lan_ip>
+   ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats
+
+   # Every other node
+   ray start --address=${MASTER_ADDR}:6379 --num-gpus 8
+   ```
+
+   Wait until `ray status` reports 16 GPUs before submitting. Since the cluster is already up, remove the `ray start --head ...` line at the top of the script so it goes straight to `ray job submit`.
+
+3. **Adjust script arguments** (`scripts/run-qwen3-30B-A3B.sh`):
+   - Change `--actor-num-nodes` for `train.py` from `1` to `2` (keep `--actor-num-gpus-per-node` at 8). Under colocate, `--rollout-num-gpus` is auto-set to `actor_num_gpus_per_node × actor_num_nodes = 16`, so you don't set it manually.
+   - Scale up the parallelism in `PERF_ARGS` for the doubled GPU count (e.g. raise TP or add DP); for concrete large-scale ratios see the bigger-cluster examples such as [GLM-4.7](glm4.7-355B-A32B.md) and [DeepSeek-R1](deepseek-r1.md).
+   - `global-batch-size` must equal `rollout-batch-size × n-samples-per-prompt`.
+   - (Optional) Multi-node uses a distributed optimizer, which lowers optimizer memory pressure, so you may drop the CPU Adam options (`--optimizer-cpu-offload`, etc.) from `OPTIMIZER_ARGS` for speed.
+
+4. **Keep each vLLM engine within a single node**: prefer `--rollout-num-gpus-per-engine 8` (one engine per node) over `16` (a single engine spanning both nodes at TP=16). Cross-node TP is noticeably slower and more sensitive to per-token numerics; this value must divide the total rollout GPU count (16 here).
+
+⚠️ Common issues:
+- **Worker cannot join Ray / NCCL failures**: check `MASTER_ADDR`, container `/etc/hosts` (hostname must not map to `127.0.0.1`), and set `NCCL_SOCKET_IFNAME` / `GLOO_SOCKET_IFNAME` on multi-NIC hosts.
+- **`Not enough samples X for global_batch_size Y`**: keep `global-batch-size = rollout-batch-size × n-samples-per-prompt`.
+- **Fewer than 8 GPUs per node (colocate)**: set `--num-gpus-per-node` explicitly.
 
 In addition, when the total number of GPUs is not a multiple or divisor of the total number of experts, you can enable vLLM's EPLB (Expert Parallelism Load Balancer) and configure redundant experts via `--vllm-eplb-config`. For example, in a 24-GPU scenario:
 

--- a/docs/zh/examples/qwen3-30B-A3B.md
+++ b/docs/zh/examples/qwen3-30B-A3B.md
@@ -107,12 +107,35 @@ hf download Qwen/Qwen3-30B-A3B-FP8 --local-dir /root/Qwen3-30B-A3B-FP8
 
 ### 多机支持
 
-对于多机环境，需要进行如下几点修改：
+以下以 **2 节点 × 8 卡（共 16 GPU）colocate** 为例。多机与单机的差异只在于"跨节点启动 Ray"和"调整几个资源/并行度参数"，训练脚本主体不变。
 
-- 将训练模型、数据放在所有机器都可以访问到的路径上（如 NFS）；
-- 设置各台机器都可以访问到的 `MASTER_ADDR`（非 `127.0.0.1`），并在各节点手动启动 Ray 后再从 head 提交训练（见 [快速开始 — 多机训练](../get_started/quick_start.md#大规模-moe-模型的多机训练)）；
-- 按总卡数相应调整 `train.py` 的 `--actor-num-nodes` 以及 `PERF_ARGS` 中的并行度（TP/EP/CP）；
-- 去掉 CPU adam 相关配置，因为多机使用 distributed optimizer，optimizer 的显存占比会明显下降。
+1. **共享存储**：模型、数据、checkpoint 放在所有节点路径一致且都能访问的位置（如 NFS）。
+
+2. **跨节点启动 Ray**（在训练脚本之外，各节点手动执行；详见 [快速开始 — 多机训练](../get_started/quick_start.md#大规模-moe-模型的多机训练)）：
+
+   ```bash
+   # Head 节点（node0）；MASTER_ADDR 用局域网 IP，不能是 127.0.0.1
+   export MASTER_ADDR=<head 局域网 IP>
+   ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats
+
+   # 其余各节点
+   ray start --address=${MASTER_ADDR}:6379 --num-gpus 8
+   ```
+
+   等 `ray status` 显示 16 GPU 后再提交。由于集群已手动起好，运行前请去掉脚本开头的 `ray start --head ...` 一行，让脚本直接走 `ray job submit`。
+
+3. **调整脚本参数**（`scripts/run-qwen3-30B-A3B.sh`）：
+   - 把 `train.py` 的 `--actor-num-nodes` 由 `1` 改为 `2`（`--actor-num-gpus-per-node` 保持 8）。colocate 下 `--rollout-num-gpus` 会自动取 `actor_num_gpus_per_node × actor_num_nodes = 16`，无需手设。
+   - 卡数翻倍后相应增大 `PERF_ARGS` 的并行度（如提高 TP 或引入 DP）；大规模的具体配比可参考 [GLM-4.7](glm4.7-355B-A32B.md)、[DeepSeek-R1](deepseek-r1.md) 等更大集群的例子。
+   - `global-batch-size` 必须等于 `rollout-batch-size × n-samples-per-prompt`。
+   - （可选）多机使用 distributed optimizer，optimizer 显存压力下降，可去掉 `OPTIMIZER_ARGS` 中的 CPU Adam（`--optimizer-cpu-offload` 等）以提速。
+
+4. **让每个 vLLM engine 留在单节点内**：推荐 `--rollout-num-gpus-per-engine 8`（每节点 1 个 engine），而不是 `16`（单个 engine 跨 2 节点 TP=16）。跨节点 TP 会明显变慢、且对 per-token 数值更敏感；该值需整除总推理卡数（此例为 16）。
+
+⚠️  常见问题：
+- **Worker 加不进 Ray / NCCL 失败**：检查 `MASTER_ADDR`、容器 `/etc/hosts`（hostname 勿指向 `127.0.0.1`）、多网卡时设 `NCCL_SOCKET_IFNAME` / `GLOO_SOCKET_IFNAME`。
+- **`Not enough samples X for global_batch_size Y`**：保持 `global-batch-size = rollout-batch-size × n-samples-per-prompt`。
+- **每节点少于 8 卡（colocate）**：需显式设置 `--num-gpus-per-node`。
 
 此外，当总卡数不能被 expert 总数整除时，可以开启 vLLM 的 EPLB（Expert Parallelism Load Balancer），通过 `--vllm-eplb-config` 配置冗余 expert。例如 24 卡的场景：
 

--- a/docs/zh/examples/qwen3-30B-A3B.md
+++ b/docs/zh/examples/qwen3-30B-A3B.md
@@ -2,9 +2,24 @@
 
 ## 环境准备
 
-搭建环境、下载模型、数据与 ckpt 转换均与 Qwen3-4B 模型相同，可以参考 [示例：Qwen3-4B](qwen3-4B.md)，将文中 Qwen3-4B 的部分转换为 Qwen3-30B-A3B 即可。
+搭建环境与 ckpt 转换均与 Qwen3-4B 相同，可参考 [示例：Qwen3-4B](qwen3-4B.md)，将文中 Qwen3-4B 替换为 Qwen3-30B-A3B 即可。
 
-可以用如下方法把 huggingface checkpoint 转化为 torch_dist 格式：
+下载模型与数据：
+
+```bash
+# hf checkpoint
+hf download Qwen/Qwen3-30B-A3B --local-dir /root/Qwen3-30B-A3B
+
+# 训练数据
+hf download --repo-type dataset zhuzilin/dapo-math-17k \
+  --local-dir /root/dapo-math-17k
+
+# eval 数据
+hf download --repo-type dataset zhuzilin/aime-2024 \
+  --local-dir /root/aime-2024
+```
+
+再把 huggingface checkpoint 转化为 torch_dist 格式：
 
 ```bash
 cd vime/
@@ -68,95 +83,46 @@ bash scripts/run-qwen3-30B-A3B.sh
    )
    ```
 
-   如果要在 attention 上做 DP 同时在 expert 上做 EP，可以加 `--vllm-data-parallel-size N`
-   配合 `--vllm-enable-expert-parallel`。
+   类似地，如果要在 attention 上做 DP 同时在 expert 上做 EP，可以加
+   `--vllm-data-parallel-size N` 配合 `--vllm-enable-expert-parallel`。
+
+### bf16 训练 fp8 推理
+
+vime 也支持 bf16 训练、fp8 推理。对于 Qwen3-30B-A3B 模型，只需额外下载 fp8 权重：
+
+```bash
+hf download Qwen/Qwen3-30B-A3B-FP8 --local-dir /root/Qwen3-30B-A3B-FP8
+```
+
+并将脚本中的 `--hf-checkpoint` 替换为：
+
+```bash
+#--hf-checkpoint /root/Qwen3-30B-A3B
+--hf-checkpoint /root/Qwen3-30B-A3B-FP8
+```
+
+即可触发 fp8 推理。目前我们会将 bf16 权重直接 cast 为 fp8，后续会逐渐加入对精度影响更小的量化方案。
+
+⚠️  训练用的 megatron checkpoint 仍需是最初用 bf16 huggingface 权重转换得到的（`--ref-load` / `--load` 不变）。
 
 ### 多机支持
 
-以下以 **2台机器、每台8卡（共16GPU）** 为入门示例；脚本与参数可扩展到 **N节点**。多机与单机的主要差异：
+对于多机环境，需要进行如下几点修改：
 
-- 训练模型、数据放在所有节点均可访问的路径（如 NFS）；
-- `MASTER_ADDR` 设为 head 节点的 **局域网 IP**（非 `127.0.0.1`）；
-- 去掉 CPU Adam（多机使用 distributed optimizer，无需 `--optimizer-cpu-offload`）；
-- `global-batch-size` 必须等于 `rollout-batch-size × n-samples-per-prompt`。
+- 将训练模型、数据放在所有机器都可以访问到的路径上（如 NFS）；
+- 设置各台机器都可以访问到的 `MASTER_ADDR`（非 `127.0.0.1`），并在各节点手动启动 Ray 后再从 head 提交训练（见 [快速开始 — 多机训练](../get_started/quick_start.md#大规模-moe-模型的多机训练)）；
+- 按总卡数相应调整 `train.py` 的 `--actor-num-nodes` 以及 `PERF_ARGS` 中的并行度（TP/EP/CP）；
+- 去掉 CPU adam 相关配置，因为多机使用 distributed optimizer，optimizer 的显存占比会明显下降。
 
-#### 拓扑概览
-
-| 组件 | 双机默认配置 |
-|------|------|
-| 集群 | `ACTOR_NUM_NODES=2`，`ACTOR_NUM_GPUS_PER_NODE=8` |
-| Megatron训练 | TP=8, EP=8, CP=2（expert 分片跨节点） |
-| vLLM Rollout | 跨节点 TP=16（`rollout-num-gpus-per-engine = 节点数 × 每节点GPU`） |
-| 调度 | Ray 集群 + `--colocate` 共卡模式 |
-
-转换 checkpoint 时建议使用与训练一致的 Megatron 并行度（双机示例 TP=8, EP=8）。checkpoint 的 EP 需与 `--expert-model-parallel-size` 一致，否则 `load_checkpoint` 可能极慢或卡住。
-
-#### 启动 Ray 集群
-
-Ray 集群需在各节点上 **单独启动**，不在训练脚本内。先在所有 worker 节点加入集群，确认 `ray status` 显示预期 GPU 总数后，再在 head 提交训练。示例（双机）：
+此外，当总卡数不能被 expert 总数整除时，可以开启 vLLM 的 EPLB（Expert Parallelism Load Balancer），通过 `--vllm-eplb-config` 配置冗余 expert。例如 24 卡的场景：
 
 ```bash
-# === Head 节点 ===
-export MASTER_ADDR=<head_局域网_IP>
-ray start --head --node-ip-address="${MASTER_ADDR}" --num-gpus 8 --disable-usage-stats \
-   --dashboard-host=0.0.0.0 --dashboard-port=8265
-
-# === 各 Worker 节点 ===
-export MASTER_ADDR=<head_局域网_IP>
-ray start --address="${MASTER_ADDR}:6379" --node-ip-address=<本机_局域网_IP> --num-gpus 8
+VLLM_ARGS=(
+   --rollout-num-gpus-per-engine 24
+   --vllm-gpu-memory-utilization 0.7
+   --vllm-data-parallel-size 3
+   --vllm-enable-expert-parallel
+   --vllm-enable-eplb
+   --vllm-eplb-config '{"num_redundant_experts": 16}'
+)
 ```
-
-更多说明见 [快速开始 — 多机训练](../get_started/quick_start.md#multi-node-training-for-large-scale-moe-models)。
-
-#### 执行训练
-
-Ray 集群就绪后，在 **head 节点** 设置多机环境变量并运行 **与单机相同的脚本**（`ACTOR_NUM_NODES>1` 时脚本不会启动 Ray，并使用多机默认参数）：
-
-```bash
-export MASTER_ADDR=<head_局域网_IP>
-export ACTOR_NUM_NODES=2
-export ACTOR_NUM_GPUS_PER_NODE=8
-cd /root/vime
-bash scripts/run-qwen3-30B-A3B.sh
-```
-
-2 step 冒烟示例：
-
-```bash
-NUM_ROLLOUT=2 ENABLE_R3=0 bash scripts/run-qwen3-30B-A3B.sh
-```
-
-扩展到 N 节点（例如 4×8）时，在各 worker 加入 Ray 后，于 head 设置 `ACTOR_NUM_NODES=4` 并按总卡数调整 `MEGATRON_TP` / `MEGATRON_EP` / `MEGATRON_CP` / `ROLLOUT_NUM_GPUS_PER_ENGINE`。
-
-#### 多机关键参数
-
-| 变量 | 双机默认 | 说明 |
-|------|----------|------|
-| `ACTOR_NUM_NODES` | 2（单机默认为 1） | 训练节点总数（含 head）；>1 时脚本不启动 Ray |
-| `ACTOR_NUM_GPUS_PER_NODE` | 8 | 每节点 GPU 数 |
-| `MEGATRON_TP` / `MEGATRON_EP` / `MEGATRON_CP` | 8 / 8 / 2 | Megatron 并行 |
-| `ROLLOUT_NUM_GPUS_PER_ENGINE` | 总 GPU 数 | vLLM engine 占用卡数 |
-| `ENABLE_R3` | 1 | 设为 0 可关闭 R3 路径 |
-
-脚本默认 batch：`rollout-batch-size=4`，`n-samples-per-prompt=2`，`global-batch-size=8`；vLLM 使用 `--vllm-moe-backend triton`。
-
-#### 多机常见问题
-
-- **Worker 无法加入 Ray / NCCL 失败**：检查 `MASTER_ADDR`、容器 `/etc/hosts`（hostname 勿指向 `127.0.0.1`）、`NCCL_SOCKET_IFNAME` / `GLOO_SOCKET_IFNAME`。
-- **`Not enough samples X for global_batch_size Y`**：同步调整 `global-batch-size` 与 `rollout-batch-size × n-samples-per-prompt`。
-- **GPU 显存占满但无进程**：重启容器或 `ray stop --force` 清理残留 vLLM 上下文。
-
-#### EPLB
-
-当总卡数并不能被 expert 总数整除时，可以开启 vLLM 的 EPLB（Expert Parallelism Load Balancer），通过 `--vllm-eplb-config` 配置冗余 expert。例如对于 24 卡的场景：
-
-   ```bash
-   VLLM_ARGS=(
-      --rollout-num-gpus-per-engine 24
-      --vllm-gpu-memory-utilization 0.7
-      --vllm-data-parallel-size 3
-      --vllm-enable-expert-parallel
-      --vllm-enable-eplb
-      --vllm-eplb-config '{"num_redundant_experts": 16}'
-   )
-   ```

--- a/docs/zh/examples/qwen3-30B-A3B.md
+++ b/docs/zh/examples/qwen3-30B-A3B.md
@@ -107,7 +107,7 @@ hf download Qwen/Qwen3-30B-A3B-FP8 --local-dir /root/Qwen3-30B-A3B-FP8
    ray start --address=${MASTER_ADDR}:6379 --num-gpus 8
    ```
 
-   等 `ray status` 显示 16 GPU 后再提交。由于集群已手动起好，运行前请去掉脚本开头的 `ray start --head ...` 一行，让脚本直接走 `ray job submit`。
+   等 `ray status` 显示 16 GPU 后再提交。由于集群是你手动起好的，运行前需让脚本跳过它开头的进程管理逻辑——把开头的**清理块**（`ray stop --force`、`pkill -9 ray`、`pkill -9 python`、`pkill -9 redis`）**和** `ray start --head ...` 一行都删掉（或注释掉）。否则脚本会先把你刚起的 head 杀掉（并让 worker 变孤儿），导致 `ray job submit` 连 `http://127.0.0.1:8265` 失败。脚本其余部分保留——它仍会 source 模型参数并执行 `ray job submit`。
 
 3. **调整脚本参数**（`scripts/run-qwen3-30B-A3B.sh`）：
    - 把 `train.py` 的 `--actor-num-nodes` 由 `1` 改为 `2`（`--actor-num-gpus-per-node` 保持 8）。colocate 下 `--rollout-num-gpus` 会自动取 `actor_num_gpus_per_node × actor_num_nodes = 16`，无需手设。

--- a/docs/zh/examples/qwen3-30B-A3B.md
+++ b/docs/zh/examples/qwen3-30B-A3B.md
@@ -2,21 +2,9 @@
 
 ## 环境准备
 
-搭建环境、模型下载与 ckpt 转换均与 Qwen3-4B 相同，可参考 [示例：Qwen3-4B](qwen3-4B.md)，将文中 Qwen3-4B 替换为 Qwen3-30B-A3B 即可。
+搭建环境、下载模型、数据与 ckpt 转换均与 Qwen3-4B 模型相同，可以参考 [示例：Qwen3-4B](qwen3-4B.md)，将文中 Qwen3-4B 的部分转换为 Qwen3-30B-A3B 即可。
 
-训练与评测数据（与 Qwen3-4B 一致）：
-
-```bash
-# 训练数据
-hf download --repo-type dataset zhuzilin/dapo-math-17k \
-  --local-dir /root/dapo-math-17k
-
-# eval 数据
-hf download --repo-type dataset zhuzilin/aime-2024 \
-  --local-dir /root/aime-2024
-```
-
-把 huggingface checkpoint 转化为 torch_dist 格式：
+可以用如下方法把 huggingface checkpoint 转化为 torch_dist 格式：
 
 ```bash
 cd vime/

--- a/docs/zh/examples/qwen3-30B-A3B.md
+++ b/docs/zh/examples/qwen3-30B-A3B.md
@@ -2,14 +2,11 @@
 
 ## 环境准备
 
-搭建环境与 ckpt 转换均与 Qwen3-4B 相同，可参考 [示例：Qwen3-4B](qwen3-4B.md)，将文中 Qwen3-4B 替换为 Qwen3-30B-A3B 即可。
+搭建环境、模型下载与 ckpt 转换均与 Qwen3-4B 相同，可参考 [示例：Qwen3-4B](qwen3-4B.md)，将文中 Qwen3-4B 替换为 Qwen3-30B-A3B 即可。
 
-下载模型与数据：
+训练与评测数据（与 Qwen3-4B 一致）：
 
 ```bash
-# hf checkpoint
-hf download Qwen/Qwen3-30B-A3B --local-dir /root/Qwen3-30B-A3B
-
 # 训练数据
 hf download --repo-type dataset zhuzilin/dapo-math-17k \
   --local-dir /root/dapo-math-17k
@@ -19,7 +16,7 @@ hf download --repo-type dataset zhuzilin/aime-2024 \
   --local-dir /root/aime-2024
 ```
 
-再把 huggingface checkpoint 转化为 torch_dist 格式：
+把 huggingface checkpoint 转化为 torch_dist 格式：
 
 ```bash
 cd vime/


### PR DESCRIPTION
## What

The `Qwen3-30B-A3B` example doc drifted from the actual `scripts/run-qwen3-30B-A3B.sh`. It documented an env-var-driven multi-node script (`ACTOR_NUM_NODES` / `MEGATRON_TP` / `ENABLE_R3` auto-behavior, "script skips Ray on multi-node", default batch `4/2/8`, `--vllm-moe-backend triton`) that **no longer exists** — the script is now a slime-exact single-node port whose real defaults are `rollout-batch-size 32` / `n-samples-per-prompt 8` / `global-batch-size 256`.

## Changes (zh + en)

- **Restore "BF16 training + FP8 inference"** — present upstream in slime but dropped here; matches the commented `#--hf-checkpoint /root/Qwen3-30B-A3B-FP8` line already in the script.
- **Rewrite the multi-node section** — replace the orphaned env-var scaffolding with an actionable, code-grounded guide: Ray cross-node startup (per `quick_start`), the exact script edits (`--actor-num-nodes`; colocate auto-derives `--rollout-num-gpus`), parallelism scaling stated as constraints (concrete large-scale ratios deferred to the GLM/DeepSeek examples rather than a fabricated 2-node table), and the real pitfalls (keep each vLLM engine within a node to avoid cross-node TP=16 slowdown/numerics; `MASTER_ADDR` / `NCCL_SOCKET_IFNAME`; `global-batch = rollout-batch × n-samples`; `--num-gpus-per-node` for <8 GPUs/node). Also fixes the broken zh cross-link anchor.

Environment-preparation section is left byte-identical to upstream (model/data/ckpt already covered by the Qwen3-4B reference; the 30B-specific `torchrun` conversion command is kept).

## Correctness / scope notes

- **No script changes** — the doc is brought in line with the existing slime-exact `scripts/run-qwen3-30B-A3B.sh`.
- Multi-node guidance is grounded in `vime/utils/arguments.py` + `quick_start` + observed multi-node runs; it makes **no "tested" claim** and invents no specific 2-node TP/EP/CP table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)