### PR TITLE
[NPU] Add Retool example

### DIFF
--- a/examples/retool/README.md
+++ b/examples/retool/README.md
@@ -1,0 +1,88 @@
+# Retool: from SFT to RL
+This example _**(Retool)**_ demonstrates how to use the retool functionality for tool-enabled language model generation.
+
+## Overview
+The retool example provides:
+
+- Safe Python code execution in a sandbox environment
+- Tool registry for managing available tools
+- Integration with language model generation
+- Reward calculation for tool usage
+
+## Files
+- `generate_with_retool.py`: Main generation function with tool support
+- `tool_sandbox.py`: Tool execution and safety management
+- `sft_data_processing.py`: Process SFT dataset
+
+## Reward Design
+The RL reward function (`generate_with_retool.reward_func`) uses a **tool-aware reward shaping** strategy on top of the math accuracy reward:
+
+| Answer | Tool Used | Reward | Rationale |
+|--------|-----------|--------|-----------|
+| ✅ Correct | No | 1.0 | Pure reasoning — the ideal case |
+| ✅ Correct | Yes | 1.0 + min(0.2, turns × 0.05) | Bonus for effective tool use (capped at 0.2) |
+| ❌ Wrong | No | 0.0 | Neutral — model didn't attempt tools |
+| ❌ Wrong | Yes | min(0.1, turns × 0.02) | Small positive to encourage exploration |
+
+This design encourages the model to **explore tool calling** during early RL training without letting it reward-hack by preferring tool calls over correct answers. As training progresses and accuracy improves, the accuracy reward dominates and the tool bonus becomes a tiebreaker.
+
+## Usage
+### 1. Setup
+```
+git clone -b ascend https://github.com/vllm-project/vime.git
+cd vime
+docker build -f docker/Dockerfile.npu -t vime-ascend:latest .
+```
+```
+# Update the vime image
+export IMAGE=vime-ascend:latest
+
+docker run -d --name vime-npu -it --net=host --shm-size=1024g \
+    --privileged=true \
+    --cap-add=SYS_PTRACE \
+    --device=/dev/davinci_manager \
+    --device=/dev/hisi_hdc \
+    --device=/dev/devmm_svm \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/sbin:/usr/local/sbin \
+    -v /home:/home \
+    -v /mnt:/mnt \
+    -v /tmp:/tmp \
+    -v /data:/data \
+    -v /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime \
+    $IMAGE
+
+docker exec -it vime-npu bash
+```
+### 2. Download
+```
+# For SFT part, you can use later model to RL directly and skip SFT.
+hf download --repo-type dataset JoeYing/ReTool-SFT  --local-dir /path/to/ReTool-SFT
+hf download Qwen/Qwen3-4B-Instruct-2507 --local-dir /path/to/Qwen3-4B-Instruct-2507
+
+# For RL part
+hf download --repo-type dataset zhuzilin/dapo-math-17k --local-dir /path/to/dapo-math-17k
+hf download --repo-type dataset zhuzilin/aime-2024  --local-dir /path/to/aime-2024
+# download our SFT model if you want to skip SFT
+hf download font-info/qwen3-4b-sft-SGLang-RL --local-dir /path/to/qwen3-4b-sft
+```
+### 3. Preprocessing
+```
+cd /root/vime
+# Replace the save path with /path/to/ReTool-SFT.parquet
+python examples/retool/sft_data_processing.py
+```
+### 4. SFT
+```
+cd /root/vime
+# Replace the model and data loading/saving paths
+python examples/retool/retool_qwen3_4b_sft.sh
+```
+### 5. RL
+```
+cd /root/vime
+# Replace the model and data loading/saving paths
+python examples/retool/retool_qwen3_4b_rl.sh
+```

--- a/examples/retool/README_zh.md
+++ b/examples/retool/README_zh.md
@@ -1,9 +1,7 @@
 # Retool：从 SFT 到 RL
-
 本示例 **(Retool)** 演示了如何使用 retool 功能进行带工具调用的语言模型生成。
 
 ## 概述
-
 Retool 示例提供了：
 
 - 沙盒环境中的安全 Python 代码执行
@@ -12,7 +10,6 @@ Retool 示例提供了：
 - 工具使用的奖励计算
 
 ## 文件说明
-
 - `generate_with_retool.py`：主生成函数，支持工具调用
 - `tool_sandbox.py`：工具执行与安全管理
 - `sft_data_processing.py`：处理 SFT 数据集
@@ -30,9 +27,7 @@ RL 奖励函数（`generate_with_retool.reward_func`）在数学正确性奖励�
 该设计鼓励模型在 RL 训练早期**探索工具调用**，同时避免模型通过偏好工具调用而非正确答案来进行奖励投机。随着训练推进和准确率提升，正确性奖励将占主导，工具奖励变为辅助项。
 
 ## 使用方法
-
 ### 1. 环境搭建
-
 ```bash
 git clone -b ascend https://github.com/vllm-project/vime.git
 cd vime
@@ -64,7 +59,6 @@ docker exec -it vime-npu bash
 ```
 
 ### 2. 下载
-
 ```bash
 # SFT 部分，你也可以直接使用后续模型进行 RL 而跳过 SFT。
 hf download --repo-type dataset JoeYing/ReTool-SFT  --local-dir /path/to/ReTool-SFT
@@ -78,7 +72,6 @@ hf download font-info/qwen3-4b-sft-SGLang-RL --local-dir /path/to/qwen3-4b-sft
 ```
 
 ### 3. 数据预处理
-
 ```bash
 cd /root/vime
 # 将保存路径替换为 /path/to/ReTool-SFT.parquet
@@ -86,7 +79,6 @@ python examples/retool/sft_data_processing.py
 ```
 
 ### 4. SFT
-
 ```bash
 cd /root/vime
 # 替换模型和数据加载/保存路径
@@ -94,7 +86,6 @@ python examples/retool/retool_qwen3_4b_sft.sh
 ```
 
 ### 5. RL
