### PR TITLE
refactor(vllm): use native IPC engine for colocated weight sync

### DIFF
--- a/tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py
+++ b/tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py
@@ -1,4 +1,4 @@
-"""Unit tests for colocated vLLM IPC weight sync (UpdateWeightFromTensor)."""
+"""Unit tests for colocated vLLM IPC weight sync."""
 
 from __future__ import annotations
 
@@ -14,6 +14,13 @@ import torch
 
 MODULE_PATH = "vime.backends.megatron_utils.update_weight.update_weight_from_tensor"
 
+_PURGE_PREFIXES = ("megatron", "mindspeed", "vime.backends.megatron_utils")
+
+
+def _collect_subtree(prefix: str) -> list[str]:
+    """Collect all modules in sys.modules that start with the given prefix."""
+    return [k for k in sys.modules.keys() if k == prefix or k.startswith(prefix + ".")]
+
 
 def _install_stubs():
     mpu_stub = MagicMock()
@@ -24,9 +31,12 @@ def _install_stubs():
     mpu_stub.get_pipeline_model_parallel_rank.return_value = 0
 
     megatron_core = types.ModuleType("megatron.core")
+    megatron_core.__path__ = []
     megatron_core.mpu = mpu_stub
     megatron_mod = types.ModuleType("megatron")
+    megatron_mod.__path__ = []
     megatron_mod.core = megatron_core
+
     sys.modules.setdefault("megatron", megatron_mod)
     sys.modules.setdefault("megatron.core", megatron_core)
 
@@ -78,16 +88,9 @@ def _install_stubs():
     return hf_iter_stub, upw_dist_mod
 
 
-# Placeholder iterator stored on freshly-built instances; every test that drives a real
-# update overrides obj._hf_weight_iterator with its own MagicMock, so this only needs to be
-# a non-None object.
 _HF_ITER_STUB = MagicMock()
 _HF_ITER_STUB.get_hf_weight_chunks.return_value = iter([])
 
