### PR TITLE
[Bugfix][Training] Avoid entropy grad graph when entropy_coef is zero

### DIFF
--- a/vime/backends/megatron_utils/loss.py
+++ b/vime/backends/megatron_utils/loss.py
@@ -202,7 +202,7 @@ def _allgather_cp_redistribute(
                     response_length,
                     dtype=ref_dtype,
                     device=ref_device,
-                    requires_grad=True,
+                    requires_grad=ref_value.requires_grad,
                 )
             else:
                 resp_start = s - logit_global_start
@@ -444,9 +444,9 @@ def _extract_per_sample(
             s = max(logit_global_start, chunk_start)
             e = min(logit_global_end, chunk_end)
             if e <= s:
-                log_probs_list.append(torch.zeros((0,), dtype=log_prob_full.dtype, device=log_prob_full.device))
+                log_probs_list.append(log_prob_full[:0])
                 if entropy_full is not None:
-                    entropy_list.append(torch.zeros((0,), dtype=entropy_full.dtype, device=entropy_full.device))
+                    entropy_list.append(entropy_full[:0])
             else:
                 log_probs_list.append(log_prob_full[s - chunk_start : e - chunk_start])
                 if entropy_full is not None:
@@ -484,9 +484,6 @@ def get_log_probs_and_entropy(
     Computes on the **full** logits ``[T, V]`` tensor at once (instead of
     per-sample slicing) so backward traverses ``[T, V]`` only once, then
     extracts per-sample response portions.
-
-    When ``entropy_coef == 0``, entropy is computed under ``torch.no_grad()``
-    to avoid retaining the computation graph and to skip cloning.
     """
     assert non_loss_data
     assert logits.dtype == torch.float32, f"{logits.dtype}"
@@ -503,6 +500,10 @@ def get_log_probs_and_entropy(
     device = logits.device
     tp_group = mpu.get_tensor_model_parallel_group()
     chunk_size = args.log_probs_chunk_size
+
+    # Keep entropy metrics, but skip saving entropy-backward activations when
+    # the entropy term cannot affect the loss.
+    with_entropy_grad = with_entropy and getattr(args, "entropy_coef", 0.0) != 0
 
     # --- build full shifted-token target tensor ---
     full_tokens = _build_shifted_tokens(T, device, unconcat_tokens, total_lengths, response_lengths, args.allgather_cp)
@@ -527,6 +528,7 @@ def get_log_probs_and_entropy(
         full_tokens,
         tp_group,
         with_entropy=with_entropy,
+        with_entropy_grad=with_entropy_grad,
         chunk_size=chunk_size,
         log_prob_keep_mask=top_p_keep_mask,
     )

--- a/vime/utils/ppo_utils.py
+++ b/vime/utils/ppo_utils.py
@@ -1,6 +1,7 @@
 # Adapt from https://github.com/OpenRLHF/OpenRLHF/blob/10c733694ed9fbb78a0a2ff6a05efc7401584d46/openrlhf/models/utils.py
 # and https://github.com/OpenRLHF/OpenRLHF/blob/10c733694ed9fbb78a0a2ff6a05efc7401584d46/openrlhf/trainer/ppo_utils/experience_maker.py
 
+import contextlib
 from argparse import Namespace
 
 import torch
@@ -690,9 +691,16 @@ def chunked_gae(
 
 
 def calculate_log_probs_and_entropy(
-    logits, tokens, tp_group, with_entropy: bool = False, chunk_size: int = -1, log_prob_keep_mask=None
+    logits,
+    tokens,
+    tp_group,
+    with_entropy: bool = False,
+    with_entropy_grad: bool = True,
+    chunk_size: int = -1,
+    log_prob_keep_mask=None,
 ):
     logits = logits.contiguous()
+    with_entropy_grad = with_entropy and with_entropy_grad
     entropy = None
     if logits.size(0) != 0:
         if chunk_size > 0:
@@ -704,11 +712,13 @@ def calculate_log_probs_and_entropy(
             )
 
             if with_entropy:
-                entropys = []
-                for logits_chunk in logits_chunks:
-                    entropy_input = logits_chunk.clone()
-                    entropys.append(compute_entropy_from_logits(entropy_input, tp_group))
-                entropy = torch.cat(entropys, dim=0)
+                entropy_context = torch.no_grad() if not with_entropy_grad else contextlib.nullcontext()
+                with entropy_context:
+                    entropys = []
+                    for logits_chunk in logits_chunks:
+                        entropy_input = logits_chunk.clone() if with_entropy_grad else logits_chunk
+                        entropys.append(compute_entropy_from_logits(entropy_input, tp_group))
+                    entropy = torch.cat(entropys, dim=0)
 
             log_probs = []
             for tokens_chunk, logits_chunk, mask_chunk in zip(tokens_chunks, logits_chunks, mask_chunks, strict=True):
@@ -717,8 +727,10 @@ def calculate_log_probs_and_entropy(
             log_prob = torch.cat(log_probs, dim=0)
         else:
             if with_entropy:
-                entropy_input = logits.clone()
-                entropy = compute_entropy_from_logits(entropy_input, tp_group)
+                entropy_context = torch.no_grad() if not with_entropy_grad else contextlib.nullcontext()
+                with entropy_context:
+                    entropy_input = logits.clone() if with_entropy_grad else logits
+                    entropy = compute_entropy_from_logits(entropy_input, tp_group)
 
             log_prob = compute_log_probs(logits.clone(), tokens, tp_group, keep_mask=log_prob_keep_mask)
     else:


### PR DESCRIPTION
## Summary

This PR reduces actor-update memory usage when entropy is logged but does not contribute to the loss.

Long-context actor updates can become memory-bound because entropy is evaluated over the full vocabulary. When `entropy_coef == 0`, VIME still computes entropy metrics, but the entropy tensor is only used for reporting and has no gradient contribution. The current implementation always builds the entropy autograd graph and clones the full logits tensor before entropy computation, which increases peak memory without changing the loss.

The change keeps the existing VIME log-probability and entropy implementation, but adds an explicit `with_entropy_grad` gate:

- `get_log_probs_and_entropy()` computes
  `with_entropy_grad = with_entropy and getattr(args, "entropy_coef", 0.0) != 0`.
- `calculate_log_probs_and_entropy()` computes entropy under `torch.no_grad()` when `with_entropy_grad` is false.
- In the no-grad entropy path, logits are reused directly instead of cloned.
- When entropy gradients are needed, the existing clone behavior is preserved.

The PR also includes two allgather-CP graph fixes from [slime #2123](https://github.com/THUDM/slime/pull/2123):

- zero-filled response tensors created during allgather-CP redistribution now use `requires_grad=ref_value.requires_grad` instead of always requiring gradients;
- empty allgather-CP per-sample slices now use `log_prob_full[:0]` and `entropy_full[:0]` instead of newly allocated detached zero tensors.

This keeps entropy values available for metrics while avoiding unnecessary entropy-backward activations when the entropy loss coefficient is zero.

## Upstream references

This PR follows recent slime changes, but only applies the pieces that fit VIME's separate log-probability and entropy paths.

- [**slime #2130**](https://github.com/THUDM/slime/pull/2130) (open, not merged): proposed computing entropy under `torch.no_grad()` and skipping the defensive `logits.clone()` when `entropy_coef == 0` on the separate `_VocabParallelEntropy` path. This is the closest conceptual match to VIME's current implementation.

- [**slime #2144**](https://github.com/THUDM/slime/pull/2144) / [**slime #2152**](https://github.com/THUDM/slime/pull/2152): slime later moved to a fused `_VocabParallelLogProbEntropy` function and added an internal `with_entropy_grad` gate. This PR borrows the same gate derivation, `with_entropy_grad = with_entropy and getattr(args, "entropy_coef", 0.0) != 0`, but does not port the fused function because VIME still uses separate `compute_log_probs` and `_VocabParallelEntropy` paths.

- [**slime #2123**](https://github.com/THUDM/slime/pull/2123): fixed allgather-CP graph participation issues by using `requires_grad=ref_value.requires_grad` for redistributed zero fills and `log_prob_full[:0]` / `entropy_full[:0]` for empty slices. This PR includes those small fixes to keep allgather-CP tensors' autograd state consistent when entropy may be computed without gradients.

Not included: the fused `_VocabParallelLogProbEntropy` refactor. Porting it would replace Megatron's `fused_vocab_parallel_cross_entropy` with a custom vocab-parallel softmax, which is a larger behavioral change than this bug fix needs.

## Correctness

The no-grad branch is safe because `_VocabParallelEntropy.forward()` does not modify the input logits in place. Its in-place `exp_()` and `div_()` operations are applied to tensors derived from `vocab_parallel_logits - logits_max`, not to the original logits tensor.

The clone is still kept when entropy gradients are required, preserving the original behavior for nonzero entropy coefficients.

Using `getattr(args, "entropy_coef", 0.0) != 0` keeps the gradient path for any nonzero coefficient, including negative values.

The allgather-CP changes keep empty or missing response pieces aligned with the reference tensor's autograd state. This avoids creating artificial gradient paths for metric-only tensors, while still preserving graph connectivity for tensors that need to participate in distributed backward.

## Validation

The profiling run followed the official GRPO training script structure in `scripts/run-qwen3.5-27B.sh`: Ray job submission to `train.py`, colocated actor/rollout, DAPO-style math data, GRPO with `entropy_coef=0`, dynamic batching, recompute, and Megatron context parallelism. The run was adapted to Qwen3.5-2B.

Run setup:

- Hardware: GPU, 4×A100-80GB
- CUDA: 12.9
- PyTorch: 2.11.0+cu129
- vLLM: 0.23.0
- Model: Qwen3.5-2B
- Training mode: GRPO, `entropy_coef=0`, `TP=2`, `CP=2`, rollout max response length 32k
- Main relevant changes from the official script: smaller Qwen3.5-2B checkpoint, 4 local GPUs, `rollout-num-gpus-per-engine=4`, `global-batch-size=128`, `max-tokens-per-gpu=16384`, and `log-probs-chunk-size=1024`

For matched ~32k-token actor microbatches, the internal loss-segment `torch.cuda.max_memory_allocated` peak was:

- patched: ~25.6 GiB
- unpatched: ~40.9 GiB

a reduction of ~15 GiB (~37%). This matches expectations: at ~32k tokens with vocab 248320 and `TP=2` (`V_local = 124160`, fp32), one full `[T, V_local]` tensor is ~15 GiB, and the patch removes the entropy autograd graph and defensive logits clone that contribute that order of magnitude to the loss-segment peak. 

## AI Assistance

This PR was prepared with AI assistance from OpenAI Codex. I reviewed the changed code, compared it against the relevant slime changes, and validated the patch locally.
