### PR TITLE
[Doc] Add Ascend NPU platform tutorial and expand hardware support section

### DIFF
--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -9,7 +9,11 @@ Since vime may contain temporary patches for vllm/megatron, to avoid potential e
 
 ### Hardware Support
 
-**vime** supports multiple NVIDIA GPU hardware platforms:
+**vime** supports multiple hardware platforms.
+
+**NVIDIA GPU**:
+
+Currently stable, production-ready hardware includes:
 
 - **GB200 / GB300 / B200 / 300 Series**: Fully supported with identical setup steps as H-series GPUs
 - **H-Series (H100/H200)**: Official support with comprehensive CI testing and stable performance
@@ -18,8 +22,18 @@ Since vime may contain temporary patches for vllm/megatron, to avoid potential e
 - Latest Docker images are compatible with both B-series and H-series GPUs without additional configuration
 - Megatron backend on H-series GPUs has CI protection, thoroughly validated, recommended for production environments
 - B-series basic functionality is stable and suitable for development/testing, but currently lacks CI protection
-- Both hardware platforms use identical installation and startup procedures
-- For AMD support, please refer to [AMD Usage Tutorial](../platform_support/amd_tutorial.md).
+- Both NVIDIA hardware platforms use identical installation and startup procedures
+- Other GPUs (e.g., A100/A800) may also run, but are not actively maintained
+
+
+**Ascend NPU**:
+
+- See [Ascend NPU Usage Tutorial](../platform_support/ascend_tutorial.md).
+- NPU scripts and patches live on the [ascend](https://github.com/vllm-project/vime/tree/ascend) branch.
+
+**AMD GPU**:
+
+See [AMD Usage Tutorial](../platform_support/amd_tutorial.md).
 
 ### Pull and Start Docker Container
 

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -66,3 +66,10 @@ vime is built on `slime <https://github.com/THUDM/slime>`_, the RL framework beh
    developer_guide/debug.md
    developer_guide/trace.md
    developer_guide/profiling.md
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Hardware Platforms
+
+   platform_support/amd_tutorial.md
+   platform_support/ascend_tutorial.md

--- a/docs/en/platform_support/ascend_tutorial.md
+++ b/docs/en/platform_support/ascend_tutorial.md
@@ -1,0 +1,143 @@
+# Ascend NPU Quick Start
+
+> **Branch notice:** Ascend NPU support is currently maintained on the [ascend](https://github.com/vllm-project/vime/tree/ascend)
+> branch (not yet on `main`), with plans to merge into `main` later.
+> Clone or checkout that branch before running any NPU examples below.
+
+⚠️ If you encounter problems running vime on Ascend NPU, feel free to open an
+issue on [vllm-project/vime](https://github.com/vllm-project/vime/issues).
+
+## Overview
+
+vime on Ascend NPU uses the **Megatron** training backend together with the
+**vLLM Ascend** rollout backend. In decoupled mode, actor weights sync to vLLM
+over HCCL; in colocate mode (`--colocate`), weights sync over NPU IPC.
+
+Current support targets Ascend **Atlas A2 / A3** (aarch64) hardware.
+
+## Get the Ascend Branch
+
+```bash
+git clone --branch ascend https://github.com/vllm-project/vime.git
+cd vime
+```
+
+If you already have the repo:
+
+```bash
+git fetch origin ascend
+git checkout ascend
+```
+
+## Ascend Branch Resources
+
+| Resource | Description |
+| -------- | ----------- |
+| [docs/en/get_started/NPU.md](https://github.com/vllm-project/vime/blob/ascend/docs/en/get_started/NPU.md) | Full NPU guide with end-to-end GRPO example and training flags |
+| [docker/npu_patch/README.md](https://github.com/vllm-project/vime/blob/ascend/docker/npu_patch/README.md) | Source-build guide, pinned commits, and patch list |
+| [scripts/run-qwen3-4B-npu.sh](https://github.com/vllm-project/vime/blob/ascend/scripts/run-qwen3-4B-npu.sh) | Qwen3-4B decoupled training (4 actor + 4 rollout NPUs) |
+| [scripts/run-qwen3-30B-A3B-npu.sh](https://github.com/vllm-project/vime/blob/ascend/scripts/run-qwen3-30B-A3B-npu.sh) | Qwen3-30B-A3B MoE NPU training script |
+| [scripts/models/qwen3-30B-A3B-npu.sh](https://github.com/vllm-project/vime/blob/ascend/scripts/models/qwen3-30B-A3B-npu.sh) | Model args for Qwen3-30B-A3B on NPU |
+
+## Basic Environment Setup
+
+### Docker Image
+
+The recommended path for validation is the published vime NPU image:
+
+```bash
+export IMAGE=quay.io/ascend/vime:vime-latest
+# A2: export IMAGE=quay.io/ascend/vime:vime-a2-latest
+
+docker pull "${IMAGE}"
+```
+
+For source builds and dependency debugging, follow
+[docker/npu_patch/README.md](https://github.com/vllm-project/vime/blob/ascend/docker/npu_patch/README.md)
+on the `ascend` branch.
+
+### Pull and Start Docker Container
+
+Start the container with Ascend devices and driver files mounted. Device names
+and mount paths vary by host; reuse the mounts from a known working vLLM Ascend
+container if the layout differs.
+
+```bash
+docker run -d --name vime-npu -it --net=host --shm-size=1024g \
+    --privileged=true \
+    --cap-add=SYS_PTRACE \
+    --device=/dev/davinci_manager \
+    --device=/dev/hisi_hdc \
+    --device=/dev/devmm_svm \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/sbin:/usr/local/sbin \
+    -v /home:/home \
+    -v /mnt:/mnt \
+    -v /tmp:/tmp \
+    -v /data:/data \
+    -v /path/to:/path/to \
+    -v /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime \
+    "${IMAGE}"
+
+docker exec -it vime-npu bash
+```
+
+Inside the container, initialize the CANN environment before training:
+
+```bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+```
+
+## Model and Dataset Download
+
+```bash
+export MODEL_ROOT=/root
+mkdir -p ${MODEL_ROOT}/models ${MODEL_ROOT}/datasets
+
+# Model weights (Qwen3-4B)
+hf download Qwen/Qwen3-4B --local-dir ${MODEL_ROOT}/models/Qwen3-4B
+
+# Training dataset (dapo-math-17k)
+hf download --repo-type dataset zhuzilin/dapo-math-17k \
+  --local-dir ${MODEL_ROOT}/datasets/dapo-math-17k
+```
+
+## Training (Qwen3-4B Example)
+
+After checking out the `ascend` branch inside the container, run the bundled
+script:
+
+```bash
+cd /root/vime
+
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+
+MODEL_ROOT=/root bash scripts/run-qwen3-4B-npu.sh
+```
+
+The full log is written to `/root/vime/train_qwen3_4b_vllm.log`.
+
+> **Note:** The main difference from the NVIDIA workflow is Ascend-specific
+> environment variables — use `ASCEND_RT_VISIBLE_DEVICES` instead of
+> `CUDA_VISIBLE_DEVICES`, and set
+> `RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1` so Ray schedules NPUs
+> correctly. The reference script targets an Atlas A3 host with 16 visible NPUs;
+> on an 8-NPU host, set `ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7`.
+
+For the full training command, HCCL port ranges, and flag explanations, see
+[NPU.md on the ascend branch](https://github.com/vllm-project/vime/blob/ascend/docs/en/get_started/NPU.md).
+
+## MoE Example (Qwen3-30B-A3B)
+
+For the MoE model on NPU, use the scripts on the `ascend` branch:
+
+```bash
+bash scripts/run-qwen3-30B-A3B-npu.sh
+```
+
+See [scripts/models/qwen3-30B-A3B-npu.sh](https://github.com/vllm-project/vime/blob/ascend/scripts/models/qwen3-30B-A3B-npu.sh)
+for model-specific arguments.

--- a/docs/zh/get_started/quick_start.md
+++ b/docs/zh/get_started/quick_start.md
@@ -8,7 +8,11 @@
 
 ### 硬件支持说明
 
-**vime** 支持多种 NVIDIA GPU 硬件平台：
+**vime** 支持多种硬件平台。
+
+**NVIDIA GPU**：
+
+为目前稳定支持的硬件，包括：
 
 - **GB200 / GB300 / B200 / 300 系列**：完全支持，运行步骤与 H 系列完全相同
 - **H 系列 (H100/H200)**：官方支持，具有完整的 CI 测试保护，运行稳定可靠
@@ -17,8 +21,18 @@
 - 最新的 Docker 镜像对 B 卡和 H 卡通用，无需额外配置
 - Megatron 后端在 H 卡上具有 CI 保护，经过充分测试验证，推荐生产环境使用
 - B 卡基本功能稳定，可作为开发和测试参考，但暂无 CI 保护
-- 两种硬件平台使用完全相同的安装和启动流程
-- 对于 AMD 支持，请参考 [AMD 使用教程](../../en/platform_support/amd_tutorial.md)。
+- 两种 NVIDIA 硬件平台使用完全相同的安装和启动流程
+- 其它卡（如A100/A800）也可以运行，但暂不进行功能维护
+
+
+**Ascend NPU**：
+
+- 使用说明请参考 [Ascend NPU 教程](../platform_support/ascend_tutorial.md)。
+- NPU 脚本与 patch 位于 [ascend](https://github.com/vllm-project/vime/tree/ascend) 分支。
+
+**AMD GPU**：
+
+请参考 [AMD 使用教程](../../en/platform_support/amd_tutorial.md)。
 
 ### 拉取并启动 Docker 容器
 

--- a/docs/zh/index.rst
+++ b/docs/zh/index.rst
@@ -66,3 +66,9 @@ vime 构建于 `slime <https://github.com/THUDM/slime>`_ 之上，slime 正是 G
    developer_guide/debug.md
    developer_guide/trace.md
    developer_guide/profiling.md
+
+.. toctree::
+   :maxdepth: 1
+   :caption: 硬件平台
+
+   platform_support/ascend_tutorial.md

--- a/docs/zh/platform_support/ascend_tutorial.md
+++ b/docs/zh/platform_support/ascend_tutorial.md
@@ -1,0 +1,137 @@
+# Ascend NPU 快速上手
+
+> **分支说明：** Ascend NPU 支持目前维护在 [ascend](https://github.com/vllm-project/vime/tree/ascend)
+> 分支（尚未合入 `main`），后续有计划将其合并至 `main`。
+> 运行下文任何 NPU 示例前，请先 clone 或 checkout 该分支。
+
+⚠️ 如在 Ascend NPU 上运行 vime 遇到问题，欢迎在
+[vllm-project/vime](https://github.com/vllm-project/vime/issues) 提交 Issue。
+
+## 概述
+
+vime 在 Ascend NPU 上使用 **Megatron** 训练后端与 **vLLM Ascend** rollout 后端。
+解耦模式下 actor 权重经 HCCL 同步到 vLLM；colocate 模式（`--colocate`）下经 NPU IPC 同步。
+
+当前支持 Ascend **Atlas A2 / A3**（aarch64）硬件。
+
+## 获取 ascend 分支
+
+```bash
+git clone --branch ascend https://github.com/vllm-project/vime.git
+cd vime
+```
+
+若已有仓库：
+
+```bash
+git fetch origin ascend
+git checkout ascend
+```
+
+## ascend 分支资源索引
+
+| 资源 | 说明 |
+| ---- | ---- |
+| [docs/en/get_started/NPU.md](https://github.com/vllm-project/vime/blob/ascend/docs/en/get_started/NPU.md) | 完整 NPU 指南，含 GRPO 端到端示例与训练参数 |
+| [docker/npu_patch/README.md](https://github.com/vllm-project/vime/blob/ascend/docker/npu_patch/README.md) | 源码构建、依赖版本与 patch 列表 |
+| [scripts/run-qwen3-4B-npu.sh](https://github.com/vllm-project/vime/blob/ascend/scripts/run-qwen3-4B-npu.sh) | Qwen3-4B 解耦训练（4 actor + 4 rollout NPU） |
+| [scripts/run-qwen3-30B-A3B-npu.sh](https://github.com/vllm-project/vime/blob/ascend/scripts/run-qwen3-30B-A3B-npu.sh) | Qwen3-30B-A3B MoE NPU 训练脚本 |
+| [scripts/models/qwen3-30B-A3B-npu.sh](https://github.com/vllm-project/vime/blob/ascend/scripts/models/qwen3-30B-A3B-npu.sh) | Qwen3-30B-A3B NPU 模型参数 |
+
+## 基础环境
+
+### Docker 镜像
+
+推荐使用已发布的 vime NPU 镜像：
+
+```bash
+export IMAGE=quay.io/ascend/vime:vime-latest
+# A2: export IMAGE=quay.io/ascend/vime:vime-a2-latest
+
+docker pull "${IMAGE}"
+```
+
+源码构建与依赖调试请参考 `ascend` 分支上的
+[docker/npu_patch/README.md](https://github.com/vllm-project/vime/blob/ascend/docker/npu_patch/README.md)。
+
+### 拉取并启动容器
+
+挂载 Ascend 设备与驱动文件后启动容器。设备名与挂载路径因主机而异，可参考已跑通的 vLLM Ascend 容器配置。
+
+```bash
+docker run -d --name vime-npu -it --net=host --shm-size=1024g \
+    --privileged=true \
+    --cap-add=SYS_PTRACE \
+    --device=/dev/davinci_manager \
+    --device=/dev/hisi_hdc \
+    --device=/dev/devmm_svm \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/sbin:/usr/local/sbin \
+    -v /home:/home \
+    -v /mnt:/mnt \
+    -v /tmp:/tmp \
+    -v /data:/data \
+    -v /path/to:/path/to \
+    -v /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime \
+    "${IMAGE}"
+
+docker exec -it vime-npu bash
+```
+
+容器内训练前初始化 CANN 环境：
+
+```bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+```
+
+## 模型与数据集下载
+
+```bash
+export MODEL_ROOT=/root
+mkdir -p ${MODEL_ROOT}/models ${MODEL_ROOT}/datasets
+
+# 模型权重（Qwen3-4B）
+hf download Qwen/Qwen3-4B --local-dir ${MODEL_ROOT}/models/Qwen3-4B
+
+# 训练数据集（dapo-math-17k）
+hf download --repo-type dataset zhuzilin/dapo-math-17k \
+  --local-dir ${MODEL_ROOT}/datasets/dapo-math-17k
+```
+
+## 训练示例（Qwen3-4B）
+
+在容器内 checkout `ascend` 分支后，运行脚本：
+
+```bash
+cd /root/vime
+
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+
+MODEL_ROOT=/root bash scripts/run-qwen3-4B-npu.sh
+```
+
+完整日志写入 `/root/vime/train_qwen3_4b_vllm.log`。
+
+> **说明：** 与 NVIDIA 流程的主要区别是 Ascend 环境变量 — 使用
+> `ASCEND_RT_VISIBLE_DEVICES` 替代 `CUDA_VISIBLE_DEVICES`，并设置
+> `RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1` 以便 Ray 正确调度 NPU。
+> 参考脚本面向 16 卡 Atlas A3；8 卡主机请设置
+> `ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7`。
+
+完整训练命令、HCCL 端口范围与参数说明见
+[ascend 分支 NPU.md](https://github.com/vllm-project/vime/blob/ascend/docs/en/get_started/NPU.md)。
+
+## MoE 示例（Qwen3-30B-A3B）
+
+MoE 模型请使用 `ascend` 分支脚本：
+
+```bash
+bash scripts/run-qwen3-30B-A3B-npu.sh
+```
+
+模型参数见
+[scripts/models/qwen3-30B-A3B-npu.sh](https://github.com/vllm-project/vime/blob/ascend/scripts/models/qwen3-30B-A3B-npu.sh)。


### PR DESCRIPTION
## Summary

- Add ascend_tutorial.md (EN/ZH) on main, pointing NPU workflows to the ascend branch (planned merge into main later).
- Restructure quick_start hardware support: NVIDIA / Ascend NPU / AMD GPU.
- Add Hardware Platforms toctree (EN: amd + ascend; ZH: ascend only).

## Test plan

- [ ] cd docs && bash ./build.sh en && bash ./build.sh zh
- [ ] Verify links in quick_start and ascend_tutorial resolve correctly
