### PR TITLE
[Doc] Fix H800→H100 typo in Qwen3-30B-A3B example

### DIFF
--- a/docs/en/examples/qwen3-30B-A3B.md
+++ b/docs/en/examples/qwen3-30B-A3B.md
@@ -31,7 +31,7 @@ bash scripts/run-qwen3-30B-A3B.sh
 
 Here, we will briefly introduce the MoE-related parts in the [run-qwen3-30B-A3B.sh](https://github.com/vllm-project/vime/blob/main/scripts/run-qwen3-30B-A3B.sh) script.
 
-1.  To support running Qwen3-30B-A3B in an 8xH800 environment, we need to enable Megatron's CPU Adam to save GPU memory. The corresponding configuration is:
+1.  To support running Qwen3-30B-A3B in an 8xH100 environment, we need to enable Megatron's CPU Adam to save GPU memory. The corresponding configuration is:
 
     ```bash
     OPTIMIZER_ARGS=(

--- a/docs/zh/examples/qwen3-30B-A3B.md
+++ b/docs/zh/examples/qwen3-30B-A3B.md
@@ -30,7 +30,7 @@ bash scripts/run-qwen3-30B-A3B.sh
 
 这里我们简单介绍一下脚本 [run-qwen3-30B-A3B.sh](https://github.com/vllm-project/vime/blob/main/scripts/run-qwen3-30B-A3B.sh) 中与 MoE 相关的部分。
 
-1. 为了支持在 8xH800 环境中运行 Qwen3-30B-A3B，我们需要开启 megatron 的 CPU Adam 以节省显存，对应配置为：
+1. 为了支持在 8xH100 环境中运行 Qwen3-30B-A3B，我们需要开启 megatron 的 CPU Adam 以节省显存，对应配置为：
 
    ```bash
    OPTIMIZER_ARGS=(


### PR DESCRIPTION
The Qwen3-30B-A3B example page is titled **8xH100**, but the first parameter bullet said "in an 8xH800 environment" — an inconsistency inherited from slime. Both are 80 GB cards, so the CPU-Adam rationale is unchanged; this just aligns the text with the page title (zh + en).

🤖 Generated with [Claude Code](https://claude.com/claude-code)