-
 ```bash
 cd /root/vime
 # 替换模型和数据加载/保存路径

--- a/examples/retool/README_zh.md
+++ b/examples/retool/README_zh.md
@@ -1,0 +1,102 @@
+# Retool：从 SFT 到 RL
+
+本示例 **(Retool)** 演示了如何使用 retool 功能进行带工具调用的语言模型生成。
+
+## 概述
+
+Retool 示例提供了：
+
+- 沙盒环境中的安全 Python 代码执行
+- 工具注册表，用于管理可用工具
+- 与语言模型生成的集成
+- 工具使用的奖励计算
+
+## 文件说明
+
+- `generate_with_retool.py`：主生成函数，支持工具调用
+- `tool_sandbox.py`：工具执行与安全管理
+- `sft_data_processing.py`：处理 SFT 数据集
+
+## 奖励设计
+RL 奖励函数（`generate_with_retool.reward_func`）在数学正确性奖励的基础上采用了**工具感知的奖励塑形**策略：
+
+| 答案 | 是否使用工具 | 奖励值 | 说明 |
+|------|-------------|--------|------|
+| ✅ 正确 | 否 | 1.0 | 纯推理——理想情况 |
+| ✅ 正确 | 是 | 1.0 + min(0.2, 轮次 × 0.05) | 有效工具使用的额外奖励（上限 0.2） |
+| ❌ 错误 | 否 | 0.0 | 中性——模型未尝试使用工具 |
+| ❌ 错误 | 是 | min(0.1, 轮次 × 0.02) | 小额正奖励以鼓励探索 |
+
+该设计鼓励模型在 RL 训练早期**探索工具调用**，同时避免模型通过偏好工具调用而非正确答案来进行奖励投机。随着训练推进和准确率提升，正确性奖励将占主导，工具奖励变为辅助项。
+
+## 使用方法
+
+### 1. 环境搭建
+
+```bash
+git clone -b ascend https://github.com/vllm-project/vime.git
+cd vime
+docker build -f docker/Dockerfile.npu -t vime-ascend:latest .
+```
+
+```bash
+# 更新 vime 镜像
+export IMAGE=vime-ascend:latest
+
+docker run -d --name vime-npu -it --net=host --shm-size=1024g \
+    --privileged=true \
+    --cap-add=SYS_PTRACE \
+    --device=/dev/davinci_manager \
+    --device=/dev/hisi_hdc \
+    --device=/dev/devmm_svm \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/sbin:/usr/local/sbin \
+    -v /home:/home \
+    -v /mnt:/mnt \
+    -v /tmp:/tmp \
+    -v /data:/data \
+    -v /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime \
+    $IMAGE
+
+docker exec -it vime-npu bash
+```
+
+### 2. 下载
+
+```bash
+# SFT 部分，你也可以直接使用后续模型进行 RL 而跳过 SFT。
+hf download --repo-type dataset JoeYing/ReTool-SFT  --local-dir /path/to/ReTool-SFT
+hf download Qwen/Qwen3-4B-Instruct-2507 --local-dir /path/to/Qwen3-4B-Instruct-2507
+
+# RL 部分
+hf download --repo-type dataset zhuzilin/dapo-math-17k --local-dir /path/to/dapo-math-17k
+hf download --repo-type dataset zhuzilin/aime-2024  --local-dir /path/to/aime-2024
+# 如果你想跳过 SFT，可下载我们的 SFT 模型
+hf download font-info/qwen3-4b-sft-SGLang-RL --local-dir /path/to/qwen3-4b-sft
+```
+
+### 3. 数据预处理
+
+```bash
+cd /root/vime
+# 将保存路径替换为 /path/to/ReTool-SFT.parquet
+python examples/retool/sft_data_processing.py
+```
+
+### 4. SFT
+
+```bash
+cd /root/vime
+# 替换模型和数据加载/保存路径
+python examples/retool/retool_qwen3_4b_sft.sh
+```
+
+### 5. RL
+
+```bash
+cd /root/vime
+# 替换模型和数据加载/保存路径
+python examples/retool/retool_qwen3_4b_rl.sh
+```

--- a/examples/retool/generate_with_retool.py
+++ b/examples/retool/generate_with_retool.py
@@ -1,0 +1,558 @@
+# Adapted from https://github.com/volcengine/verl/blob/cb809d66e46dfd3342d008628891a14a054fa424/recipe/retool/retool.py
+# Adapted for vLLM /inference/v1/generate endpoint (disagg API)
+import logging
+import random
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+try:
+    from jinja2 import Template
+except ImportError as e:
+    raise ImportError("Jinja2 is required. Please install it with: pip install jinja2") from e
+
+from vime.rollout.vllm_rollout import GenerateState, _build_inference_sampling_params
+from vime.utils.http_utils import post
+from vime.utils.types import Sample
+
+# Import reward models
+try:
+    from vime.rollout.rm_hub.math_dapo_utils import compute_score as math_dapo_compute_score
+except ImportError as e:
+    raise ImportError("MathDapo is not installed") from e
+
+# Import tool sandbox functionality
+from tool_sandbox import SEMAPHORE, TOOL_CONFIGS, tool_registry
+
+# ── Sample-level verbose logging ──────────────────────────────────────────
+# Roughly 1/20 samples are logged so the output stays readable.
+_LOG_SAMPLE_PROB = 0.05
+_LOG_WIDTH = 300
+
+# ── Log probability collection ───────────────────────────────────────────
+# When True, collect log probabilities for TIS (Trajectory Importance Sampling).
+# When True, we CANNOT postprocess the decoded text because that would break
+# token/logp alignment. Instead, we rely on stop strings to ensure the engine
+# stops at tool/answer boundaries.
+RETURN_LOGPROB = True
+
+
+def _trunc(s: str, n: int = 300) -> str:
+    """Truncate *s* to at most *n* characters for display."""
+    if len(s) <= n:
+        return s
+    return s[:n] + f"…[+{len(s) - n}]"
+
+
+# Jinja2 template for tool-enabled conversations
+TOOL_TEMPLATE = """<|im_start|>system
+{%- if messages[0]['role'] == 'system' %}
+{{- messages[0]['content'] }}
+{%- else %}
+You are a helpful assistant.
+{%- endif %}
+{%- if tools %}
+# Tools
+
+You can write Python code to solve problems. Put your code between <code> and </code> tags. The code will be executed and you will see the output.
+When you have the final answer, write it as: Answer: \\boxed{your_answer}
+{%- endif %}
+<|im_end|>
+{%- for message in messages %}
+{%- if message['role'] == 'user' %}
+<|im_start|>user
+{{- message['content'] }}<|im_end|>
+{%- elif message['role'] == 'assistant' %}
+<|im_start|>assistant
+{{- message['content'] }}<|im_end|>
+{%- endif %}
+{%- endfor %}
+<|im_start|>assistant
+"""
+
+
+def format_conversation_with_tools(
+    prompt: str, tools: list[dict[str, Any]] = None, system_prompt: str = None, messages: list[dict[str, Any]] = None
+) -> str:
+    """Format conversation using Jinja2 template with tool support"""
+    template = Template(TOOL_TEMPLATE)
+
+    # Prepare messages
+    messages_to_render = []
+
+    # Always add system message - use provided one or default
+    if system_prompt:
+        system_content = system_prompt
+    else:
+        system_content = (
+            "You are a helpful assistant that solves "
+            "mathematical problems step by step."
+        )
+
+    messages_to_render.append({"role": "system", "content": system_content})
+
+    # Add user message if provided
+    if prompt:
+        messages_to_render.append({"role": "user", "content": prompt})
+
+    # Add assistant responses from previous turns if provided
+    if messages:
+        messages_to_render.extend(messages)
+
+    # Render template
+    formatted_text = template.render(messages=messages_to_render, tools=tools or [])
+
+    return formatted_text
+
+
+def postprocess_predictions(prediction: str):
+    """Extract action and content from prediction string"""
+    # Check for Answer: \boxed{...} format (only format we need for math_dapo)
+    # Use a more robust regex that handles nested braces
+    answer_pattern = r"Answer:\s*\\boxed\{((?:[^{}]|\{[^{}]*\})*)\}"
+    answer_match = re.search(answer_pattern, prediction, re.DOTALL)
+    if answer_match:
+        content = answer_match.group(1).strip()
+        return "answer", content
+
+    # Then check for <tool_call> tags (new format from Jinja2 template)
+    tool_call_pattern = r"<tool_call>\s*(\{.*?\})\s*</tool_call>"
+    tool_call_match = re.search(tool_call_pattern, prediction, re.DOTALL)
+    if tool_call_match:
+        try:
+            import json
+
+            # Clean up the JSON string by removing newlines and extra
+            # whitespace
+            json_str = tool_call_match.group(1)
+            # Replace newlines in string values with \n
+            json_str = json_str.replace("\n", "\\n")
+            tool_call_data = json.loads(json_str)
+            tool_name = tool_call_data.get("name")
+            arguments = tool_call_data.get("arguments", {})
+
+            if tool_name == "code_interpreter":
+                code = arguments.get("code", "")
+                if code.strip():
+                    return "code", code
+        except (json.JSONDecodeError, KeyError, AttributeError):
+            pass
+
+    # Then check for <code> tags
+    code_pattern = r"<code>(.*?)</code>"
+    code_match = re.search(code_pattern, prediction, re.DOTALL)
+    if code_match:
+        content = code_match.group(1).strip()
+        return "code", content
+
+    # Finally check for ```python code blocks (lowest priority)
+    python_code_pattern = r"```python\s*(.*?)\s*```"
+    python_code_match = re.search(python_code_pattern, prediction, re.DOTALL)
+    if python_code_match:
+        content = python_code_match.group(1).strip()
+        return "code", content
+
+    return None, ""
+
+
+def postprocess_responses(resp: str) -> str:
+    """Post-process response to ensure tag completeness.
+
+    IMPORTANT: Only used when RETURN_LOGPROB is False. When log prob collection
+    is enabled, we cannot postprocess the decoded text because that would break
+    token/logp alignment. Instead, we rely on stop strings to ensure the engine
+    stops at tool/answer boundaries.
+    """
+    # Handle <tool_call> tags (new format from Jinja2 template)
+    if "<tool_call>" in resp:
+        # Find the last occurrence of <tool_call>...</tool_call>
+        tool_call_pattern = r"<tool_call>\s*\{.*?\}\s*</tool_call>"
+        matches = list(re.finditer(tool_call_pattern, resp, re.DOTALL))
+        if matches:
+            last_match = matches[-1]
+            return resp[: last_match.end()]
+
+    # Handle <code> tags
+    if "</code>" in resp:
+        return resp.split("</code>")[0] + "</code>"
+
+    # Handle ```python code blocks
+    if "```python" in resp:
+        # Find the last occurrence of ```python...```
+        python_pattern = r"```python\s*.*?```"
+        matches = list(re.finditer(python_pattern, resp, re.DOTALL))
+        if matches:
+            last_match = matches[-1]
+            return resp[: last_match.end()]
+
+    # Handle Answer: \boxed{...} format (only format we need for math_dapo)
+    if "Answer:" in resp and "\\boxed{" in resp:
+        # Find the last occurrence of Answer: \boxed{...} with nested braces support
+        answer_pattern = r"Answer:\s*\\boxed\{((?:[^{}]|\{[^{}]*\})*)\}"
+        matches = list(re.finditer(answer_pattern, resp, re.DOTALL))
+        if matches:
+            last_match = matches[-1]
+            return resp[: last_match.end()]
+
+    return resp
+
+
+async def execute_predictions(prediction: str) -> str:
+    """Execute predictions and return results"""
+    action, content = postprocess_predictions(prediction)
+
+    if action == "code":
+        # Content is already the Python code (extracted by
+        # postprocess_predictions)
+        code = content.strip()
+        if code:
+            async with SEMAPHORE:
+                result = await tool_registry.execute_tool("code_interpreter", {"code": code})
+            next_obs = f"\n\n<interpreter>\n{result}\n</interpreter>\n\n"
+            done = False
+        else:
+            next_obs = "\n\n<interpreter>\nError: No Python code found\n</interpreter>\n\n"
+            done = False
+    elif action == "answer":
+        next_obs = ""
+        done = True
+    else:
+        next_obs = (
+            "\nMy previous action is invalid. "
+            "If I want to execute code, I should put the code between "
+            "<code> and </code>. "
+            "If I want to give the final answer, I should write "
+            "'Answer: ' followed by a boxed expression. Let me try again.\n"
+        )
+        done = False
+
+    return next_obs, done
+
+
+# Stop tags: make the inference engine STOP at the tool boundary.
+# "Answer:" was previously included, but it caused the engine to stop
+# immediately after "Answer:" before the model could generate "\boxed{...}",
+# resulting in invalid actions and reward=-1 every time.  The model now
+# completes its answer naturally; execute_predictions detects the
+# Answer: \boxed{...} pattern and sets done=True, ending the turn cleanly.
+_STOP_TAGS = ["</code>"]
+
+
+async def generate(args, sample: Sample, sampling_params) -> Sample:
+    """Custom generation function supporting tool calls (vLLM version)"""
+    assert not args.partial_rollout, "Partial rollout is not supported for " "this function at the moment."
+
+    state = GenerateState(args)
+    router_ip = args.vllm_router_ip
+    router_port = args.vllm_router_port
+    url = f"http://{router_ip}:{router_port}/inference/v1/generate"
+
+    # Set up the initial prompt with system prompt and tools (outside the loop)
+    tool_specs = tool_registry.get_tool_specs()
+
+    # Extract the raw user content from sample.prompt to avoid duplicate
+    # <|im_start|>user tags — the Jinja2 template adds them itself.
+    _raw_prompt = sample.prompt
+    if isinstance(_raw_prompt, list):
+        # List of message dicts, e.g. [{"role": "user", "content": "..."}]
+        _raw_prompt = "".join(m.get("content", "") for m in _raw_prompt)
+    # If the prompt string already contains chat-format tags, strip them so
+    # the template can re-add them consistently.
+    if isinstance(_raw_prompt, str) and "<|im_start|>" in _raw_prompt:
+        _raw_prompt = re.sub(r"<\|im_start\|>(?:system|user|assistant)\n?", "", _raw_prompt)
+        _raw_prompt = _raw_prompt.replace("<|im_end|>", "")
+        _raw_prompt = _raw_prompt.strip()
+
+    prompt = format_conversation_with_tools(prompt=_raw_prompt, tools=tool_specs)
+
+    prompt_tokens_ids = state.tokenizer(prompt, add_special_tokens=False)["input_ids"]
+    response = ""
+    response_token_ids = []
+    loss_masks = []
+    rollout_log_probs = [] if RETURN_LOGPROB else None
+    tool_call_count = 0  # Track actual tool call rounds
+    consecutive_memory_errors = 0  # Track consecutive "Memory usage too high" errors
+    obs_truncated = False  # Flag: obs caused total length to exceed max_context_length
+    # Calculate max context length once at the beginning
+    max_context_length = len(prompt_tokens_ids) + args.rollout_max_response_len
+    logger.debug("max_context_length is set to %d", max_context_length)
+
+    # Randomly select a small fraction of samples for detailed turn-by-turn logging.
+    verbose = random.random() < _LOG_SAMPLE_PROB
+    if verbose:
+        _sep = "═" * _LOG_WIDTH
+        _prompt_display = (
+            "".join(m.get("content", "") for m in sample.prompt)
+            if isinstance(sample.prompt, list)
+            else sample.prompt
+        )
+        logger.debug("\n%s\n[ReTool LOG] prompt (%d tokens): %s\n%s", _sep, len(prompt_tokens_ids), _trunc(_prompt_display, 200), _sep)
+
+    # Add stop tags to sampling_params so the engine stops at tool/answer boundaries.
+    # This is critical for keeping token/logp alignment when RETURN_LOGPROB is enabled.
+    _existing_stop = sampling_params.get("stop") or []
+    if isinstance(_existing_stop, str):
+        _existing_stop = [_existing_stop]
+    sampling_params = {**sampling_params, "stop": list(dict.fromkeys([*_existing_stop, *_STOP_TAGS]))}
+
+    # Build vLLM-style sampling params (maps max_new_tokens -> max_tokens, adds logprobs, etc.)
+    inference_sampling_params = _build_inference_sampling_params(sampling_params)
+
+    for turn in range(TOOL_CONFIGS["max_turns"]):
+        # vLLM /inference/v1/generate requires token_ids instead of text.
+        # For multi-turn, re-tokenize the full context each time.
+        full_text = prompt + response
+        current_token_ids = state.tokenizer(full_text, add_special_tokens=False)["input_ids"]
+
+        # Check if total length exceeds max context length
+        total_length = len(current_token_ids)
+        if total_length >= max_context_length:
+            sample.status = Sample.Status.TRUNCATED
+            break
+
+        # Dynamically calculate remaining token budget for this turn
+        remaining_tokens = max_context_length - total_length
+
+        # Update max_tokens for this turn to respect the remaining budget
+        current_inference_params = dict(inference_sampling_params)
+        current_inference_params["max_tokens"] = min(
+            inference_sampling_params["max_tokens"],
+            remaining_tokens,
+        )
+
+        # Check if we have budget for more tokens
+        if current_inference_params["max_tokens"] <= 0:
+            sample.status = Sample.Status.TRUNCATED
+            break
+
+        payload = {
+            "token_ids": current_token_ids,
+            "sampling_params": current_inference_params,
+        }
+        if hasattr(args, 'hf_checkpoint'):
+            payload["model"] = args.hf_checkpoint
+
+        # Log payload to wandb for debugging
+        try:
+            import wandb
+
+            if wandb.run is not None:
+                # Count available tools (from tool_specs)
+                available_tools = len(tool_specs)
+                # Count tools used in the current response
+                tools_used = response.count("<interpreter>")
+
+                wandb.log(
+                    {
+                        "debug/payload_length": len(prompt + response),
+                        "debug/available_tools": available_tools,
+                        "debug/tools_used": tools_used,
+                        "debug/turn": turn,
+                    }
+                )
+        except ImportError:
+            pass  # wandb not available
+
+        output = await post(url, payload)
+
+        # Parse vLLM GenerateResponse: {"choices": [{"token_ids": [...], "logprobs": ..., "finish_reason": "stop"}]}
+        choice = output["choices"][0]
+        finish_reason = choice.get("finish_reason", "stop")
+
+        # Handle abort
+        if finish_reason == "abort":
+            sample.status = Sample.Status.ABORTED
+            return sample
+
+        # Extract token IDs from vLLM response
+        cur_response_token_ids = choice.get("token_ids") or []
+
+        # Decode text from token_ids
+        skip_sp = current_inference_params.get("skip_special_tokens")
+        skip_decode = True if skip_sp is None else bool(skip_sp)
+        cur_response = state.tokenizer.decode(cur_response_token_ids, skip_special_tokens=skip_decode) if cur_response_token_ids else ""
+
+        # Extract log probs if enabled
+        if RETURN_LOGPROB:
+            cur_response_log_probs: list[float] = []
+            lp = choice.get("logprobs")
+            if isinstance(lp, dict):
+                content_items = lp.get("content") or []
+                cur_response_log_probs = [
+                    float(item.get("logprob", 0.0)) if isinstance(item, dict) else 0.0 for item in content_items
+                ]
+            if not cur_response_log_probs:
+                cur_response_log_probs = [0.0] * len(cur_response_token_ids)
+        else:
+            # When not collecting log probs, we can safely postprocess the response
+            cur_response = postprocess_responses(cur_response)
+            # Re-tokenize after postprocessing
+            cur_response_token_ids = state.tokenizer(cur_response, add_special_tokens=False)["input_ids"]
+            cur_response_log_probs = None
+
+        response += cur_response
+        response_token_ids += cur_response_token_ids
+        loss_masks += [1] * len(cur_response_token_ids)
+
+        # Add log probs if enabled
+        if RETURN_LOGPROB:
+            rollout_log_probs += cur_response_log_probs
+
+        # verbose: show what the model generated this turn
+        if verbose:
+            n_tok = len(cur_response_token_ids)
+            logger.debug("\n%s\n[Turn %d] model output (%d tok, finish=%s):\n  %s", "─" * _LOG_WIDTH, turn + 1, n_tok, finish_reason, _trunc(cur_response).replace("\n", "\n  "))
+
+        # Check length limit
+        if finish_reason == "length":
+            if verbose:
+                logger.debug("[Turn %d] → length limit reached, stopping.", turn + 1)
+            break
+
+        next_obs, done = await execute_predictions(cur_response)
+
+        # Track consecutive memory errors to break the vicious retry cycle.
+        # When sandbox keeps returning "Memory usage too high", the model
+        # generates another code attempt which also fails, consuming more
+        # tokens and memory. Force done=True after N consecutive failures.
+        if "Memory usage too high" in next_obs:
+            consecutive_memory_errors += 1
+            if consecutive_memory_errors >= TOOL_CONFIGS.get("max_consecutive_memory_errors", 3):
+                done = True
+        else:
+            consecutive_memory_errors = 0
+
+        # verbose: show action and observation
+        if verbose:
+            if done:
+                logger.debug("[Turn %d] → answer detected (DONE)", turn + 1)
+            elif "<interpreter>" in next_obs:
+                obs_display = "  " + _trunc(next_obs, 300).replace("\n", "\n  ")
+                logger.debug("[Turn %d] → code executed, observation:\n%s", turn + 1, obs_display)
+            else:
+                logger.debug("[Turn %d] → invalid action (no recognized code or answer)", turn + 1)
+
+        if done:
+            break
+
+        # Count tool calls (when we get interpreter output, it means a tool
+        # was called)
+        if "<interpreter>" in next_obs:
+            tool_call_count += 1
+
+        assert next_obs != "", "Next observation should not be empty."
+        obs_tokens_ids = state.tokenizer(next_obs, add_special_tokens=False)["input_ids"]
+        response += next_obs
+        response_token_ids += obs_tokens_ids
+        loss_masks += [0] * len(obs_tokens_ids)
+
+        # Add dummy log probs for observation tokens if enabled (they won't be used due to loss_mask=0)
+        if RETURN_LOGPROB:
+            rollout_log_probs += [0.0] * len(obs_tokens_ids)
+
+            # Verify alignment when collecting log probs
+            assert len(response_token_ids) == len(
+                rollout_log_probs
+            ), f"Token/logp length mismatch at turn {turn}: {len(response_token_ids)} tokens vs {len(rollout_log_probs)} logps"
+
+        # Truncate if obs pushed total response tokens beyond max_context_length
+        max_response_tokens = max_context_length - len(prompt_tokens_ids)
+        if len(response_token_ids) > max_response_tokens:
+            response_token_ids = response_token_ids[:max_response_tokens]
+            loss_masks = loss_masks[:max_response_tokens]
+            if RETURN_LOGPROB:
+                rollout_log_probs = rollout_log_probs[:max_response_tokens]
+            obs_truncated = True
+            break
+
+        if tool_call_count >= TOOL_CONFIGS["max_tool_calls"]:
+            break
+
+    if verbose:
+        logger.debug(
+            "\n%s\n[ReTool LOG] finished | tool_calls=%d | "
+            "response_tokens=%d | finish=%s\n%s",
+            "═" * _LOG_WIDTH, tool_call_count,
+            len(response_token_ids), finish_reason,
+            "═" * _LOG_WIDTH,
+        )
+
+    # Set sample attributes
+    sample.tokens = prompt_tokens_ids + response_token_ids
+    sample.response_length = len(response_token_ids)
+    sample.response = response
+    sample.loss_mask = loss_masks
+    sample.prompt = prompt
+
+    # Store log probs if enabled
+    if RETURN_LOGPROB:
+        sample.rollout_log_probs = rollout_log_probs if rollout_log_probs else None
+
+    # Store payload information for wandb logging
+    sample.payload_text = prompt + response
+    sample.payload_has_system = "<|im_start|>system" in prompt + response
+    sample.payload_has_tools = "# Tools" in prompt + response
+
+    # Store tool call count for reward calculation
+    sample.tool_call_count = tool_call_count
+
+    # Set status
+    # vLLM finish_reason is a string: "stop", "length", or "abort"
+    match finish_reason:
+        case "length":
+            sample.status = Sample.Status.TRUNCATED
+        case "abort":
+            sample.status = Sample.Status.ABORTED
+        case "stop":
+            sample.status = Sample.Status.COMPLETED
+
+    if obs_truncated:
+        sample.status = Sample.Status.TRUNCATED
+
+    return sample
+
+
+async def reward_func(args, sample, **kwargs):
+    """Tool call reward function using math_dapo as primary reward model"""
+    if not isinstance(sample, Sample):
+        raise TypeError("Sample must be an instance of Sample class.")
+
+    # Truncated samples: neutral reward — not right, not wrong, just incomplete.
+    if sample.status == Sample.Status.TRUNCATED:
+        return {"score": 0.0, "acc": False, "pred": ""}
+
+    # Build complete solution string.
+    # sample.prompt may be a list of message dicts; flatten to plain text.
+    if isinstance(sample.prompt, list):
+        prompt_str = "".join(m.get("content", "") for m in sample.prompt)
+    else:
+        prompt_str = sample.prompt
+    solution_str = prompt_str + sample.response
+
+    # Get ground truth answer - label is a string, not a dict
+    ground_truth = sample.label if sample.label is not None else ""
+
+    # Get tool call count as num_turns
+    num_turns = getattr(sample, "tool_call_count", 0)
+
+    # use \\boxed{...} answer
+    result = math_dapo_compute_score(solution_str, ground_truth, strict_box_verify=True)
+
+    # Reward shaping:
+    #   Correct + no tools    → 1.0  (pure reasoning, best)
+    #   Correct + tools       → 1.0 + bonus (tools helped, still good)
+    #   Wrong + no tools      → 0.0  (neutral — model didn't even try tools)
+    #   Wrong + tools         → small positive (encourages exploration,
+    #                           but capped low to avoid reward hacking:
+    #                           the model should not prefer tool-calling
+    #                           over getting the right answer)
+    if result["score"] > 0:
+        result["score"] = 1.0 + min(0.2, num_turns * 0.05)
+    else:
+        result["score"] = min(0.1, num_turns * 0.02)
+
+    if result["pred"] is None:
+        result["pred"] = ""
+
+    return result

