### PR TITLE
Forward recompute flags to the bridge provider; two hybrid model fixes

### DIFF
--- a/vime/backends/megatron_utils/model.py
+++ b/vime/backends/megatron_utils/model.py
@@ -627,12 +627,17 @@ def train_one_step(
             # vime-patch: mcore MambaModel.forward (hybrid NemotronH) has no
             # loss_mask kwarg (GPTModel does). Drop it when unsupported; loss
             # masking happens in vime's own loss fn, not the model.
-            import inspect as _inspect
-
             _m = model
             while hasattr(_m, "module"):
                 _m = _m.module
-            if "loss_mask" not in _inspect.signature(_m.forward).parameters:
+            # Signature does not change during training, so compute once and cache.
+            accepts_loss_mask = getattr(_m, "_vime_forward_accepts_loss_mask", None)
+            if accepts_loss_mask is None:
+                import inspect
+
+                accepts_loss_mask = "loss_mask" in inspect.signature(_m.forward).parameters
+                _m._vime_forward_accepts_loss_mask = accepts_loss_mask
+            if not accepts_loss_mask:
                 forward_kwargs.pop("loss_mask", None)
 
             if batch["multimodal_train_inputs"] is not None:

--- a/vime/backends/megatron_utils/model.py
+++ b/vime/backends/megatron_utils/model.py
@@ -624,6 +624,17 @@ def train_one_step(
                 "loss_mask": batch["full_loss_masks"],
             }
 
+            # vime-patch: mcore MambaModel.forward (hybrid NemotronH) has no
+            # loss_mask kwarg (GPTModel does). Drop it when unsupported; loss
+            # masking happens in vime's own loss fn, not the model.
+            import inspect as _inspect
+
+            _m = model
+            while hasattr(_m, "module"):
+                _m = _m.module
+            if "loss_mask" not in _inspect.signature(_m.forward).parameters:
+                forward_kwargs.pop("loss_mask", None)
+
             if batch["multimodal_train_inputs"] is not None:
                 forward_kwargs.update(batch["multimodal_train_inputs"])
 

--- a/vime/backends/megatron_utils/model_provider.py
+++ b/vime/backends/megatron_utils/model_provider.py
@@ -58,6 +58,80 @@ class LinearForLastLayer(torch.nn.Linear):
         return logits, None
 
 
+def _apply_bridge_runtime_config(provider, args: argparse.Namespace) -> None:
+    """Copy the runtime config from args onto a bridge-built provider.
+
+    Bridge mode builds the model from the HF checkpoint and skips
+    core_transformer_config_from_args, so command-line args never reach the
+    provider. We copy only some fields, not all of args: the provider already
+    holds the right values from the HF checkpoint, while args only has default
+    values for model shape, dtype, and fields the provider set on purpose.
+    Copying those would quietly break the model -- the bridge only logs a
+    warning and keeps going, it does not fail. So we copy just the training,
+    parallelism, memory, and numerics settings that really come from args. Put
+    new training flags here, not spread across the code.
+
+    Ported from miles' backends/megatron_utils/model_provider.py to keep the
+    two bridge integrations in sync (see vllm-project/vime#337, which fixed
+    only the recompute_* fields below).
+    """
+    # parallelism / sharding
+    provider.tensor_model_parallel_size = args.tensor_model_parallel_size
+    provider.pipeline_model_parallel_size = args.pipeline_model_parallel_size
+    provider.expert_model_parallel_size = args.expert_model_parallel_size
+    provider.expert_tensor_parallel_size = args.expert_tensor_parallel_size
+    provider.sequence_parallel = args.sequence_parallel
+    provider.context_parallel_size = args.context_parallel_size
+    provider.gradient_accumulation_fusion = args.gradient_accumulation_fusion
+
+    # loss / sequence handling
+    provider.calculate_per_token_loss = args.calculate_per_token_loss  # CP>1 VL models assert this
+    provider.variable_seq_lengths = args.variable_seq_lengths
+
+    # numerics (training infra, not model-defining)
+    provider.attention_softmax_in_fp32 = args.attention_softmax_in_fp32
+    provider.fp32_residual_connection = args.fp32_residual_connection
+    provider.deterministic_mode = args.deterministic_mode
+
+    # activation recompute (silently dropped before -> no checkpointing -> OOM at long context)
+    provider.recompute_granularity = args.recompute_granularity
+    provider.recompute_method = args.recompute_method
+    provider.recompute_num_layers = args.recompute_num_layers
+    provider.recompute_modules = args.recompute_modules
+
+    # activation / memory offload
+    provider.cpu_offloading_num_layers = args.cpu_offloading_num_layers
+    provider.distribute_saved_activations = args.distribute_saved_activations
+    # cpu_offloading is derived, set only when cpu_offloading_num_layers>0; guard its presence.
+    if hasattr(args, "cpu_offloading"):
+        provider.cpu_offloading = args.cpu_offloading
+
+    # communication overlap
+    provider.tp_comm_overlap = args.tp_comm_overlap
+
+    # fp8
+    provider.fp8 = args.fp8
+    provider.fp8_recipe = args.fp8_recipe
+
+    # attention kernel selection
+    provider.attention_backend = args.attention_backend
+
+    # MoE token dispatcher (same-name, always present)
+    provider.moe_token_dispatcher_type = args.moe_token_dispatcher_type
+
+    # arg name != provider field; arg default None, so propagate only when the user set it
+    if getattr(args, "decoder_first_pipeline_num_layers", None) is not None:
+        provider.num_layers_in_first_pipeline_stage = args.decoder_first_pipeline_num_layers
+    if getattr(args, "decoder_last_pipeline_num_layers", None) is not None:
+        provider.num_layers_in_last_pipeline_stage = args.decoder_last_pipeline_num_layers
+
+    # MoE training knobs: override only when explicitly set, else keep the provider's value
+    if getattr(args, "moe_router_bias_update_rate", None) is not None:
+        provider.moe_router_bias_update_rate = args.moe_router_bias_update_rate
+    if getattr(args, "moe_aux_loss_coeff", None) is not None:
+        provider.moe_aux_loss_coeff = args.moe_aux_loss_coeff
+
+
 def _get_model_provider_func(
     args: argparse.Namespace,
     role: Literal["actor", "critic"] = "actor",
@@ -91,45 +165,34 @@ def _get_model_provider_func(
 
         bridge = patch_auto_bridge_hf_config(AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True))
         provider = bridge.to_megatron_provider(load_weights=False)
-        # TODO: we should not manually set this...
-        provider.tensor_model_parallel_size = args.tensor_model_parallel_size
-        provider.pipeline_model_parallel_size = args.pipeline_model_parallel_size
-        provider.expert_model_parallel_size = args.expert_model_parallel_size
-        provider.expert_tensor_parallel_size = args.expert_tensor_parallel_size
-        provider.sequence_parallel = args.sequence_parallel
-        provider.context_parallel_size = args.context_parallel_size
-        provider.variable_seq_lengths = args.variable_seq_lengths
-        provider.gradient_accumulation_fusion = args.gradient_accumulation_fusion
-        # vime-patch: bridge-built provider ignores CLI recompute flags; the whitelist
-        # above never forwarded them, so activation recompute was silently disabled for
-        # the hybrid model. Forward them so MoELayer.moe_layer_recompute engages.
-        if getattr(args, "recompute_granularity", None) is not None:
-            provider.recompute_granularity = args.recompute_granularity
-            provider.recompute_modules = getattr(args, "recompute_modules", None)
-            provider.recompute_method = getattr(args, "recompute_method", None)
-            provider.recompute_num_layers = getattr(args, "recompute_num_layers", None)
-        if hasattr(args, "moe_token_dispatcher_type"):
-            provider.moe_token_dispatcher_type = args.moe_token_dispatcher_type
-        if getattr(args, "decoder_first_pipeline_num_layers", None) is not None:
-            provider.num_layers_in_first_pipeline_stage = args.decoder_first_pipeline_num_layers
-        if getattr(args, "decoder_last_pipeline_num_layers", None) is not None:
-            provider.num_layers_in_last_pipeline_stage = args.decoder_last_pipeline_num_layers
+        _apply_bridge_runtime_config(provider, args)
         provider.finalize()
 
-        if role == "critic":
-            _original_provide = provider.provide
+        def wrapped_bridge_provider(
+            pre_process: bool = True,
+            post_process: bool = True,
+            vp_stage: int | None = None,
+            config: TransformerConfig | None = None,
+            pg_collection=None,
+        ) -> GPTModel:
+            assert (
+                config is None
+            ), "vime builds the bridge provider's config from args, so it expects config to be None"
+            # vime-patch (ported from miles): PP>1 paths in some megatron.bridge
+            # providers (e.g. mamba_provider, needed for hybrid Mamba/attention
+            # models like NemotronH) read self._pg_collection.pp during provide();
+            # without forwarding the caller's pg_collection here, those code
+            # paths hit AttributeError.
+            if pg_collection is not None:
+                provider._pg_collection = pg_collection
+            model = provider.provide(pre_process=pre_process, post_process=post_process, vp_stage=vp_stage)
+            if post_process and role == "critic":
+                model.output_layer = LinearForLastLayer(
+                    input_size=model.config.hidden_size, output_size=1, config=model.config
+                )
+            return model
 
-            def _critic_provide(pre_process=True, post_process=True, vp_stage=None):
-                model = _original_provide(pre_process=pre_process, post_process=post_process, vp_stage=vp_stage)
-                if post_process:
-                    model.output_layer = LinearForLastLayer(
-                        input_size=model.config.hidden_size, output_size=1, config=model.config
-                    )
-                return model
-
-            return _critic_provide
-
-        return provider.provide
+        return wrapped_bridge_provider
 
     def model_provider(pre_process: bool = True, post_process: bool = True, vp_stage: int | None = None) -> GPTModel:
         """Builds the model.

--- a/vime/backends/megatron_utils/model_provider.py
+++ b/vime/backends/megatron_utils/model_provider.py
@@ -100,6 +100,14 @@ def _get_model_provider_func(
         provider.context_parallel_size = args.context_parallel_size
         provider.variable_seq_lengths = args.variable_seq_lengths
         provider.gradient_accumulation_fusion = args.gradient_accumulation_fusion
+        # vime-patch: bridge-built provider ignores CLI recompute flags; the whitelist
+        # above never forwarded them, so activation recompute was silently disabled for
+        # the hybrid model. Forward them so MoELayer.moe_layer_recompute engages.
+        if getattr(args, "recompute_granularity", None) is not None:
+            provider.recompute_granularity = args.recompute_granularity
+            provider.recompute_modules = args.recompute_modules
+            provider.recompute_method = args.recompute_method
+            provider.recompute_num_layers = args.recompute_num_layers
         if hasattr(args, "moe_token_dispatcher_type"):
             provider.moe_token_dispatcher_type = args.moe_token_dispatcher_type
         if getattr(args, "decoder_first_pipeline_num_layers", None) is not None:

--- a/vime/backends/megatron_utils/model_provider.py
+++ b/vime/backends/megatron_utils/model_provider.py
@@ -105,9 +105,9 @@ def _get_model_provider_func(
         # the hybrid model. Forward them so MoELayer.moe_layer_recompute engages.
         if getattr(args, "recompute_granularity", None) is not None:
             provider.recompute_granularity = args.recompute_granularity
-            provider.recompute_modules = args.recompute_modules
-            provider.recompute_method = args.recompute_method
-            provider.recompute_num_layers = args.recompute_num_layers
+            provider.recompute_modules = getattr(args, "recompute_modules", None)
+            provider.recompute_method = getattr(args, "recompute_method", None)
+            provider.recompute_num_layers = getattr(args, "recompute_num_layers", None)
         if hasattr(args, "moe_token_dispatcher_type"):
             provider.moe_token_dispatcher_type = args.moe_token_dispatcher_type
         if getattr(args, "decoder_first_pipeline_num_layers", None) is not None:

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -58,7 +58,6 @@ def launch_server_process(server_args_dict: dict) -> multiprocessing.Process:
 def _build_subprocess_env(server_args_dict: dict[str, Any]) -> dict[str, str]:
     args = server_args_dict["_args"]
     env = os.environ.copy()
-    env.pop("PYTORCH_CUDA_ALLOC_CONF", None)
     env.setdefault("NCCL_CUMEM_ENABLE", "0")
     env["CUDA_VISIBLE_DEVICES"] = server_args_dict["_visible_devices"]
     # ROCm: keep HIP visibility in sync with CUDA (no-op on CUDA).
@@ -86,6 +85,15 @@ def _build_subprocess_env(server_args_dict: dict[str, Any]) -> dict[str, str]:
 
 def _run_vllm_server(kwargs: dict, env: dict) -> None:
     os.environ.update(env)
+    # multiprocessing(spawn) inherits the parent's full live environment before
+    # this function runs; os.environ.update(env) above only adds/overrides keys
+    # present in `env`, it can't remove an inherited key that isn't in `env`.
+    # So this must pop straight from this process's own os.environ (after the
+    # inherit, not from a dict merged into it) to actually take effect,
+    # regardless of whether the parent's PYTORCH_CUDA_ALLOC_CONF came from
+    # Ray's runtime_env or anywhere else. expandable_segments breaks vLLM's
+    # custom all-reduce CUDA IPC.
+    os.environ.pop("PYTORCH_CUDA_ALLOC_CONF", None)
 
     from vllm.entrypoints.cli.serve import ServeSubcommand
     from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -85,15 +85,6 @@ def _build_subprocess_env(server_args_dict: dict[str, Any]) -> dict[str, str]:
 
 def _run_vllm_server(kwargs: dict, env: dict) -> None:
     os.environ.update(env)
-    # multiprocessing(spawn) inherits the parent's full live environment before
-    # this function runs; os.environ.update(env) above only adds/overrides keys
-    # present in `env`, it can't remove an inherited key that isn't in `env`.
-    # So this must pop straight from this process's own os.environ (after the
-    # inherit, not from a dict merged into it) to actually take effect,
-    # regardless of whether the parent's PYTORCH_CUDA_ALLOC_CONF came from
-    # Ray's runtime_env or anywhere else. expandable_segments breaks vLLM's
-    # custom all-reduce CUDA IPC.
-    os.environ.pop("PYTORCH_CUDA_ALLOC_CONF", None)
 
     from vllm.entrypoints.cli.serve import ServeSubcommand
     from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args

--- a/vime/ray/rollout.py
+++ b/vime/ray/rollout.py
@@ -191,6 +191,8 @@ class ServerGroup:
             )
 
             env_vars = {name: "1" for name in NOSET_VISIBLE_DEVICES_ENV_VARS_LIST}
+            # vime-patch: expandable_segments breaks vLLM custom-allreduce CUDA IPC; force default allocator in engines
+            env_vars["PYTORCH_CUDA_ALLOC_CONF"] = ""
             rollout_engine = RolloutRayActor.options(
                 num_cpus=num_cpus,
                 num_gpus=num_gpus,

--- a/vime/ray/rollout.py
+++ b/vime/ray/rollout.py
@@ -196,9 +196,7 @@ class ServerGroup:
             # IPC. Strip only that key, keeping any other allocator settings.
             _alloc = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
             env_vars["PYTORCH_CUDA_ALLOC_CONF"] = ",".join(
-                kv
-                for kv in _alloc.split(",")
-                if kv and not kv.strip().startswith("expandable_segments")
+                kv for kv in _alloc.split(",") if kv and not kv.strip().startswith("expandable_segments")
             )
             rollout_engine = RolloutRayActor.options(
                 num_cpus=num_cpus,

--- a/vime/ray/rollout.py
+++ b/vime/ray/rollout.py
@@ -2,6 +2,7 @@ import dataclasses
 import itertools
 import logging
 import multiprocessing
+import os
 import random
 import time
 from pathlib import Path
@@ -191,8 +192,14 @@ class ServerGroup:
             )
 
             env_vars = {name: "1" for name in NOSET_VISIBLE_DEVICES_ENV_VARS_LIST}
-            # vime-patch: expandable_segments breaks vLLM custom-allreduce CUDA IPC; force default allocator in engines
-            env_vars["PYTORCH_CUDA_ALLOC_CONF"] = ""
+            # vime-patch: expandable_segments breaks vLLM custom all-reduce CUDA
+            # IPC. Strip only that key, keeping any other allocator settings.
+            _alloc = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
+            env_vars["PYTORCH_CUDA_ALLOC_CONF"] = ",".join(
+                kv
+                for kv in _alloc.split(",")
+                if kv and not kv.strip().startswith("expandable_segments")
+            )
             rollout_engine = RolloutRayActor.options(
                 num_cpus=num_cpus,
                 num_gpus=num_gpus,


### PR DESCRIPTION
Three small fixes needed to run a hybrid Mamba + attention + MoE model (NemotronH) through the megatron-bridge path.

- `model_provider.py`: the bridge-built provider only copies a fixed allowlist of args (TP/PP/CP/EP/...), so `--recompute-*` never reaches it and activation recompute is silently disabled. On a large hybrid MoE that leaves all expert activations resident and OOMs. Forward the recompute args so they take effect.

- `model.py`: `MambaModel.forward` has no `loss_mask` kwarg (GPTModel does), which raises at the first train step. Drop the kwarg when the model's forward does not accept it.

- `ray/rollout.py`: blank `PYTORCH_CUDA_ALLOC_CONF` for the vLLM engines. `expandable_segments:True` (set on the trainer to reduce fragmentation) breaks vLLM's custom all-reduce CUDA IPC, so engines fail to start unless the allocator stays at default.