-# Modules stubbed by _install_stubs(), plus torch.distributed attributes it overwrites.
-# These are installed ONLY for this module's tests (inside the fixture) and restored on
-# teardown. Installing at import time leaked the stubs into sibling modules' COLLECTION (and
-# left MagicMocks on torch.distributed), one source of the cross-test order-pollution.
 _STUBBED_MODULES = (
     "megatron",
     "megatron.core",
@@ -104,24 +107,32 @@ _DIST_ATTRS = ("get_rank", "get_world_size", "get_process_group_ranks", "barrier
 def upw_vllm():
     import torch.distributed as _dist
 
-    saved_mods = {k: sys.modules.get(k) for k in (*_STUBBED_MODULES, MODULE_PATH)}
-    saved_dist = {a: getattr(_dist, a, None) for a in _DIST_ATTRS}
-    # Pop first so _install_stubs()'s setdefault() actually installs stubs (hermetic).
+    purge_keys = set()
+    for prefix in _PURGE_PREFIXES:
+        purge_keys.update(_collect_subtree(prefix))
     for k in _STUBBED_MODULES:
+        purge_keys.add(k)
+    purge_keys.add(MODULE_PATH)
+
+    saved_mods = {k: sys.modules.get(k) for k in purge_keys}
+    saved_dist = {a: getattr(_dist, a, None) for a in _DIST_ATTRS}
+    for k in purge_keys:
         sys.modules.pop(k, None)
     _install_stubs()
     sys.modules.pop(MODULE_PATH, None)
-    try:
-        yield importlib.import_module(MODULE_PATH)
-    finally:
-        for k, original in saved_mods.items():
-            if original is None:
-                sys.modules.pop(k, None)
-            else:
-                sys.modules[k] = original
-        for a, original in saved_dist.items():
-            if original is not None:
-                setattr(_dist, a, original)
+
+    with patch("vime.utils.common.is_npu", return_value=False):
+        try:
+            yield importlib.import_module(MODULE_PATH)
+        finally:
+            for k, original in saved_mods.items():
+                if original is None:
+                    sys.modules.pop(k, None)
+                else:
+                    sys.modules[k] = original
+            for a, original in saved_dist.items():
+                if original is not None:
+                    setattr(_dist, a, original)
 
 
 @dataclass
@@ -146,7 +157,7 @@ class RecordingVLLMEngine:
     init_weight_transfer_engine: RecordingRemoteMethod = field(default_factory=RecordingRemoteMethod)
     start_weight_update: RecordingRemoteMethod = field(default_factory=RecordingRemoteMethod)
     finish_weight_update: RecordingRemoteMethod = field(default_factory=RecordingRemoteMethod)
-    update_weights_from_tensor: RecordingRemoteMethod = field(default_factory=RecordingRemoteMethod)
+    update_weights: RecordingRemoteMethod = field(default_factory=RecordingRemoteMethod)
     pause_generation: RecordingRemoteMethod = field(default_factory=RecordingRemoteMethod)
     flush_cache: RecordingRemoteMethod = field(default_factory=RecordingRemoteMethod)
     continue_generation: RecordingRemoteMethod = field(default_factory=RecordingRemoteMethod)
@@ -176,9 +187,6 @@ def _make_instance(upw_vllm, args=None):
     obj.rollout_engines = []
     obj.distributed_rollout_engines = []
     obj.use_distribute = False
-    obj._ipc_engine = None
-    obj._ipc_gather_group = None
-    obj._ipc_gather_src = None
     obj._model_update_groups = None
     obj._is_distributed_src_rank = False
     obj._group_name = "vime"
@@ -186,25 +194,11 @@ def _make_instance(upw_vllm, args=None):
     return obj
 
 
-def _bind_single_slot(obj, engine, *, src=0):
-    """Bind ``obj`` to one colocated engine forming a slot whose leader rank is ``src``."""
-    obj.rollout_engines = [engine]
-    obj._ipc_engine = engine
-    obj._ipc_gather_group = "slot_group"
-    obj._ipc_gather_src = src
-
-
 def _chunks(n=1):
     return [[(f"p.{i}", torch.zeros(2, 2)) for i in range(2)] for _ in range(n)]
 
 
-def _run_update(obj, *, chunks=None, rank=0, slot_size=1) -> dict:
-    """Drive ``update_weights`` with controlled rank / slot size.
-
-    ``slot_size`` is what ``dist.get_world_size(self._ipc_gather_group)`` returns,
-    so slot_size==1 takes the direct IPC path and slot_size>1 the gather path.
-    Returns counters for barriers and ipc_collect calls.
-    """
+def _run_update(obj, *, chunks=None, rank=0) -> dict[str, int]:
     chunks = chunks or _chunks(1)
     obj._hf_weight_iterator = MagicMock()
     obj._hf_weight_iterator.get_hf_weight_chunks.return_value = iter(chunks)
@@ -218,228 +212,154 @@ def _run_update(obj, *, chunks=None, rank=0, slot_size=1) -> dict:
         counters["ipc_collect"] += 1
 
     with patch("torch.distributed.get_rank", return_value=rank), patch(
-        "torch.distributed.get_world_size", return_value=slot_size
-    ), patch("torch.distributed.barrier", side_effect=counting_barrier), patch(
-        "torch.cuda.ipc_collect", side_effect=counting_ipc_collect
-    ):
+        "torch.distributed.barrier", side_effect=counting_barrier
+    ), patch("torch.cuda.ipc_collect", side_effect=counting_ipc_collect):
         obj.update_weights()
     return counters
 
 
 @pytest.mark.unit
-def test_colocated_lifecycle_uses_pause_flush_and_weight_transfer_apis(upw_vllm):
+def test_colocated_lifecycle_uses_native_weight_transfer_session(upw_vllm):
     obj = _make_instance(upw_vllm)
     engine = RecordingVLLMEngine()
-    _bind_single_slot(obj, engine, src=0)
+    obj.rollout_engines = [engine]
 
-    dummy_info = {"names": ["w"], "dtype_names": ["bfloat16"], "shapes": [[2, 2]], "ipc_handles": [{"u": ("f", ())}]}
-    with patch(f"{MODULE_PATH}._build_ipc_update_info_from_named_tensors", return_value=(dummy_info, [])):
+    with patch(f"{MODULE_PATH}._send_to_colocated_engine") as send_to_colocated:
         counters = _run_update(obj, chunks=_chunks(2))
 
-    # Colocate quiesce: pause_generation + flush_cache only, no /sleep round-trip;
-    # continue_generation resumes. No release/resume_memory_occupation.
     assert len(engine.pause_generation.calls) == 1
     assert len(engine.flush_cache.calls) == 1
     assert len(engine.release_memory_occupation.calls) == 0
     assert len(engine.resume_memory_occupation.calls) == 0
-    # vLLM #39212: init runs in connect_rollout_engines, not update_weights.
-    assert len(engine.init_weight_transfer_engine.calls) == 0
     assert len(engine.start_weight_update.calls) == 1
-    assert engine.start_weight_update.calls[0].kwargs.get("is_checkpoint_format") is True
+    assert engine.start_weight_update.calls[0].kwargs == {"is_checkpoint_format": True}
     assert len(engine.finish_weight_update.calls) == 1
+    assert engine.finish_weight_update.calls[0].kwargs == {}
     assert len(engine.continue_generation.calls) == 1
-    # ipc_collect: one per HF chunk + one after the loop.
-    assert counters["ipc_collect"] == 2 + 1
-    # lifecycle barriers (no per-chunk barrier).
+
+    assert send_to_colocated.call_count == 2
+    assert counters["ipc_collect"] == 3
     assert counters["barrier"] >= 4
 
 
-@pytest.mark.unit
-def test_send_via_ipc_dispatches_update_weights_from_tensor_with_version(upw_vllm):
-    """slot_size=1: every HF chunk fires
-    ``engine.update_weights_from_tensor.remote(**fields, weight_version=...)`` —
-    same name, parameterized fields, version travels with data (no piggyback onto
-    ``finish_weight_update``)."""
-    obj = _make_instance(upw_vllm)
-    engine = RecordingVLLMEngine()
-    _bind_single_slot(obj, engine, src=0)
-
-    dummy_info = {"names": ["w"], "dtype_names": ["bfloat16"], "shapes": [[2, 2]], "ipc_handles": [{"u": ("f", ())}]}
-    with patch(
-        f"{MODULE_PATH}._build_ipc_update_info_from_named_tensors",
-        return_value=(dummy_info, []),
-    ):
-        _run_update(obj, chunks=_chunks(2))
-
-    # 2 HF chunks → 2 IPC RPCs
-    assert len(engine.update_weights_from_tensor.calls) == 2
-    kwargs = engine.update_weights_from_tensor.calls[0].kwargs
-    # fields are passed as explicit kwargs (** expanded from local_info)
-    assert kwargs["names"] == dummy_info["names"]
-    assert kwargs["dtype_names"] == dummy_info["dtype_names"]
-    assert kwargs["shapes"] == dummy_info["shapes"]
-    assert kwargs["ipc_handles"] is dummy_info["ipc_handles"]
-    # weight_version is the trainer's post-increment version (0 + 1 = 1) as a str
-    assert kwargs["weight_version"] == "1"
-    # finish_weight_update is a stateless bookend now — no kwargs
-    assert len(engine.finish_weight_update.calls) == 1
-    assert engine.finish_weight_update.calls[0].kwargs == {}
+@dataclass
+class _FakeUpdateInfo:
+    names: list[str]
+    dtype_names: list[str]
+    shapes: list[list[int]]
+    ipc_handles: list[dict[str, tuple]]
+    packed: bool = False
 
 
-@pytest.mark.unit
-def test_send_via_ipc_dispatches_update_weights_from_tensor_coordinator_multi_gpu(upw_vllm):
-    """slot_size > 1: the slot leader (rank == _ipc_gather_src) gathers payloads from
-    all slot ranks, merges them, and fires a single update_weights_from_tensor RPC per chunk."""
-    obj = _make_instance(upw_vllm)
-    engine = RecordingVLLMEngine()
-    _bind_single_slot(obj, engine, src=0)
+def _install_fake_npu_ipc_modules(monkeypatch, calls: list[dict]):
+    root_mod = types.ModuleType("vllm_ascend")
+    distributed_mod = types.ModuleType("vllm_ascend.distributed")
+    weight_transfer_mod = types.ModuleType("vllm_ascend.distributed.weight_transfer")
+    ipc_mod = types.ModuleType("vllm_ascend.distributed.weight_transfer.npu_ipc_engine")
 
-    dummy_info_0 = {
-        "names": ["w"],
-        "dtype_names": ["bfloat16"],
-        "shapes": [[2, 2]],
-        "ipc_handles": [{"uuid-gpu0": ("f", ())}],
-    }
-    dummy_info_1 = {
-        "names": ["w"],
-        "dtype_names": ["bfloat16"],
-        "shapes": [[2, 2]],
-        "ipc_handles": [{"uuid-gpu1": ("f", ())}],
-    }
+    @dataclass
+    class FakeNPUIPCTrainerSendWeightsArgs:
+        send_mode: object
+        packed: bool = False
 
-    def fake_all_gather_object(gathered_payloads, payload, group=None):
-        gathered_payloads[0] = "payload0"
-        gathered_payloads[1] = "payload1"
-
-    with patch(
-        f"{MODULE_PATH}._build_ipc_update_info_from_named_tensors",
-        return_value=(dummy_info_0, []),
-    ), patch(
-        f"{MODULE_PATH}._serialize_ipc_update_info", return_value="payload0"
-    ), patch(f"{MODULE_PATH}._deserialize_ipc_update_info", side_effect=[dummy_info_0, dummy_info_1] * 2), patch(
-        "torch.distributed.all_gather_object", side_effect=fake_all_gather_object
-    ):
-        _run_update(obj, chunks=_chunks(2), rank=0, slot_size=2)
-
-    assert len(engine.update_weights_from_tensor.calls) == 2
-    kwargs = engine.update_weights_from_tensor.calls[0].kwargs
-    assert kwargs["names"] == dummy_info_0["names"]
-    assert kwargs["dtype_names"] == dummy_info_0["dtype_names"]
-    assert kwargs["shapes"] == dummy_info_0["shapes"]
-    assert len(kwargs["ipc_handles"]) == 1
-    assert set(kwargs["ipc_handles"][0].keys()) == {"uuid-gpu0", "uuid-gpu1"}
-    assert kwargs["weight_version"] == "1"
-
-
-@pytest.mark.unit
-def test_merge_ipc_update_infos_combines_gpu_uuids(upw_vllm):
-    info0 = {
-        "names": ["w"],
-        "dtype_names": ["bfloat16"],
-        "shapes": [[2, 2]],
-        "ipc_handles": [{"uuid-gpu0": ("f0", ())}],
-    }
-    info1 = {
-        "names": ["w"],
-        "dtype_names": ["bfloat16"],
-        "shapes": [[2, 2]],
-        "ipc_handles": [{"uuid-gpu1": ("f1", ())}],
-    }
-    merged = upw_vllm._merge_ipc_update_infos([info0, info1])
-    assert set(merged["ipc_handles"][0].keys()) == {"uuid-gpu0", "uuid-gpu1"}
-
-
-@pytest.mark.unit
-def test_connect_binds_engine_and_slot_leader_per_gpu_slot(upw_vllm):
-    """Each rank binds to its slot's engine; the slot leader (== _ipc_gather_src,
-    the lowest trainer rank in the engine GPU range) is the start/finish coordinator."""
-    engines = [RecordingVLLMEngine() for _ in range(4)]
-    for rank, engine_idx, expected_src in [
-        (0, 0, 0),
-        (1, 0, 0),
-        (2, 1, 2),
-        (3, 1, 2),
-    ]:
-        obj = _make_instance(
-            upw_vllm,
-            args=_default_args(actor_num_gpus_per_node=8, rollout_num_gpus_per_engine=2),
-        )
-        with patch("torch.distributed.get_rank", return_value=rank), patch(
-            "megatron.core.mpu.get_tensor_model_parallel_rank", return_value=rank % 2
-        ), patch("torch.distributed.new_group", return_value="slot_group"):
-            obj.connect_rollout_engines(
-                engines,
-                rollout_engine_lock=MagicMock(),
-                engine_gpu_counts=[2, 2, 2, 2],
-                engine_gpu_offsets=[0, 2, 4, 6],
+    class FakeNPUIPCWeightTransferEngine:
+        @staticmethod
+        def trainer_send_weights(iterator, trainer_args):
+            calls.append({"items": list(iterator), "trainer_args": trainer_args})
+            trainer_args.send_mode(
+                _FakeUpdateInfo(
+                    names=["layer.weight"],
+                    dtype_names=["float32"],
+                    shapes=[[2, 2]],
+                    ipc_handles=[{"uuid": ("handle", ())}],
+                )
             )
-        assert obj._ipc_engine is engines[engine_idx]
-        assert obj._ipc_gather_src == expected_src
-        is_coordinator = rank == obj._ipc_gather_src
-        assert is_coordinator is (rank in (0, 2))
-        assert obj.use_distribute is False
-        assert obj.distributed_rollout_engines == []
-        # vLLM #39212: init_weight_transfer_engine fires once during connect (rank 0 only).
-        if rank == 0:
-            assert len(engines[0].init_weight_transfer_engine.calls) == 1
-            assert engines[0].init_weight_transfer_engine.calls[0].args[0] == {"init_info": {}}
+
+    ipc_mod.NPUIPCTrainerSendWeightsArgs = FakeNPUIPCTrainerSendWeightsArgs
+    ipc_mod.NPUIPCWeightTransferEngine = FakeNPUIPCWeightTransferEngine
+    weight_transfer_mod.npu_ipc_engine = ipc_mod
+    distributed_mod.weight_transfer = weight_transfer_mod
+    root_mod.distributed = distributed_mod
+    monkeypatch.setitem(sys.modules, "vllm_ascend", root_mod)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.distributed", distributed_mod)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.distributed.weight_transfer", weight_transfer_mod)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.distributed.weight_transfer.npu_ipc_engine", ipc_mod)
 
 
 @pytest.mark.unit
-def test_non_leader_skips_start_finish_and_merged_rpc(upw_vllm):
-    obj = _make_instance(upw_vllm)
+def test_send_to_colocated_engine_uses_native_npu_ipc_engine(upw_vllm, monkeypatch):
     engine = RecordingVLLMEngine()
-    # slot leader is rank 0; we drive update_weights as rank 1 (non-leader).
-    _bind_single_slot(obj, engine, src=0)
+    calls: list[dict] = []
+    _install_fake_npu_ipc_modules(monkeypatch, calls)
 
-    dummy_info = {"names": [], "dtype_names": [], "shapes": [], "ipc_handles": []}
-    with patch(
-        f"{MODULE_PATH}._build_ipc_update_info_from_named_tensors",
-        return_value=(dummy_info, []),
-    ), patch(
-        f"{MODULE_PATH}._serialize_ipc_update_info", return_value="payload"
-    ), patch("torch.distributed.all_gather_object") as all_gather_obj:
-        _run_update(obj, chunks=_chunks(1), rank=1, slot_size=2)
+    tensors = [("layer.weight", torch.zeros(2, 2))]
+    with patch(f"{MODULE_PATH}.is_npu", return_value=True):
+        upw_vllm._send_to_colocated_engine(tensors, rollout_engines=[engine], weight_version=42)
 
-    all_gather_obj.assert_called_once()
-    # non-leader: no start/finish, and no merged update_weights_from_tensor RPC
-    assert len(engine.start_weight_update.calls) == 0
-    assert len(engine.finish_weight_update.calls) == 0
-    assert len(engine.update_weights_from_tensor.calls) == 0
+    assert calls[0]["items"] == tensors
+    assert calls[0]["trainer_args"].packed is False
+    assert len(engine.update_weights.calls) == 1
+    call = engine.update_weights.calls[0]
+    assert call.args[0]["update_info"]["names"] == ["layer.weight"]
+    assert call.args[0]["update_info"]["packed"] is False
+    assert call.kwargs == {"weight_version": "42"}
 
 
 @pytest.mark.unit
-def test_ipc_init_runs_once_in_connect(upw_vllm):
-    """init_weight_transfer_engine fires once in connect_rollout_engines (rank 0),
-    not in update_weights. A second connect call does not re-init."""
+def test_send_hf_params_returns_only_distributed_refs(upw_vllm):
+    obj = _make_instance(upw_vllm)
+    obj.rollout_engines = [RecordingVLLMEngine()]
+    obj.distributed_rollout_engines = [RecordingVLLMEngine()]
+    obj.use_distribute = True
+    obj._is_distributed_src_rank = True
+    obj._model_update_groups = "groups"
+    tensors = _chunks(1)[0]
+
+    with patch(f"{MODULE_PATH}._send_to_colocated_engine") as send_to_colocated, patch(
+        f"{MODULE_PATH}.update_weights_from_distributed", return_value=["distributed-ref"]
+    ) as send_distributed:
+        refs = obj._send_hf_params(tensors)
+
+    send_to_colocated.assert_called_once_with(
+        tensors,
+        rollout_engines=obj.rollout_engines,
+        weight_version=obj.weight_version,
+    )
+    send_distributed.assert_called_once()
+    assert refs == ["distributed-ref"]
+
+
+@pytest.mark.unit
+def test_connect_keeps_colocated_engines_and_initializes_once(upw_vllm):
     engines = [RecordingVLLMEngine() for _ in range(2)]
     obj = _make_instance(
         upw_vllm,
         args=_default_args(actor_num_gpus_per_node=4, rollout_num_gpus_per_engine=2),
     )
-    with patch("torch.distributed.get_rank", return_value=0), patch(
-        "megatron.core.mpu.get_tensor_model_parallel_rank", return_value=0
-    ), patch("torch.distributed.new_group", return_value="slot_group"):
+
+    with patch("torch.distributed.get_rank", return_value=0):
         obj.connect_rollout_engines(
             engines,
             rollout_engine_lock=MagicMock(),
             engine_gpu_counts=[2, 2],
             engine_gpu_offsets=[0, 2],
         )
+
+    assert obj.rollout_engines == engines
+    assert obj.distributed_rollout_engines == []
+    assert obj.use_distribute is False
     assert obj._ipc_initialized is True
     assert len(engines[0].init_weight_transfer_engine.calls) == 1
     assert len(engines[1].init_weight_transfer_engine.calls) == 1
 
-    # Second connect with _ipc_initialized=True does not re-init.
     engines2 = [RecordingVLLMEngine() for _ in range(2)]
-    with patch("torch.distributed.get_rank", return_value=0), patch(
-        "megatron.core.mpu.get_tensor_model_parallel_rank", return_value=0
-    ), patch("torch.distributed.new_group", return_value="slot_group"):
+    with patch("torch.distributed.get_rank", return_value=0):
         obj.connect_rollout_engines(
             engines2,
             rollout_engine_lock=MagicMock(),
             engine_gpu_counts=[2, 2],
             engine_gpu_offsets=[0, 2],
         )
+
     assert len(engines2[0].init_weight_transfer_engine.calls) == 0
     assert len(engines2[1].init_weight_transfer_engine.calls) == 0

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import base64
 import dataclasses
 import json
+import pickle
 
 import pytest
 import requests
@@ -241,7 +243,7 @@ def test_finish_weight_update_posts_empty_body(vllm_engine, monkeypatch):
 
 
 @pytest.mark.unit
-def test_update_weights_from_tensor_posts_ipc_payload_and_records_version(vllm_engine, monkeypatch):
+def test_update_weights_posts_native_ipc_payload_and_records_version(vllm_engine, monkeypatch):
     posted: list[tuple[str, dict]] = []
 
     def fake_post(endpoint: str, payload: dict):
@@ -251,28 +253,35 @@ def test_update_weights_from_tensor_posts_ipc_payload_and_records_version(vllm_e
     monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
     assert vllm_engine._weight_version is None
 
-    vllm_engine.update_weights_from_tensor(
-        names=["layer.0.weight"],
-        dtype_names=["float32"],
-        shapes=[[2, 2]],
-        ipc_handles=[{"uuid-gpu0": ("rebuild_fn", (1, 2, 3))}],
+    ipc_handles = [{"uuid-gpu0": ("rebuild_fn", (1, 2, 3))}]
+    vllm_engine.update_weights(
+        {
+            "update_info": {
+                "names": ["layer.0.weight"],
+                "dtype_names": ["float32"],
+                "shapes": [[2, 2]],
+                "ipc_handles": ipc_handles,
+                "packed": False,
+            }
+        },
         weight_version="42",
     )
 
-    assert posted[0][0] == "collective_rpc"
-    assert posted[0][1]["method"] == "update_weights_chunk"
-    sent = posted[0][1]["kwargs"]["update_info"]
-    # ipc_handles got cloudpickle'd into ipc_handles_pickled
+    assert posted[0][0] == "update_weights"
+    sent = posted[0][1]["update_info"]
+    # ipc_handles are pickled for native vLLM/vLLM-Ascend parse_update_info.
     assert "ipc_handles" not in sent
     assert isinstance(sent["ipc_handles_pickled"], str)
+    assert pickle.loads(base64.b64decode(sent["ipc_handles_pickled"])) == ipc_handles
     assert sent["names"] == ["layer.0.weight"]
     assert sent["shapes"] == [[2, 2]]
+    assert sent["packed"] is False
     # version recorded after POST success
     assert vllm_engine._weight_version == "42"
 
 
 @pytest.mark.unit
-def test_update_weights_from_tensor_does_not_advance_version_on_failure(vllm_engine, monkeypatch):
+def test_update_weights_does_not_advance_version_on_failure(vllm_engine, monkeypatch):
     """POST failure must not advance _weight_version (else a retry would skip the resync)."""
 
     def fake_post_fail(endpoint: str, payload: dict) -> dict:
@@ -282,8 +291,9 @@ def test_update_weights_from_tensor_does_not_advance_version_on_failure(vllm_eng
 
     vllm_engine._weight_version = "old"
     with pytest.raises(RuntimeError, match="simulated POST failure"):
-        vllm_engine.update_weights_from_tensor(
-            names=[], dtype_names=[], shapes=[], ipc_handles=[], weight_version="new"
+        vllm_engine.update_weights(
+            {"update_info": {"names": [], "dtype_names": [], "shapes": [], "ipc_handles": []}},
+            weight_version="new",
         )
     assert vllm_engine._weight_version == "old"
 

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -1,27 +1,18 @@
 """
-Colocated vLLM weight sync (trainer + worker)
-=============================================
-
-Trainer: ``UpdateWeightFromTensor`` — Megatron → HF chunks → CUDA IPC (Ray).
-
-Worker: ``vLLMColocateWorkerExtension`` — passed to ``vllm serve`` via
-``--worker-extension-cls``; patches IPC receive before handle deserialisation.
-
-https://docs.vllm.ai/en/stable/examples/rl/rlhf_ipc/
+Colocated vLLM weight sync using native IPC transfer engines.
 """
 
 from __future__ import annotations
 
 import os
 from argparse import Namespace
-from collections.abc import Callable, Iterable, Mapping, Sequence
-from typing import Any
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict
 
 import ray
 import torch
 import torch.distributed as dist
 from megatron.core import mpu
-from ray import ObjectRef
 from ray.actor import ActorHandle
 
 from vime.utils.common import is_npu
@@ -34,169 +25,6 @@ from .update_weight_from_distributed import (
     post_process_weights,
     update_weights_from_distributed,
 )
-
-
-def _patch_npu_colocate_worker() -> None:
-    """Skip layerwise_reload in NPUWorker weight-update hooks (colocate OOM fix)."""
-    try:
-        from vllm_ascend.worker.worker import NPUWorker
-    except ImportError:
-        return
-
-    if getattr(NPUWorker, "_vime_colocate_patched", False):
-        return
-
-    def _patched_start_weight_update(self, is_checkpoint_format: bool = True) -> None:
-        self._weight_update_active = True
-        self._is_checkpoint_format = is_checkpoint_format
-
-    def _patched_finish_weight_update(self) -> None:
-        self._weight_update_active = False
-
-    NPUWorker.start_weight_update = _patched_start_weight_update  # type: ignore[method-assign]
-    NPUWorker.finish_weight_update = _patched_finish_weight_update  # type: ignore[method-assign]
-    NPUWorker._vime_colocate_patched = True  # type: ignore[attr-defined]
-
-
-def _current_gpu_uuid() -> str:
-    if is_npu():
-        device_index = torch.npu.current_device()
-        props = torch.npu.get_device_properties(device_index)
-        return str(getattr(props, "uuid", f"npu:{device_index}"))
-    device_index = torch.cuda.current_device()
-    props = torch.cuda.get_device_properties(device_index)
-    return str(props.uuid)
-
-
-def _load_colocate_weights_direct(
-    model: torch.nn.Module,
-    weights: list[tuple[str, torch.Tensor]],
-    *,
-    tp_rank: int,
-) -> None:
-    """Load HF-named weights into vLLM packed params (qkv_proj, gate_up_proj, etc.)."""
-    from vllm.model_executor.utils import get_packed_modules_mapping
-
-    packed_map = get_packed_modules_mapping(model)
-    sub_to_packed = {}
-    for packed_name, sub_names in packed_map.items():
-        for idx, sub_name in enumerate(sub_names):
-            sub_to_packed[sub_name] = (packed_name, idx)
-    qkv_shard_ids = {"q_proj": "q", "k_proj": "k", "v_proj": "v"}
-
-    def _remap_and_get_shard_id(hf_name: str) -> tuple[str, object | None]:
-        parts = hf_name.split(".")
-        shard_id = None
-        for i in range(len(parts)):
-            if parts[i] in sub_to_packed:
-                packed_name, idx = sub_to_packed[parts[i]]
-                shard_id = qkv_shard_ids.get(parts[i], idx)
-                parts[i] = packed_name
-                break
-        return ".".join(parts), shard_id
-
-    for name, weight in weights:
-        remapped, shard_id = _remap_and_get_shard_id(name)
-        try:
-            param = model.get_parameter(remapped)
-        except AttributeError:
-            continue
-        weight_loader = getattr(param, "weight_loader", None)
-        if weight_loader is not None and shard_id is not None:
-            weight_loader(param, weight, loaded_shard_id=shard_id)
-        elif weight_loader is not None:
-            weight_loader(param, weight)
-        elif param.shape == weight.shape:
-            param.data.copy_(weight)
-        else:
-            for dim in range(len(param.shape)):
-                if param.shape[dim] != weight.shape[dim]:
-                    shard_size = param.shape[dim]
-                    param.data.copy_(weight.narrow(dim, tp_rank * shard_size, shard_size))
-                    break
-
-
-def _build_ipc_update_info_from_named_tensors(
-    named_tensors: Iterable[tuple[str, torch.Tensor]],
-) -> tuple[dict[str, list], list[torch.Tensor]]:
-    """Build vLLM IPC ``update_info`` payload from tensors on this rank's GPU.
-
-    Each handle is keyed by the physical GPU UUID of the producing rank rather
-    than by a local device index. The coordinator gathers all ranks' dicts and
-    merges them; the receiver looks up its own UUID to pick the matching handle,
-    then vLLM unconditionally overwrites ``args[6]`` (device_index) with its own
-    local index before ``rebuild_cuda_tensor``. This UUID-keyed routing makes
-    the path correct under any ``CUDA_VISIBLE_DEVICES`` ordering without
-    relying on a torch reductions monkey-patch.
-
-    Return the contiguous tensor refs alongside the payload. ``reduce_tensor``
-    only exports CUDA IPC metadata, so the producer storage must stay alive
-    until the receiver opens the handle.
-    """
-    from torch.multiprocessing.reductions import reduce_tensor
-
-    names: list[str] = []
-    dtype_names: list[str] = []
-    shapes: list[list[int]] = []
-    ipc_handles: list[dict[str, tuple]] = []
-    weight_refs: list[torch.Tensor] = []
-    gpu_uuid = _current_gpu_uuid()
-
-    for name, tensor in named_tensors:
-        names.append(name)
-        dtype_names.append(str(tensor.dtype).split(".")[-1])
-        shapes.append(list(tensor.shape))
-        weight = tensor.detach().contiguous()
-        weight_refs.append(weight)
-        rebuild_func, ipc_args = reduce_tensor(weight)
-        ipc_handles.append({gpu_uuid: (rebuild_func, ipc_args)})
-
-    return (
-        {
-            "names": names,
-            "dtype_names": dtype_names,
-            "shapes": shapes,
-            "ipc_handles": ipc_handles,
-        },
-        weight_refs,
-    )
-
-
-def _serialize_ipc_update_info(info: dict[str, list]) -> str:
-    """Pickle IPC handles for cross-rank gather (Gloo ``all_gather_object`` cannot carry them)."""
-    import base64
-
-    import cloudpickle
-
-    return base64.b64encode(cloudpickle.dumps(info)).decode("ascii")
-
-
-def _deserialize_ipc_update_info(payload: str) -> dict[str, list]:
-    import base64
-
-    import cloudpickle
-
-    return cloudpickle.loads(base64.b64decode(payload.encode("ascii")))
-
-
-def _merge_ipc_update_infos(infos: Sequence[dict[str, list]]) -> dict[str, list]:
-    """Merge per-rank IPC payloads so each weight has handles for every GPU UUID in the slot."""
-    if not infos:
-        raise ValueError("no IPC update_info payloads to merge")
-    base = infos[0]
-    merged_handles: list[dict[str, tuple]] = []
-    num_params = len(base["names"])
-    for i in range(num_params):
-        combined: dict[str, tuple] = {}
-        for info in infos:
-            combined.update(info["ipc_handles"][i])
-        merged_handles.append(combined)
-    return {
-        "names": base["names"],
-        "dtype_names": base["dtype_names"],
-        "shapes": base["shapes"],
-        "ipc_handles": merged_handles,
-    }
 
 
 class UpdateWeightFromTensor:
@@ -232,13 +60,10 @@ class UpdateWeightFromTensor:
             args=args, model=model, model_name=model_name, quantization_config=quantization_config
         )
 
-        self._ipc_gather_group = None
-        self._ipc_gather_src = None
-        self._ipc_engine = None
         self._model_update_groups = None
         # vLLM #39212 IPC transfer-engine init runs once per set of colocated engines.
         self._ipc_initialized = False
-        # vLLM IPC handle payloads may use cloudpickle on the Ray/HTTP bridge.
+        # vLLM IPC handle payloads are pickled on the Ray/HTTP bridge.
         os.environ.setdefault("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
 
     # ------------------------------------------------------------------
@@ -300,26 +125,6 @@ class UpdateWeightFromTensor:
                     engine_gpu_counts=distributed_gpu_counts,
                 )
 
-        colocate_gpu_offsets = engine_gpu_offsets[:colocate_engine_nums]
-        colocate_gpu_counts = engine_gpu_counts[:colocate_engine_nums]
-
-        # Create IPC Gloo gather groups (only on first call; partitioning is
-        # fixed across reconnects).
-        if self._ipc_gather_group is None:
-            for i in range(colocate_engine_nums):
-                group_ranks = list(range(colocate_gpu_offsets[i], colocate_gpu_offsets[i] + colocate_gpu_counts[i]))
-                new_group = dist.new_group(ranks=group_ranks, backend="gloo")
-                if dist.get_rank() in group_ranks:
-                    self._ipc_gather_group = new_group
-                    self._ipc_gather_src = colocate_gpu_offsets[i]
-
-        # Map training ranks to colocated engine actors.
-        for i, engine in enumerate(self.rollout_engines):
-            start = colocate_gpu_offsets[i]
-            end = start + colocate_gpu_counts[i]
-            if start <= dist.get_rank() < end:
-                self._ipc_engine = engine
-
         # vLLM #39212: one-time IPC transfer-engine init on each colocated engine.
         if dist.get_rank() == 0 and self.rollout_engines and not self._ipc_initialized:
             ray.get([engine.init_weight_transfer_engine.remote({"init_info": {}}) for engine in self.rollout_engines])
@@ -356,22 +161,18 @@ class UpdateWeightFromTensor:
                 )
         dist.barrier(group=get_gloo_group())
 
-        # vLLM #39212: enter weight-update mode on each slot leader.
-        # NPU colocate: direct param loading avoids layerwise_reload + checkpoint remap issues.
-        is_checkpoint_format = not is_npu()
-        if self._ipc_engine is not None and rank == self._ipc_gather_src:
-            ray.get(self._ipc_engine.start_weight_update.remote(is_checkpoint_format=is_checkpoint_format))
+        # Enter the native vLLM weight-update state machine on every colocated engine.
+        if rank == 0:
+            ray.get([engine.start_weight_update.remote(is_checkpoint_format=True) for engine in self.rollout_engines])
         dist.barrier(group=get_gloo_group())
 
         megatron_local_weights = self.weights_getter()
 
         for hf_named_tensors in self._hf_weight_iterator.get_hf_weight_chunks(megatron_local_weights):
-            refs, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+            refs = self._send_hf_params(hf_named_tensors)
             ray.get(refs)
-            # Free GPU tensors so the caching allocator can reuse the blocks,
-            # then release CUDA IPC cache entries whose consumers (vLLM engines)
-            # have already closed their IPC handles.
-            del long_lived_tensors, hf_named_tensors
+            # Free chunk tensors so the caching allocator can reuse the blocks.
+            del hf_named_tensors
             if is_npu():
                 torch.npu.synchronize()
             else:
@@ -385,9 +186,9 @@ class UpdateWeightFromTensor:
         else:
             torch.cuda.ipc_collect()
 
-        # vLLM #39212: exit weight-update mode.
-        if self._ipc_engine is not None and rank == self._ipc_gather_src:
-            ray.get(self._ipc_engine.finish_weight_update.remote())
+        # Exit the native vLLM weight-update state machine.
+        if rank == 0:
+            ray.get([engine.finish_weight_update.remote() for engine in self.rollout_engines])
         dist.barrier(group=get_gloo_group())
 
         # int4/fp4 post_process
@@ -401,17 +202,14 @@ class UpdateWeightFromTensor:
             ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
         dist.barrier(group=get_gloo_group())
 
-    def _send_hf_params(self, hf_named_tensors) -> tuple[list[ObjectRef], Any]:
-        all_refs = []
+    def _send_hf_params(self, hf_named_tensors) -> list[object]:
+        all_refs: list[object] = []
 
-        refs_colocated, long_lived_tensors = _send_to_colocated_engine(
+        _send_to_colocated_engine(
             hf_named_tensors,
-            ipc_engine=self._ipc_engine,
-            ipc_gather_src=self._ipc_gather_src,
-            ipc_gather_group=self._ipc_gather_group,
+            rollout_engines=self.rollout_engines,
             weight_version=self.weight_version,
         )
-        all_refs.extend(refs_colocated)
 
         if self.use_distribute and self._is_distributed_src_rank:
             refs_distributed = update_weights_from_distributed(
@@ -425,45 +223,37 @@ class UpdateWeightFromTensor:
             if refs_distributed:
                 all_refs.extend(refs_distributed)
 
-        return all_refs, long_lived_tensors
+        return all_refs
 
 
 def _send_to_colocated_engine(
     hf_named_tensors: list[tuple[str, torch.Tensor]],
     *,
-    ipc_engine,
-    ipc_gather_src,
-    ipc_gather_group,
-    weight_version,
-) -> tuple[list[ObjectRef], Any]:
-    # Placeholder ranks (GPU slots reserved but no engine) have no gather group.
-    # all_gather_object is only collective among group members, so we skip entirely.
-    if ipc_gather_group is None:
-        return [], None
+    rollout_engines: Sequence[ActorHandle],
+    weight_version: int,
+) -> None:
+    if not rollout_engines:
+        return
 
-    slot_size = dist.get_world_size(ipc_gather_group)
-    if slot_size <= 1:
-        local_info, weight_refs = _build_ipc_update_info_from_named_tensors(hf_named_tensors)
-        ref = ipc_engine.update_weights_from_tensor.remote(**local_info, weight_version=str(weight_version))
-        return [ref], weight_refs
+    def send_to_vllm(update_info) -> None:
+        request = {"update_info": asdict(update_info)}
+        ray.get(
+            [engine.update_weights.remote(request, weight_version=str(weight_version)) for engine in rollout_engines]
+        )
 
-    local_info, weight_refs = _build_ipc_update_info_from_named_tensors(hf_named_tensors)
-    payload = _serialize_ipc_update_info(local_info)
+    if is_npu():
+        from vllm_ascend.distributed.weight_transfer.npu_ipc_engine import (
+            NPUIPCTrainerSendWeightsArgs,
+            NPUIPCWeightTransferEngine,
+        )
 
-    # all_gather_object is monkey-patched for ReloadableProcessGroup; gather_object
-    # is not (it fails after a Megatron reload).
-    gathered_payloads = [None] * slot_size
-    dist.all_gather_object(gathered_payloads, payload, group=ipc_gather_group)
+        trainer_args = NPUIPCTrainerSendWeightsArgs(send_mode=send_to_vllm, packed=False)
+        NPUIPCWeightTransferEngine.trainer_send_weights(iter(hf_named_tensors), trainer_args)
+    else:
+        from vllm.distributed.weight_transfer.ipc_engine import IPCTrainerSendWeightsArgs, IPCWeightTransferEngine
 
-    refs = []
-    if dist.get_rank() == ipc_gather_src:
-        if any(p is None for p in gathered_payloads):
-            raise RuntimeError(f"Missing IPC payloads in slot {ipc_gather_src}; got {gathered_payloads!r}")
-        slot_infos = [_deserialize_ipc_update_info(p) for p in gathered_payloads]
-        merged = _merge_ipc_update_infos(slot_infos)
-        refs.append(ipc_engine.update_weights_from_tensor.remote(**merged, weight_version=str(weight_version)))
-
-    return refs, weight_refs
+        trainer_args = IPCTrainerSendWeightsArgs(send_mode=send_to_vllm, packed=False)
+        IPCWeightTransferEngine.trainer_send_weights(iter(hf_named_tensors), trainer_args)
 
 
 # ---------------------------------------------------------------------------
@@ -472,9 +262,9 @@ def _send_to_colocated_engine(
 
 
 class _VLLMHijack:
-    """Monkey-patch vLLM IPC receive so CUDA IPC handles deserialize on the correct GPU.
+    """vLLM worker extension helpers.
 
-    On NPU only:
+    On NPU:
     - Patches NPUWorker.load_model and NPUWorker.start_weight_update to fix
       MoE weight_loader missing on EP (a vLLM bug where w13_weight/w2_weight
       params lack weight_loader attr when EP is enabled).
@@ -482,21 +272,6 @@ class _VLLMHijack:
       (mindspeed/megatron backends introduce flash_attn as a dummy module,
       but vllm_ascend does not use it).
     """
-
-    @staticmethod
-    def hijack() -> None:
-        from vllm.distributed.weight_transfer.ipc_engine import IPCWeightTransferEngine
-
-        if getattr(IPCWeightTransferEngine, "_vime_receive_patched", False):
-            return
-
-        _orig = IPCWeightTransferEngine.receive_weights
-
-        def _vime_receive_weights(self, update_info, load_weights, _orig=_orig):
-            _orig(self, update_info, load_weights)
-
-        IPCWeightTransferEngine.receive_weights = _vime_receive_weights
-        IPCWeightTransferEngine._vime_receive_patched = True  # type: ignore[attr-defined]
 
     @staticmethod
     def _patch_npu_worker() -> None:
@@ -582,99 +357,13 @@ class _VLLMHijack:
 
 
 class vLLMColocateWorkerExtension:
-    """vLLM ``--worker-extension-cls`` entry for colocated IPC weight sync."""
+    """vLLM ``--worker-extension-cls`` entry for colocated rollout workers."""
 
     def __new__(cls, **kwargs):
         if is_npu():
-            _patch_npu_colocate_worker()
-        else:
-            _VLLMHijack.hijack()
+            _VLLMHijack._patch_npu_worker()
+            _VLLMHijack._patch_npu_rotary_emb()
         return super().__new__(cls)
-
-    # ── Three-phase weight update protocol ────────────────────────────────────
-    # Mirrors SkyRL's NewInferenceWorkerWrap. Callable via /collective_rpc from
-    # VLLMEngine.update_weights_chunk / update_weights_chunk on the trainer side.
-
-    def update_weights_chunk(self, update_info: dict) -> None:
-        """Receive and load a single chunk of weights via CUDA IPC.
-
-        Accepts the ``update_info`` dict produced by
-        ``VLLMEngine.update_weights`` / ``update_weights``, which
-        carries ``ipc_handles_pickled`` (cloudpickle + base64 serialised CUDA
-        IPC handles assembled by the trainer's
-        ``IPCWeightTransferEngine.trainer_send_weights``).
-
-        Deserialises IPC handles inline (the same pattern as SkyRL's
-        NewInferenceWorkerWrap) and reconstructs each weight tensor before
-        loading into the model — no dependency on
-        ``weight_transfer_engine.receive_weights``.
-
-        Args:
-            update_info: Dict with keys:
-                - names: list[str]
-                - dtype_names: list[str]
-                - shapes: list[list[int]]
-                - ipc_handles_pickled: base64(cloudpickle({gpu_uuid: (func, args)}))
-        """
-        if not getattr(self, "_weight_update_active", False):
-            raise RuntimeError("start_weight_update must be called before update_weights.")
-
-        import base64
-
-        import cloudpickle
-
-        # Deserialise cloudpickle+b64 encoded IPC handles back to raw callables.
-        inner = dict(update_info)
-        if "ipc_handles_pickled" in inner:
-            inner["ipc_handles"] = cloudpickle.loads(base64.b64decode(inner.pop("ipc_handles_pickled")))
-
-        names: list[str] = inner["names"]
-        shapes: list[list[int]] = inner["shapes"]
-        ipc_handles: list[dict] = inner["ipc_handles"]
-
-        if is_npu():
-            device_index = torch.npu.current_device()
-            props = torch.npu.get_device_properties(device_index)
-            physical_gpu_id = str(getattr(props, "uuid", f"npu:{device_index}"))
-        else:
-            device_index = torch.cuda.current_device()
-            physical_gpu_id = str(torch.cuda.get_device_properties(device_index).uuid)
-
-        # Reconstruct weights from per-tensor IPC handles (one handle per
-        # parameter — the vLLM IPCWeightTransferEngine.trainer_send_weights
-        # convention, which differs from SkyRL's single-packed-buffer approach).
-        weights: list[tuple[str, torch.Tensor]] = []
-        for name, _shape, ipc_handle in zip(names, shapes, ipc_handles, strict=True):
-            if physical_gpu_id not in ipc_handle:
-                raise ValueError(
-                    f"IPC handle not found for GPU UUID {physical_gpu_id}. "
-                    f"Available UUIDs: {list(ipc_handle.keys())}"
-                )
-            func, args = ipc_handle[physical_gpu_id]
-            # Index 6 is the device_index in torch's rebuild_cuda_tensor tuple.
-            # Remap to the local (receiver-side) device index.
-            list_args = list(args)
-            list_args[6] = device_index
-            weight: torch.Tensor = func(*list_args)
-            weights.append((name, weight))
-
-        # Load weights into the model.
-        from vllm.config import set_current_vllm_config
-
-        model = self.model_runner.model
-        with set_current_vllm_config(self.vllm_config), torch.device(self.device):
-            if self._is_checkpoint_format:
-                model.load_weights(weights=iter(weights))
-            else:
-                _load_colocate_weights_direct(
-                    model,
-                    weights,
-                    tp_rank=self.rank % self.parallel_config.tensor_parallel_size,
-                )
-
-        # Ensure the receiver has finished consuming the IPC tensors before
-        # the sender drops its reference on the next barrier.
-        torch.accelerator.synchronize()
 
 
 class vLLMWorkerExtension:

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -14,12 +14,12 @@ import ipaddress
 import logging
 import multiprocessing
 import os
+import pickle
 import time
 from argparse import BooleanOptionalAction
 from typing import Any
 from urllib.parse import quote
 
-import cloudpickle
 import requests
 
 from vime.backends.vllm_utils.arguments import SKIPPED_DESTS, get_vllm_cli_action_table
@@ -755,70 +755,19 @@ class VLLMEngine(RayActor):
         response.raise_for_status()
         return True
 
-    def update_weights_from_tensor(
-        self,
-        *,
-        names: list[str],
-        dtype_names: list[str],
-        shapes: list[list[int]],
-        ipc_handles: list[dict] | None = None,
-        weight_version: str | None = None,
-        flush_cache: bool = False,
-    ) -> dict | None:
-        """POST ``IPCWeightTransferUpdateInfo`` (names / dtype_names / shapes /
-        ipc_handles) to ``/update_weights``; record ``weight_version`` only on
-        success. ``ipc_handles`` are base64-cloudpickle'd (rebuild_fn closures).
-        """
+    def update_weights(self, request: dict, weight_version: str | None = None) -> dict | None:
+        """POST native vLLM ``/update_weights`` payloads from transfer engines."""
         if self.node_rank != 0:
             return None
 
-        payload: dict = {"names": names, "dtype_names": dtype_names, "shapes": shapes}
-        if ipc_handles is not None:
-            payload["ipc_handles_pickled"] = base64.b64encode(cloudpickle.dumps(ipc_handles)).decode("utf-8")
-        if flush_cache:
-            self.flush_cache()
+        update_info = request["update_info"] if "update_info" in request else request
+        payload = dict(update_info)
+        if "ipc_handles" in payload:
+            payload["ipc_handles_pickled"] = base64.b64encode(pickle.dumps(payload.pop("ipc_handles"))).decode("utf-8")
 
-        response = self._make_request(
-            "collective_rpc",
-            {"method": "update_weights_chunk", "kwargs": {"update_info": payload}},
-        )
+        response = self._post_vllm_update_weights_http(payload)
         if weight_version is not None:
             self._weight_version = str(weight_version)
-        return response
-
-    def update_weights_chunk(self, update_info: dict) -> dict:
-        """POST ``/update_weights_chunk`` with a single named-tensor chunk.
-
-        Mirrors the SkyRL ``RemoteInferenceClient.update_weights_chunk`` API.
-        Must be called between :meth:`start_weight_update` and
-        :meth:`finish_weight_update`.
-
-        Unlike :meth:`update_weights`, ``update_info`` is the *inner* payload
-        dict (``names``, ``dtype_names``, ``shapes``, and one of
-        ``ipc_handles`` / ``ipc_handles_pickled`` for IPC, or ``packed`` for
-        NCCL) — **not** wrapped in ``{"update_info": ...}``.
-
-        If ``ipc_handles`` are present (raw CUDA callables produced by
-        ``reduce_tensor``), they are serialised with cloudpickle + base64 so
-        vLLM can deserialise them when
-        ``VLLM_ALLOW_INSECURE_SERIALIZATION=1`` is set.
-        """
-        if self.node_rank != 0:
-            return {"ok": True, "skipped": True}
-
-        import base64
-
-        import cloudpickle
-
-        payload = dict(update_info)
-        if payload.get("ipc_handles") is not None:
-            payload["ipc_handles_pickled"] = base64.b64encode(cloudpickle.dumps(payload.pop("ipc_handles"))).decode(
-                "utf-8"
-            )
-        response = self._make_request(
-            "collective_rpc",
-            {"method": "update_weights_chunk", "kwargs": {"update_info": payload}},
-        )
         return response
 
     def flush_cache(self):
@@ -877,8 +826,8 @@ class VLLMEngine(RayActor):
         if self._weight_version is None:
             raise RuntimeError(
                 "VLLMEngine.get_weight_version called before any successful "
-                "weight transfer recorded a version (update_weights_from_tensor "
-                "/ update_weights_from_distributed never reached their "
+                "weight transfer recorded a version (update_weights "
+                "/ update_weights_from_distributed never reached its "
                 "post-POST version write)."
             )
         return self._weight_version
@@ -926,16 +875,15 @@ class VLLMEngine(RayActor):
                     time.sleep(2 * attempt)
         raise RuntimeError(f"vLLM init_weight_transfer_engine failed: {last_error}") from last_error
 
-    def start_weight_update(self, is_checkpoint_format: bool = False) -> dict:
+    def start_weight_update(self, is_checkpoint_format: bool = True) -> dict:
         """``POST /start_weight_update`` — signals vLLM to enter IPC weight-update mode."""
         return self._make_request("start_weight_update", {"is_checkpoint_format": is_checkpoint_format})
 
     def finish_weight_update(self) -> dict:
         """``POST /finish_weight_update`` — signals vLLM to exit IPC weight-update mode.
 
-        Purely a state-machine bookend now; ``_weight_version`` is recorded by
-        ``update_weights_from_tensor`` (the IPC data-carrying RPC), matching slime's
-        single-RPC version-with-data semantics.
+        Purely a state-machine bookend; ``_weight_version`` is recorded by
+        the data-carrying ``update_weights`` / distributed update calls.
         """
         return self._make_request("finish_weight_update", {})
 


### PR DESCRIPTION
## Summary

Replace VIME's custom colocated IPC weight-sync implementation with the native weight transfer engines provided by vLLM and vLLM-Ascend.

This removes the manual IPC handle gathering, serialization, and worker-side chunk loading path while aligning colocated weight updates with vLLM's native `/update_weights` lifecycle.

## What changed

- Use  `NPUIPCWeightTransferEngine` on Ascend to send colocated weights.
- Route native `update_info` payloads through `VLLMEngine.update_weights` and vLLM's `/update_weights` endpoint.
- Initialize the native weight transfer engine once when colocated rollout engines are connected.
- Use the native `start_weight_update` / `finish_weight_update` state machine with checkpoint-format loading.
- Remove the custom:
  - trainer-rank IPC gather groups
  - IPC handle merging and serialization helpers
  - `update_weights_from_tensor` / `update_weights_chunk` RPC path
  - colocated worker-side tensor reconstruction logic
- Retain the Ascend worker compatibility patches for MoE expert weight loaders and rotary embeddings.
- Update unit tests to cover the native CUDA/NPU IPC transfer flow and isolate optional dependency stubs between test modules.

## Why

The previous implementation duplicated functionality already supported by vLLM's native IPC transfer engines and required VIME to maintain custom GPU-slot gathering, IPC handle reconstruction, and worker RPC code.

Using the native transfer path reduces VIME-specific integration code and keeps colocated weight synchronization aligned with upstream vLLM and vLLM-Ascend behavior.

## Testing

- [x] `pytest tests/unit/backends/megatron_utils/update_weight/test_update_weight_from_tensor.py -q`
- [x] `pytest tests/unit/backends/vllm_utils/test_vllm_engine.py -q`
- [x] Pre-commit formatting and lint checks
- [x] End-to-end Qwen3-4B colocated training on Ascend NPU