--- a/examples/retool/generate_with_retool.py
+++ b/examples/retool/generate_with_retool.py
@@ -85,10 +85,7 @@ def format_conversation_with_tools(
     if system_prompt:
         system_content = system_prompt
     else:
-        system_content = (
-            "You are a helpful assistant that solves "
-            "mathematical problems step by step."
-        )
+        system_content = "You are a helpful assistant that solves " "mathematical problems step by step."
 
     messages_to_render.append({"role": "system", "content": system_content})
 
@@ -283,11 +280,15 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
     if verbose:
         _sep = "═" * _LOG_WIDTH
         _prompt_display = (
-            "".join(m.get("content", "") for m in sample.prompt)
-            if isinstance(sample.prompt, list)
-            else sample.prompt
+            "".join(m.get("content", "") for m in sample.prompt) if isinstance(sample.prompt, list) else sample.prompt
         )
-        logger.debug("\n%s\n[ReTool LOG] prompt (%d tokens): %s\n%s", _sep, len(prompt_tokens_ids), _trunc(_prompt_display, 200), _sep)
+        logger.debug(
+            "\n%s\n[ReTool LOG] prompt (%d tokens): %s\n%s",
+            _sep,
+            len(prompt_tokens_ids),
+            _trunc(_prompt_display, 200),
+            _sep,
+        )
 
     # Add stop tags to sampling_params so the engine stops at tool/answer boundaries.
     # This is critical for keeping token/logp alignment when RETURN_LOGPROB is enabled.
@@ -330,7 +331,7 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
             "token_ids": current_token_ids,
             "sampling_params": current_inference_params,
         }
-        if hasattr(args, 'hf_checkpoint'):
+        if hasattr(args, "hf_checkpoint"):
             payload["model"] = args.hf_checkpoint
 
         # Log payload to wandb for debugging
@@ -371,7 +372,11 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
         # Decode text from token_ids
         skip_sp = current_inference_params.get("skip_special_tokens")
         skip_decode = True if skip_sp is None else bool(skip_sp)
-        cur_response = state.tokenizer.decode(cur_response_token_ids, skip_special_tokens=skip_decode) if cur_response_token_ids else ""
+        cur_response = (
+            state.tokenizer.decode(cur_response_token_ids, skip_special_tokens=skip_decode)
+            if cur_response_token_ids
+            else ""
+        )
 
         # Extract log probs if enabled
         if RETURN_LOGPROB:
@@ -402,7 +407,14 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
         # verbose: show what the model generated this turn
         if verbose:
             n_tok = len(cur_response_token_ids)
-            logger.debug("\n%s\n[Turn %d] model output (%d tok, finish=%s):\n  %s", "─" * _LOG_WIDTH, turn + 1, n_tok, finish_reason, _trunc(cur_response).replace("\n", "\n  "))
+            logger.debug(
+                "\n%s\n[Turn %d] model output (%d tok, finish=%s):\n  %s",
+                "─" * _LOG_WIDTH,
+                turn + 1,
+                n_tok,
+                finish_reason,
+                _trunc(cur_response).replace("\n", "\n  "),
+            )
 
         # Check length limit
         if finish_reason == "length":
@@ -471,10 +483,11 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
 
     if verbose:
         logger.debug(
-            "\n%s\n[ReTool LOG] finished | tool_calls=%d | "
-            "response_tokens=%d | finish=%s\n%s",
-            "═" * _LOG_WIDTH, tool_call_count,
-            len(response_token_ids), finish_reason,
+            "\n%s\n[ReTool LOG] finished | tool_calls=%d | " "response_tokens=%d | finish=%s\n%s",
+            "═" * _LOG_WIDTH,
+            tool_call_count,
+            len(response_token_ids),
+            finish_reason,
             "═" * _LOG_WIDTH,
         )
 

--- a/examples/retool/generate_with_retool.py
+++ b/examples/retool/generate_with_retool.py
@@ -56,7 +56,7 @@ You are a helpful assistant.
 # Tools
 
 You can write Python code to solve problems. Put your code between <code> and </code> tags. The code will be executed and you will see the output.
-When you have the final answer, write it as: Answer: \\boxed{your_answer}
+When you have the final answer, write it as: Answer: \boxed{your_answer}
 {%- endif %}
 <|im_end|>
 {%- for message in messages %}

--- a/examples/retool/requirements.txt
+++ b/examples/retool/requirements.txt
@@ -1,0 +1,3 @@
+jinja2>=3.0.0
+psutil>=5.8.0
+pytest>=7.0.0

--- a/examples/retool/retool_qwen3_4b_rl.sh
+++ b/examples/retool/retool_qwen3_4b_rl.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+set -ex
+ulimit -u 65535
+
+# cleanup
+pkill -9 -f "vllm serve" 2>/dev/null || true
+sleep 2
+npu-smi info 2>/dev/null | grep rayWorker | awk '{print $4}' | xargs -r kill -9 2>/dev/null || true
+sleep 3
+
+# Ray isolation: independent temp-dir, ports, and cleanup
+export RAY_TMPDIR=/tmp/ray_vime_npu_retool
+export RAY_PORT=6379
+export RAY_DASHBOARD_PORT=8265
+export RAY_AGENT_PORT=52378
+unset RAY_ADDRESS RAY_REDIS_ADDRESS
+
+ray stop --force 2>/dev/null || true
+rm -rf "${RAY_TMPDIR}"
+sleep 2
+
+project_name="vime"
+exp_name="qwen3-4b-retool-rl"
+RAY_DATA_HOME=${RAY_DATA_HOME:-"/root/logs"}
+start_time=$(date +"%Y%m%d_%H%M%S")
+LOG_DIR=${LOG_DIR:-"${RAY_DATA_HOME}/${project_name}/${exp_name}"}
+mkdir -p "${LOG_DIR}"
+LOG_FILE="${LOG_DIR}/${start_time}.log"
+
+echo "Experiment Log will be saved to: ${LOG_FILE}"
+VIME_DIR="/root/vime"
+
+# NPU environment
+source /usr/local/Ascend/driver/bin/setenv.bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+export PYTHONPATH="${VIME_DIR}:${VIME_DIR}/examples/retool:/root/Megatron-LM:/root/vllm:/root/vllm-ascend:/root/Megatron-Bridge:/root/mbridge:/root/MindSpeed:/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:/usr/local/Ascend/ascend-toolkit/latest/tools/ms_fmk_transplt/torch_npu_bridge:${PYTHONPATH}"
+export PYTHONUNBUFFERED=1
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:False
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+export HCCL_HOST_SOCKET_PORT_RANGE=60000-60050
+export HCCL_NPU_SOCKET_PORT_RANGE=61000-61050
+export HCCL_CONNECT_TIMEOUT=7200
+export HCCL_DETERMINISTIC=true
+export VLLM_ASCEND_ENABLE_NZ=0
+export ASCEND_COREDUMP_SIGNAL=None
+export ATB_MATMUL_SHUFFLE_K_ENABLE=0
+export ATB_LLM_LCOC_ENABLE=0
+export TASK_QUEUE_ENABLE=1
+export RAY_DISABLE_SIGINT_OVERRIDE=1
+export RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1
+export LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64:/usr/local/Ascend/ascend-toolkit/latest/lib64:/usr/local/Ascend/nnal/atb/latest/atb/cxx_abi_1/lib:/usr/local/Ascend/cann/lib64:${LD_LIBRARY_PATH}
+export VLLM_DISABLE_COMPILE_CACHE=1
+export TRANSFORMERS_VERBOSITY=error
+export RUST_LOG=vllm_router_rs=warn
+
+NUM_NPUS=16
+source "${VIME_DIR}/scripts/models/qwen3-4B-Instruct-2507.sh"
+
+CKPT_ARGS=(
+   --hf-checkpoint /path/to/Qwen3-4B_sft_vime_hf
+   --ref-load /path/to/Qwen3-4B_sft_vime_hf
+   --load /path/to/Qwen3-4B_vime_npu/
+   --save /path/to/Qwen3-4B_vime_npu/
+   --save-interval 20
+   --no-load-optim
+   --megatron-to-hf-mode bridge
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data /path/to/dapo-math-17k/dapo-math-17k.jsonl
+   --input-key prompt
+   --label-key label
+   --apply-chat-template
+   --rollout-shuffle
+   --reward-key score
+   --num-rollout 200
+   --rollout-batch-size 32
+   --n-samples-per-prompt 8
+   --rollout-max-response-len 8192
+   --rollout-temperature 1
+   --global-batch-size 256
+   --balance-data
+)
+
+EVAL_ARGS=(
+   --eval-interval 50
+   --eval-prompt-data aime /path/to/aime-2024/aime-2024.jsonl
+   --n-samples-per-eval-prompt 16
+   --eval-max-response-len 16384
+   --eval-top-p 1
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 4
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   --micro-batch-size 1
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 9216
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --use-kl-loss
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+VLLM_ARGS=(
+   --rollout-num-gpus-per-engine 4
+   --vllm-gpu-memory-utilization 0.7
+   --vllm-enable-sleep-mode
+   --vllm-weight-sync-mode native
+   --vllm-max-model-len 16384
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+   --use-flash-attn
+)
+
+CUSTOM_ARGS=(
+   --custom-generate-function-path generate_with_retool.generate
+   --custom-rm-path generate_with_retool.reward_func
+)
+
+# launch the master node of ray in container
+unset https_proxy http_proxy proxy
+ray start --head \
+	--temp-dir="${RAY_TMPDIR}" \
+	--port="${RAY_PORT}" \
+	--dashboard-port="${RAY_DASHBOARD_PORT}" \
+	--dashboard-agent-listen-port="${RAY_AGENT_PORT}" \
+	--node-ip-address 127.0.0.1 \
+	--num-gpus 0 \
+	--resources "{\"NPU\": $NUM_NPUS}" \
+	--disable-usage-stats \
+	--dashboard-host=0.0.0.0
+
+# Build the runtime environment JSON with proper variable substitution
+RUNTIME_ENV_JSON=$(cat << 'EOF'
+{
+  "env_vars": {
+    "PYTHONPATH": "${VIME_DIR}:${VIME_DIR}/examples/retool:/root/Megatron-LM:/root/vllm:/root/vllm-ascend:/root/Megatron-Bridge:/root/mbridge:/root/MindSpeed:/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:/usr/local/Ascend/ascend-toolkit/latest/tools/ms_fmk_transplt/torch_npu_bridge",
+    "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+    "HCCL_HOST_SOCKET_PORT_RANGE": "60000-60050",
+    "HCCL_NPU_SOCKET_PORT_RANGE": "61000-61050",
+    "HCCL_CONNECT_TIMEOUT": "7200",
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:False",
+    "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES": "1",
+    "VLLM_DISABLE_COMPILE_CACHE": "1",
+    "TRANSFORMERS_VERBOSITY": "error",
+    "RUST_LOG": "vllm_router_rs=warn",
+    "LD_LIBRARY_PATH": "/usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64/driver:/usr/local/Ascend/driver/lib64/common:/usr/local/Ascend/ascend-toolkit/latest/lib64:/usr/local/Ascend/ascend-toolkit/latest/compiler/lib64/plugin/opskernel:/usr/local/Ascend/ascend-toolkit/latest/compiler/lib64/plugin/nnengine:/usr/local/Ascend/ascend-toolkit/latest/opp/built-in/op_impl/ai_core/tbe/op_tiling/lib/:/usr/local/Ascend/nnal/atb/latest/atb/cxx_abi_1/lib:/usr/local/Ascend/cann/lib64:/usr/local/Ascend/cann/aarch64-linux/devlib"
+  }
+}
+EOF
+)
+
+ray job submit --address="http://127.0.0.1:${RAY_DASHBOARD_PORT}" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   --working-dir="${VIME_DIR}" \
+   -- python3 -u train.py \
+   --train-backend megatron \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node 8 \
+   --rollout-num-gpus 8 \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${VLLM_ARGS[@]} \
+   ${MISC_ARGS[@]} \
+   ${CUSTOM_ARGS[@]} \
+   2>&1 | tee "${LOG_FILE}"

--- a/examples/retool/retool_qwen3_4b_sft.sh
+++ b/examples/retool/retool_qwen3_4b_sft.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+set -ex
+ulimit -u 65535
+
+# cleanup
+pkill -9 -f "vllm serve" 2>/dev/null || true
+sleep 2
+npu-smi info 2>/dev/null | grep rayWorker | awk '{print $4}' | xargs -r kill -9 2>/dev/null || true
+sleep 3
+
+# Ray isolation: independent temp-dir, ports, and cleanup
+export RAY_TMPDIR=/tmp/ray_vime_npu_retool
+export RAY_PORT=6379
+export RAY_DASHBOARD_PORT=8265
+export RAY_AGENT_PORT=52378
+unset RAY_ADDRESS RAY_REDIS_ADDRESS
+
+ray stop --force 2>/dev/null || true
+rm -rf "${RAY_TMPDIR}"
+sleep 2
+
+project_name="vime"
+exp_name="qwen3-4b-retool-sft"
+RAY_DATA_HOME=${RAY_DATA_HOME:-"/root/logs"}
+start_time=$(date +"%Y%m%d_%H%M%S")
+LOG_DIR=${LOG_DIR:-"${RAY_DATA_HOME}/${project_name}/${exp_name}"}
+mkdir -p "${LOG_DIR}"
+LOG_FILE="${LOG_DIR}/${start_time}.log"
+
+echo "Experiment Log will be saved to: ${LOG_FILE}"
+VIME_DIR="/root/vime"
+
+# NPU environment
+source /usr/local/Ascend/driver/bin/setenv.bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+export PYTHONPATH="${VIME_DIR}:${VIME_DIR}/examples/retool:/root/Megatron-LM:/root/vllm:/root/vllm-ascend:/root/Megatron-Bridge:/root/mbridge:/root/MindSpeed:/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:/usr/local/Ascend/ascend-toolkit/latest/tools/ms_fmk_transplt/torch_npu_bridge:${PYTHONPATH}"
+export PYTHONUNBUFFERED=1
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:False
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+export HCCL_HOST_SOCKET_PORT_RANGE=60000-60050
+export HCCL_NPU_SOCKET_PORT_RANGE=61000-61050
+export HCCL_CONNECT_TIMEOUT=7200
+export HCCL_DETERMINISTIC=true
+export VLLM_ASCEND_ENABLE_NZ=0
+export ASCEND_COREDUMP_SIGNAL=None
+export ATB_MATMUL_SHUFFLE_K_ENABLE=0
+export ATB_LLM_LCOC_ENABLE=0
+export TASK_QUEUE_ENABLE=1
+export RAY_DISABLE_SIGINT_OVERRIDE=1
+export RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1
+export LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64:/usr/local/Ascend/ascend-toolkit/latest/lib64:/usr/local/Ascend/nnal/atb/latest/atb/cxx_abi_1/lib:/usr/local/Ascend/cann/lib64:${LD_LIBRARY_PATH}
+export VLLM_DISABLE_COMPILE_CACHE=1
+export RUST_LOG=vllm_router_rs=warn
+export TRANSFORMERS_VERBOSITY=error
+
+NUM_NPUS=16
+source "${VIME_DIR}/scripts/models/qwen3-4B-Instruct-2507.sh"
+
+CKPT_ARGS=(
+   --hf-checkpoint /path/to/Qwen3-4B-Instruct-2507
+   --ref-load /path/to/Qwen3-4B-Instruct-2507
+   --save /path/to/Qwen3-4B_sft_vime/
+   --save-interval 1000
+   --save-hf /path/to/Qwen3-4B_sft_vime_hf/
+   --no-load-optim
+   --megatron-to-hf-mode bridge
+)
+
+SFT_ARGS=(
+   --rollout-function-path vime.rollout.sft_rollout.generate_rollout
+   --prompt-data /path/to/ReTool-SFT/ReTool-SFT.parquet
+   --input-key messages
+   --rollout-shuffle
+   --num-epoch 3
+   --rollout-batch-size 128
+   --global-batch-size 128
+   --loss-type sft_loss
+   --calculate-per-token-loss
+   --disable-compute-advantages-and-returns
+   --debug-train-only
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 4
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   --micro-batch-size 1
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 9216
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-5
+   --lr-decay-style cosine
+   --min-lr 1e-6
+   --lr-warmup-fraction 0.1
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.95
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+   --use-flash-attn
+)
+
+# launch the master node of ray in container
+unset https_proxy http_proxy proxy
+ray start --head \
+	--temp-dir="${RAY_TMPDIR}" \
+	--port="${RAY_PORT}" \
+	--dashboard-port="${RAY_DASHBOARD_PORT}" \
+	--dashboard-agent-listen-port="${RAY_AGENT_PORT}" \
+	--node-ip-address 127.0.0.1 \
+	--num-gpus 0 \
+	--resources "{\"NPU\": $NUM_NPUS}" \
+	--disable-usage-stats \
+	--dashboard-host=0.0.0.0
+
+# Build the runtime environment JSON with proper variable substitution
+RUNTIME_ENV_JSON=$(cat << 'EOF'
+{
+  "env_vars": {
+    "PYTHONPATH": "${VIME_DIR}:${VIME_DIR}/examples/retool:/root/Megatron-LM:/root/vllm:/root/vllm-ascend:/root/Megatron-Bridge:/root/mbridge:/root/MindSpeed:/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:/usr/local/Ascend/ascend-toolkit/latest/tools/ms_fmk_transplt/torch_npu_bridge",
+    "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+    "HCCL_HOST_SOCKET_PORT_RANGE": "60000-60050",
+    "HCCL_NPU_SOCKET_PORT_RANGE": "61000-61050",
+    "HCCL_CONNECT_TIMEOUT": "7200",
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:False",
+    "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES": "1",
+    "VLLM_DISABLE_COMPILE_CACHE": "1",
+    "TRANSFORMERS_VERBOSITY": "error",
+    "RUST_LOG": "vllm_router_rs=warn",
+    "LD_LIBRARY_PATH": "/usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64/driver:/usr/local/Ascend/driver/lib64/common:/usr/local/Ascend/ascend-toolkit/latest/lib64:/usr/local/Ascend/ascend-toolkit/latest/compiler/lib64/plugin/opskernel:/usr/local/Ascend/ascend-toolkit/latest/compiler/lib64/plugin/nnengine:/usr/local/Ascend/ascend-toolkit/latest/opp/built-in/op_impl/ai_core/tbe/op_tiling/lib/:/usr/local/Ascend/nnal/atb/latest/atb/cxx_abi_1/lib:/usr/local/Ascend/cann/lib64:/usr/local/Ascend/cann/aarch64-linux/devlib"
+  }
+}
+EOF
+)
+
+ray job submit --address="http://127.0.0.1:${RAY_DASHBOARD_PORT}" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   --working-dir="${VIME_DIR}" \
+   -- python3 -u train.py \
+   --train-backend megatron \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node 16 \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${SFT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${MISC_ARGS[@]} \
+   2>&1 | tee "${LOG_FILE}"

--- a/examples/retool/rl_data_preprocess.py
+++ b/examples/retool/rl_data_preprocess.py
@@ -1,0 +1,21 @@
+from datasets import load_dataset
+
+# Load the original dataset
+ds = load_dataset("BytedTsinghua-SIA/DAPO-Math-17k", split="train")
+
+
+# Map to extract the ground_truth from the reward_model dict and create a new 'label' field
+def transform(example):
+    return {
+        "prompt": example["prompt"][0]["content"] if example["prompt"] else None,
+        "label": example["reward_model"]["ground_truth"],
+    }
+
+
+ds2 = ds.map(transform, remove_columns=ds.column_names)
+
+# Optionally, verify the first few entries
+print(ds2[0])
+
+# save to jsonl
+ds2.to_json("/path/to/dapo-math-17k/dapo-math-17k.jsonl", orient="records", lines=True)

--- a/examples/retool/sft_data_processing.py
+++ b/examples/retool/sft_data_processing.py
@@ -1,0 +1,31 @@
+from datasets import load_dataset
+
+ds = load_dataset("/path/to/ReTool-SFT")["train"]
+
+
+def convert(sample):
+    conversations = sample["messages"]
+
+    def convert_role(role):
+        if role == "user":
+            return "user"
+        elif role == "assistant":
+            return "assistant"
+        elif role == "system":
+            return "system"
+        else:
+            raise ValueError(f"Unknown role: {role}")
+
+    messages = [
+        {
+            "role": convert_role(turn["role"]),
+            "content": turn["content"],
+        }
+        for turn in conversations
+    ]
+
+    return {"messages": messages}
+
+
+ds = ds.map(convert)
+ds.to_parquet("/path/to/ReTool-SFT/ReTool-SFT.parquet")

--- a/examples/retool/tool_sandbox.py
+++ b/examples/retool/tool_sandbox.py
@@ -1,0 +1,367 @@
+"""
+Tool sandbox module for safe code execution and tool management.
+
+This module provides:
+- PythonSandbox: Safe Python code execution environment
+- ToolRegistry: Tool registration and execution management
+- Memory management utilities
+"""
+
+import asyncio
+import gc
+import os
+import re
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from typing import Any
+
+import psutil
+
+# Configuration for tool execution
+TOOL_CONFIGS = {
+    "max_turns": 4,
+    "max_tool_calls": 4,
+    "max_consecutive_memory_errors": 3,  # Break retry cycle after N consecutive memory errors
+    "tool_concurrency": 8,  # Conservative: avoid RSS pressure on RolloutManager
+    # Python interpreter settings
+    "python_timeout": 120,  # 2 minutes for complex calculations
+    "python_memory_limit": "4GB",  # 4GB per Python process
+    "python_cpu_limit": 1,
+    # Memory management settings
+    "max_memory_usage": 12288,  # 12GB total (75% of 16GB)
+    "cleanup_threshold": 6144,  # 6GB
+    "aggressive_cleanup_threshold": 3072,  # 3GB
+    "force_cleanup_threshold": 9216,  # 9GB
+}
+
+# Global semaphore for controlling concurrent tool executions
+SEMAPHORE = asyncio.Semaphore(TOOL_CONFIGS["tool_concurrency"])
+
+
+def get_memory_usage() -> float:
+    """Get current memory usage in MB"""
+    process = psutil.Process()
+    return process.memory_info().rss / 1024 / 1024
+
+
+def cleanup_memory():
+    """Force garbage collection to free memory"""
+    gc.collect()
+
+
+def aggressive_cleanup_memory():
+    """More aggressive memory cleanup"""
+    # Force multiple garbage collection cycles
+    for _ in range(3):
+        gc.collect()
+
+    # Force glibc to return freed memory to the OS.
+    # Without this, Python's allocator holds onto freed pages due to
+    # heap fragmentation, causing RSS to stay high even after gc.collect().
+    # Try multiple libc paths for compatibility across different Linux distros
+    # (including Ascend NPU servers).
+    for libc_path in ("libc.so.6", "libc.musl.so.1", "libc.so"):
+        try:
+            import ctypes
+
+            ctypes.CDLL(libc_path).malloc_trim(0)
+            break
+        except OSError:
+            continue
+
+
+def check_and_cleanup_memory():
+    """Check memory usage and perform appropriate cleanup"""
+    current_memory = get_memory_usage()
+
+    if current_memory > TOOL_CONFIGS["force_cleanup_threshold"]:
+        # Force aggressive cleanup
+        aggressive_cleanup_memory()
+        return f"Warning: High memory usage ({current_memory:.1f}MB), performed aggressive cleanup"
+    elif current_memory > TOOL_CONFIGS["cleanup_threshold"]:
+        # Normal cleanup
+        cleanup_memory()
+        return f"Info: Memory usage ({current_memory:.1f}MB), performed cleanup"
+    elif current_memory > TOOL_CONFIGS["aggressive_cleanup_threshold"]:
+        # Light cleanup
+        gc.collect()
+        return f"Info: Memory usage ({current_memory:.1f}MB), performed light cleanup"
+
+    return None
+
+
+class PythonSandbox:
+    """Python code sandbox, provides safe code execution environment"""
+
+    def __init__(self, timeout: int = 10, memory_limit: str = "100MB"):
+        self.timeout = timeout
+        self.memory_limit = memory_limit
+        self.allowed_modules = {
+            "math",
+            "random",
+            "datetime",
+            "collections",
+            "itertools",
+            "functools",
+            "operator",
+            "statistics",
+            "decimal",
+            "fractions",
+        }
+
+    def _check_code_safety(self, code: str) -> tuple[bool, str]:
+        """Check code safety by scanning for dangerous patterns"""
+        # Check for dangerous operations
+        dangerous_patterns = [
+            r"import\s+os",
+            r"import\s+sys",
+            r"import\s+subprocess",
+            r"import\s+shutil",
+            r"import\s+glob",
+            r"import\s+pathlib",
+            r"__import__",
+            r"eval\s*\(",
+            r"exec\s*\(",
+            r"open\s*\(",
+            r"file\s*\(",
+            r"input\s*\(",
+            r"raw_input\s*\(",
+            r"compile\s*\(",
+            r"execfile\s*\(",
+            r"getattr\s*\(",
+            r"setattr\s*\(",
+            r"delattr\s*\(",
+            r"hasattr\s*\(",
+            r"globals\s*\(",
+            r"locals\s*\(",
+            r"vars\s*\(",
+            r"dir\s*\(",
+            r"type\s*\(",
+            r"isinstance\s*\(",
+            r"issubclass\s*\(",
+            r"super\s*\(",
+            r"property\s*\(",
+            r"staticmethod\s*\(",
+            r"classmethod\s*\(",
+            r"__\w+__",  # double underscore methods
+        ]
+
+        for pattern in dangerous_patterns:
+            if re.search(pattern, code, re.IGNORECASE):
+                return False, f"Code contains dangerous pattern: {pattern}"
+
+        # Check imported modules
+        import_pattern = r"import\s+(\w+)"
+        from_pattern = r"from\s+(\w+)"
+
+        imports = re.findall(import_pattern, code)
+        froms = re.findall(from_pattern, code)
+
+        all_imports = set(imports + froms)
+        for imp in all_imports:
+            if imp not in self.allowed_modules:
+                return False, f"Import of '{imp}' is not allowed"
+
+        return True, "Code is safe"
+
+    @contextmanager
+    def _create_safe_environment(self):
+        """Create safe execution environment with temporary directory"""
+        # Create temporary directory
+        temp_dir = tempfile.mkdtemp(prefix="python_sandbox_")
+
+        try:
+            # Create safe Python script
+            script_path = os.path.join(temp_dir, "code.py")
+
+            # Set environment variables
+            env = os.environ.copy()
+            env["PYTHONPATH"] = temp_dir
+            env["PYTHONUNBUFFERED"] = "1"
+
+            yield script_path, env, temp_dir
+
+        finally:
+            # Clean up temporary directory
+            try:
+                import shutil
+
+                shutil.rmtree(temp_dir)
+            except Exception:
+                pass
+
+    async def execute_code(self, code: str) -> str:
+        """Execute Python code in sandbox with safety checks"""
+        # Check memory usage before execution
+        current_memory = get_memory_usage()
+        if current_memory > TOOL_CONFIGS["max_memory_usage"]:
+            aggressive_cleanup_memory()
+            # Re-check after cleanup — gc.collect + malloc_trim may free enough
+            current_memory = get_memory_usage()
+            if current_memory > TOOL_CONFIGS["max_memory_usage"]:
+                return "Error: Memory usage too high, please try again"
+
+        # Check code safety
+        is_safe, message = self._check_code_safety(code)
+        if not is_safe:
+            return f"Error: {message}"
+
+        # Add necessary wrapper code with memory limits
+        # Properly indent the user code within the try block
+        # Handle indentation properly by adding 4 spaces to each line
+        indented_code = "\n".join("    " + line for line in code.split("\n"))
+
+        wrapped_code = f"""import sys
+import traceback
+from io import StringIO
+import resource
+
+# Set memory limit (4GB)
+try:
+    resource.setrlimit(resource.RLIMIT_AS, (4 * 1024 * 1024 * 1024, -1))
+except Exception:
+    pass
+
+# Redirect stdout and stderr
+old_stdout = sys.stdout
+old_stderr = sys.stderr
+stdout_capture = StringIO()
+stderr_capture = StringIO()
+sys.stdout = stdout_capture
+sys.stderr = stderr_capture
+
+try:
+    # User code
+{indented_code}
+
+    # Get output
+    stdout_output = stdout_capture.getvalue()
+    stderr_output = stderr_capture.getvalue()
+
+    # Restore standard output
+    sys.stdout = old_stdout
+    sys.stderr = old_stderr
+
+    # Return result
+    result = ""
+    if stdout_output:
+        result += f"Output:\\n{{stdout_output}}"
+    if stderr_output:
+        result += f"\\nErrors:\\n{{stderr_output}}"
+
+    print(result)
+
+except Exception as e:
+    # Restore standard output
+    sys.stdout = old_stdout
+    sys.stderr = old_stderr
+
+    # Return error information
+    error_msg = f"Error: {{str(e)}}\\nTraceback:\\n{{traceback.format_exc()}}"
+    print(error_msg)"""
+
+        with self._create_safe_environment() as (script_path, env, temp_dir):
+            # Write code to file
+            with open(script_path, "w") as f:
+                f.write(wrapped_code)
+
+            try:
+                # Use subprocess to run code
+                process = subprocess.Popen(
+                    ["python3", script_path],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    env=env,
+                    cwd=temp_dir,
+                    text=True,
+                )
+
+                # Set timeout
+                try:
+                    stdout, stderr = process.communicate(timeout=self.timeout)
+
+                    if process.returncode == 0:
+                        result = stdout.strip()
+                    else:
+                        result = f"Error: Process exited with code {process.returncode}\n{stderr}"
+
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    result = f"Error: Code execution timed out after {self.timeout} seconds"
+
+                # Explicitly release subprocess resources to reduce RSS
+                del process
+
+            except Exception as e:
+                result = f"Error: Failed to execute code: {str(e)}"
+
+            # Check memory usage after execution and cleanup if needed
+            cleanup_message = check_and_cleanup_memory()
+            if cleanup_message:
+                print(f"Memory cleanup: {cleanup_message}")
+
+            return result
+
+
+class ToolRegistry:
+    """Tool registry, manages available tools and their execution"""
+
+    def __init__(self):
+        self.tools = {}
+        self.python_sandbox = PythonSandbox(
+            timeout=TOOL_CONFIGS["python_timeout"], memory_limit=TOOL_CONFIGS["python_memory_limit"]
+        )
+        self._register_default_tools()
+
+    def _register_default_tools(self):
+        """Register default tools in the registry"""
+        # Python code interpreter
+        self.register_tool(
+            "code_interpreter",
+            {
+                "type": "function",
+                "function": {
+                    "name": "code_interpreter",
+                    "description": "A tool for executing Python code in a safe sandbox environment.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"code": {"type": "string", "description": "The Python code to execute"}},
+                        "required": ["code"],
+                    },
+                },
+            },
+        )
+
+    def register_tool(self, name: str, tool_spec: dict[str, Any]):
+        """Register a new tool in the registry"""
+        self.tools[name] = tool_spec
+
+    def get_tool_specs(self) -> list[dict[str, Any]]:
+        """Get all tool specifications as a list"""
+        return list(self.tools.values())
+
+    async def execute_tool(self, tool_name: str, arguments: dict[str, Any]) -> str:
+        """Execute a tool call with the given arguments"""
+        if tool_name not in self.tools:
+            return f"Error: Tool '{tool_name}' not found"
+
+        async with SEMAPHORE:
+            if tool_name == "code_interpreter":
+                return await self._execute_python(arguments)
+            else:
+                return f"Error: Tool '{tool_name}' not implemented"
+
+    async def _execute_python(self, arguments: dict[str, Any]) -> str:
+        """Execute Python code using the sandbox"""
+        code = arguments.get("code", "")
+        if not code.strip():
+            return "Error: No code provided"
+
+        # Execute code in sandbox
+        result = await self.python_sandbox.execute_code(code)
+        return result
+
+
+# Global tool registry instance
+tool_registry = ToolRegistry()


### PR DESCRIPTION
# ReTool: from SFT to RL

This example is ported from [slime](https://github.com/THUDM/slime) (Megatron + SGLang) and adapted for vime (Megatron + vLLM). It demonstrates a complete SFT→RL pipeline for tool-augmented mathematical reasoning, where the model learns to write and execute Python code inside a sandbox to solve math problems.

## Overview

The ReTool example provides:

- **Sandboxed Python code execution** with safety checks, memory limits, and timeout controls
- **Multi-turn tool-calling workflow**: the model generates `<code>...</code>`, receives `<interpreter>...</interpreter>` output, and iterates until it produces `Answer: \boxed{...}`
- **SFT warm-start** on ReTool-SFT data, followed by **GRPO-based RL training** with DAPO-Math-17K
- **Tool-aware reward shaping** that encourages early exploration of tool use while ensuring correctness dominates as training progresses
- **Memory management** with automatic cleanup, aggressive gc + `malloc_trim`, and consecutive-memory-error loop breaking

## Files

| File | Description |
|------|-------------|
| `generate_with_retool.py` | Main generation function with multi-turn code-interpreter tool-calling, and reward function |
| `tool_sandbox.py` | Sandboxed Python executor with safety checks, memory management, and tool registry |
| `sft_data_processing.py` | Convert ReTool-SFT dataset to parquet format |
| `retool_qwen3_4b_sft.sh` | SFT launch script (NPU 16-card, Qwen3-4B-Instruct-2507) |
| `retool_qwen3_4b_rl.sh` | RL launch script (NPU 16-card, Qwen3-4B-Instruct-2507, GRPO) |

## Reward Design

The RL reward function (`generate_with_retool.reward_func`) uses a **tool-aware reward shaping** strategy on top of the math accuracy reward:

| Answer | Tool Used | Reward | Rationale |
|--------|-----------|--------|-----------|
| ✅ Correct | No | 1.0 | Pure reasoning — the ideal case |
| ✅ Correct | Yes | 1.0 + min(0.2, turns × 0.05) | Bonus for effective tool use (capped at 0.2) |
| ❌ Wrong | No | 0.0 | Neutral — model didn't attempt tools |
| ❌ Wrong | Yes | min(0.1, turns × 0.02) | Small positive to encourage exploration |

This design encourages the model to **explore tool calling** during early RL training without letting it reward-hack by preferring tool calls over correct answers. As training progresses and accuracy improves, the accuracy reward dominates and the tool bonus becomes a tiebreaker.

## Results

> The evaluation curves below are measured on the **aime-2024** dataset using the **`generate_with_retool.reward_func`** metric for final boxed answers.

<img width="647" height="351" alt="reward" src="https://github.com/user-attachments/assets/e444c8cb-c591-4e63-8a9f-1443fa9ad21a" />
<img width="647" height="351" alt="diff" src="https://github.com/user-attachments/assets/a5e92063-7455-4235-ae8c-7ca9540c45db" />
<img width="647" height="351" alt="eval" src="https://github.com/user-attachments/assets/dab2c662-9a51-433c-a16b-52b2ea766f40" />

Closes #301 
