### PR TITLE
[Bugfix][Rollout] Fix Geo3K VLM multi-turn rollout

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -61,7 +61,7 @@ reports a passing commit status even if nobody unblocks the GPU gate.
 GPU jobs run on the shared **`mithril-h100-pool`** queue, following the same
 pattern vllm-omni uses for it: each job is a Kubernetes pod (agent-stack-k8s
 `kubernetes` plugin) on an H100 SXM node, with GPUs allocated via
-`nvidia.com/gpu` limits (2 to 8), a memory-backed `/dev/shm`, and the node's
+`nvidia.com/gpu` limits (1 to 8), a memory-backed `/dev/shm`, and the node's
 `/mnt/hf-cache` mounted as `HF_HOME`. vime tests `hf download` their models at
 startup, so a warm HF cache is all they need. `WANDB_API_KEY` is not wired up
 yet; runs report without wandb until it's added (e.g. as a k8s secret in the

--- a/.buildkite/gpu_suites.py
+++ b/.buildkite/gpu_suites.py
@@ -79,6 +79,7 @@ SUITES = {
     ],
     "vime-customized": [
         ("test_qwen2_5_0_5B_non_colocate_pp.py", 4, "", {}),
+        ("test_geo3k_vlm_multi_turn_e2e.py", 1, "", {}),
     ],
     "precision": [
         ("test_qwen3_0.6B_parallel_check.py", 8, "", {}),

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -156,7 +156,7 @@ steps:
             value: vllm-config
           - label: "run-ci-megatron — up to 8 GPU, 20 runs"
             value: megatron
-          - label: "run-ci-vime-customized — 4 GPU, 1 test"
+          - label: "run-ci-vime-customized — 1–4 GPU, 2 tests"
             value: vime-customized
           - label: "run-ci-precision — 8 GPU, 1 test"
             value: precision

--- a/examples/geo3k_vlm_multi_turn/__init__.py
+++ b/examples/geo3k_vlm_multi_turn/__init__.py
@@ -1,1 +1,1 @@
-# Multi-turn VLM Sokoban example package
+# Multi-turn VLM Geo3K example package

--- a/examples/geo3k_vlm_multi_turn/rollout.py
+++ b/examples/geo3k_vlm_multi_turn/rollout.py
@@ -1,23 +1,25 @@
 from __future__ import annotations
 
+import base64
 import importlib
 import importlib.util
+import io
 import json
 import sys
 import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import torch
 from PIL import Image
 
-# When executed as a module: python -m examples.vlm_multi_turn.rollout
 from vime.rollout.vllm_rollout import (
     GenerateState,
-    _apply_vllm_routed_experts,
     _build_inference_sampling_params,
     _coerce_flat_int_token_ids,
-    _inference_generate_tokens_and_logprobs,
     _mm_render_response_to_generate_body,
 )
 from vime.utils.http_utils import post
@@ -25,102 +27,89 @@ from vime.utils.processing_utils import encode_image_for_rollout_engine
 from vime.utils.types import Sample
 
 DEFAULT_ENV_MODULE = "examples.geo3k_vlm_multi_turn.env_geo3k"
+DUMMY_MESSAGES = (
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "I am a user."},
+    {"role": "assistant", "content": "I am an assistant."},
+)
+IMAGE_GRID_DIMENSIONS = 3
 
 
 def _load_env_module(env_path: str | None):
-    """Load the interaction environment module from a module path or a file path."""
     target = env_path or DEFAULT_ENV_MODULE
     module_path = Path(target)
-    if module_path.suffix == ".py" and module_path.exists():
-        spec = importlib.util.spec_from_file_location(f"rollout_env_{module_path.stem}", module_path)
-        if spec is None or spec.loader is None:
-            raise ImportError(f"Cannot import environment module from {module_path}")
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[spec.name] = module
-        spec.loader.exec_module(module)
-        return module
-    return importlib.import_module(target)
+    if module_path.suffix != ".py" or not module_path.exists():
+        return importlib.import_module(target)
+
+    spec = importlib.util.spec_from_file_location(f"rollout_env_{module_path.stem}", module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot import environment module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _image_to_render_url(image: Any) -> str:
-    """Convert a dataset/processor image object to the image_url payload accepted by vLLM render."""
-    if isinstance(image, str):
-        if image.startswith("data:"):
-            # Some prepared Geo3K rows use data:image/None; vLLM expects a concrete media type.
-            return image.replace("data:image/None;", "data:image/png;", 1)
-        if image.startswith(("http://", "https://")):
-            return image
-        image_path = Path(image).expanduser()
-        if image_path.exists():
-            with Image.open(image_path) as loaded_image:
-                return encode_image_for_rollout_engine(loaded_image)
+    if not isinstance(image, str):
+        return encode_image_for_rollout_engine(image)
+    if image.startswith("data:"):
+        return image.replace("data:image/None;", "data:image/png;", 1)
+    if image.startswith(("http://", "https://")):
+        return image
+
+    image_path = Path(image).expanduser()
+    if not image_path.exists():
         raise ValueError(f"Unsupported image string for vLLM render: {image!r}")
-    return encode_image_for_rollout_engine(image)
+    with Image.open(image_path) as loaded_image:
+        return encode_image_for_rollout_engine(loaded_image)
 
 
-def _build_initial_messages(sample: Sample) -> list[dict]:
-    """Build the initial conversation from the dataset prompt.
-
-    The preferred path mirrors SkyRL: keep the untemplated conversation as the source of truth
-    and let vLLM render/chat-template it on every turn. If an old pre-rendered string prompt is
-    supplied, fall back to pairing it with sample.multimodal_inputs while removing literal
-    <image> placeholders to avoid double image tokens.
-    """
+def _build_initial_messages(sample: Sample) -> list[dict[str, Any]]:
     if isinstance(sample.prompt, list):
         return [dict(message) for message in sample.prompt]
 
-    content: list[dict] = []
-    images = (sample.multimodal_inputs or {}).get("images") or []
-    for image in images:
+    content: list[dict[str, Any]] = []
+    for image in (sample.multimodal_inputs or {}).get("images") or []:
         content.append({"type": "image", "image": image})
-    # Backward-compatible fallback for old runs that pass a raw text prompt containing <image>.
-    text_prompt = str(sample.prompt).replace("<image>", "").lstrip()
-    content.append({"type": "text", "text": text_prompt})
+    content.append({"type": "text", "text": str(sample.prompt).replace("<image>", "").lstrip()})
     return [{"role": "user", "content": content}]
 
 
-def _messages_for_render(messages: list[dict]) -> list[dict]:
-    """Normalize per-turn messages to the render-route shape (image → image_url)."""
-    out: list[dict] = []
-    for msg in messages:
-        content = msg.get("content")
+def _messages_for_render(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    rendered: list[dict[str, Any]] = []
+    for message in messages:
+        content = message.get("content")
         if not isinstance(content, list):
-            out.append(msg)
+            rendered.append(dict(message))
             continue
-
-        rendered_content: list[dict] = []
+        parts: list[dict[str, Any]] = []
         for part in content:
             if part.get("type") == "image" and part.get("image") is not None:
-                rendered_content.append(
-                    {"type": "image_url", "image_url": {"url": _image_to_render_url(part["image"])}}
-                )
+                parts.append({"type": "image_url", "image_url": {"url": _image_to_render_url(part["image"])}})
             else:
-                rendered_content.append(part)
-        out.append({"role": msg["role"], "content": rendered_content})
-    return out
+                parts.append(dict(part))
+        rendered.append({"role": message["role"], "content": parts})
+    return rendered
 
 
-def _multimodal_train_inputs_from_features(features: Any) -> dict | None:
-    """Decode the latest vLLM render features into train-side multimodal tensors."""
+def _multimodal_train_inputs_from_features(features: Any) -> dict[str, torch.Tensor] | None:
     if not features:
         return None
-    if isinstance(features, str):
-        try:
-            features = json.loads(features)
-        except json.JSONDecodeError:
-            return None
-    if not isinstance(features, dict):
+    decoded = json.loads(features) if isinstance(features, str) else features
+    if not isinstance(decoded, dict):
+        raise TypeError(f"vLLM features must decode to a dictionary, got {type(decoded).__name__}")
+    kwargs_data = decoded.get("kwargs_data")
+    if not isinstance(kwargs_data, dict) or "image" not in kwargs_data:
         return None
-    kwargs_data = features.get("kwargs_data")
-    if not isinstance(kwargs_data, dict):
-        return None
-    if "image" not in kwargs_data:
-        return None
+    encoded_images = kwargs_data["image"]
+    if not isinstance(encoded_images, list):
+        raise TypeError("vLLM features.kwargs_data.image must be a list")
 
     from vllm.entrypoints.serve.disagg.mm_serde import decode_mm_kwargs_item as vllm_decode
 
     parts_by_key: dict[str, list[torch.Tensor]] = {}
-    for encoded in kwargs_data["image"]:
+    for encoded in encoded_images:
         item = vllm_decode(encoded)
         for key, value in item.get_data().items():
             if not isinstance(value, torch.Tensor):
@@ -128,17 +117,19 @@ def _multimodal_train_inputs_from_features(features: Any) -> dict | None:
             if key == "image_grid_thw" and value.dim() == 1:
                 value = value.reshape(1, -1)
             parts_by_key.setdefault(key, []).append(value)
-
-    return {
-        key: torch.cat(values, dim=0) if len(values) > 1 else values[0] for key, values in parts_by_key.items()
-    } or None
+    return {key: values[0] if len(values) == 1 else torch.cat(values, dim=0) for key, values in parts_by_key.items()}
 
 
-def _validate_multimodal_train_inputs(sample: Sample, tokenizer: Any, processor: Any, mm_inputs: dict | None) -> None:
+def _validate_multimodal_train_inputs(
+    sample: Sample,
+    tokenizer: Any,
+    processor: Any,
+    *,
+    mm_inputs: dict[str, torch.Tensor] | None,
+) -> None:
     image_token_id = tokenizer.convert_tokens_to_ids("<|image_pad|>")
     if image_token_id is None:
         raise RuntimeError("Tokenizer does not define <|image_pad|>.")
-
     image_tokens = sample.tokens.count(int(image_token_id))
     if image_tokens == 0:
         return
@@ -146,8 +137,7 @@ def _validate_multimodal_train_inputs(sample: Sample, tokenizer: Any, processor:
     grid = None if not mm_inputs else mm_inputs.get("image_grid_thw")
     if grid is None:
         raise RuntimeError(f"Found {image_tokens} image tokens, but multimodal render features are missing.")
-
-    grid = grid.reshape(-1, 3)
+    grid = grid.reshape(-1, IMAGE_GRID_DIMENSIONS)
     image_processor = getattr(processor, "image_processor", processor)
     merge_size = int(getattr(image_processor, "merge_size", 1) or 1)
     expected = int((grid.prod(dim=1) // (merge_size * merge_size)).sum().item())
@@ -158,187 +148,385 @@ def _validate_multimodal_train_inputs(sample: Sample, tokenizer: Any, processor:
         )
 
 
-async def generate(args: Any, sample: Sample, sampling_params) -> Sample:
-    """Custom multi-turn rollout that interacts with a pluggable environment via the vLLM render route."""
-    assert not args.partial_rollout, "Partial rollout is not supported for interaction rollouts."
+def _require_token_ids(value: Any, *, field: str) -> list[int]:
+    if not isinstance(value, list) or not all(type(token) is int for token in value):
+        raise TypeError(f"{field} must be a list of integer token ids")
+    return list(value)
 
-    if args.max_turns is None:
-        raise ValueError("max_turns must be set via --custom-config-path in the custom config file.")
-    state = GenerateState(args)
-    base_url = f"http://{args.vllm_router_ip}:{args.vllm_router_port}"
 
-    env_module = _load_env_module(args.rollout_interaction_env_path)
-    sample.metadata = sample.metadata or {}
-    headers = None
-    if getattr(args, "router_policy", None) == "consistent_hash":
-        sample.session_id = sample.session_id or str(uuid.uuid4())
-        headers = {"x-session-id": sample.session_id}
+def _parse_log_probs(choice: dict[str, Any], token_count: int) -> list[float]:
+    logprobs = choice.get("logprobs")
+    content = logprobs.get("content") if isinstance(logprobs, dict) else None
+    if not isinstance(content, list):
+        raise TypeError("choice.logprobs.content must be a list")
+    if len(content) != token_count:
+        raise ValueError(f"token/logprob count mismatch: tokens={token_count}, logprobs={len(content)}")
+    values: list[float] = []
+    for index, item in enumerate(content):
+        if not isinstance(item, dict) or not isinstance(item.get("logprob"), int | float):
+            raise TypeError(f"choice.logprobs.content[{index}].logprob must be numeric")
+        values.append(float(item["logprob"]))
+    return values
 
-    build_env = env_module.build_env
-    if not callable(build_env):
-        raise ValueError("Environment module must expose a callable `build_env(sample, args)`.")
-    env = build_env(sample=sample, args=args)
 
-    messages = _build_initial_messages(sample)
-    response_tokens: list[int] = []
-    sample.loss_mask = sample.loss_mask or []
-    sample.rollout_log_probs = sample.rollout_log_probs or []
-    sample.tokens = list(sample.tokens) if sample.tokens else []
+def _parse_choice(choice: dict[str, Any]) -> tuple[str, list[int], list[float]]:
+    finish = choice.get("finish_reason")
+    finish = finish.get("type") if isinstance(finish, dict) else finish
+    if finish in {"abort", "cancelled"}:
+        return "abort", [], []
+    if finish not in {"length", "stop"}:
+        raise ValueError(f"Unsupported vLLM finish_reason: {finish!r}")
 
-    sampling_params = sampling_params.copy()
-    inference_sampling_params = _build_inference_sampling_params(sampling_params)
+    token_ids = _require_token_ids(choice.get("token_ids"), field="choice.token_ids")
+    return str(finish), token_ids, _parse_log_probs(choice, len(token_ids))
 
-    max_response_budget = sampling_params.get("max_new_tokens")
 
-    def remaining_budget() -> int | None:
-        return None if max_response_budget is None else max_response_budget - sample.response_length
+def _template_token_ids(value: Any, *, field: str) -> list[int]:
+    if isinstance(value, Mapping):
+        value = value.get("input_ids")
+    return _require_token_ids(value, field=field)
 
-    async def render() -> dict:
-        payload = {"model": args.hf_checkpoint, "messages": _messages_for_render(messages)}
-        render_data = await post(f"{base_url}/v1/chat/completions/render", payload, headers=headers)
-        return _mm_render_response_to_generate_body(render_data, args.hf_checkpoint)
 
-    def append_response_window(
-        token_ids: list[int],
-        loss_mask: list[int],
-        log_probs: list[float] | None = None,
-    ) -> None:
-        if not token_ids:
-            return
-        if len(loss_mask) != len(token_ids):
-            raise ValueError(f"loss_mask length {len(loss_mask)} != token_ids length {len(token_ids)}")
-        sample.tokens.extend(token_ids)
-        sample.loss_mask.extend(loss_mask)
-        sample.rollout_log_probs.extend(log_probs if log_probs is not None else [0.0] * len(token_ids))
-        sample.response_length += len(token_ids)
-
-    def sampling_params_for_turn() -> dict | None:
-        params = dict(inference_sampling_params)
-        max_tokens = remaining_budget()
-        if max_tokens is None:
-            return params
-        if max_tokens <= 0:
-            return None
-        params["max_tokens"] = max_tokens
-        return params
-
-    try:
-        env.reset()
-        latest_features = None
-        pending_obs_offset: int | None = None
-        rendered_body = await render()
-        prompt_ids = _coerce_flat_int_token_ids(rendered_body.get("token_ids"))
-        if not sample.tokens:
-            sample.tokens = list(prompt_ids)
-        if args.rollout_max_context_len is not None:
-            max_response_budget = max(0, args.rollout_max_context_len - len(sample.tokens))
-
-        for turn_idx in range(args.max_turns):
-            input_ids = _coerce_flat_int_token_ids(rendered_body.get("token_ids"))
-            latest_features = rendered_body.get("features")
-
-            if pending_obs_offset is not None:
-                obs_tokens = input_ids[pending_obs_offset:]
-                remaining = remaining_budget()
-                if remaining is not None and len(obs_tokens) > remaining:
-                    append_response_window(obs_tokens[: max(remaining, 0)], [0] * max(remaining, 0))
-                    sample.status = Sample.Status.TRUNCATED
-                    break
-                append_response_window(obs_tokens, [0] * len(obs_tokens))
-                pending_obs_offset = None
-
-            current_sampling_params = sampling_params_for_turn()
-            if current_sampling_params is None:
-                sample.status = Sample.Status.TRUNCATED
-                break
-
-            body = dict(rendered_body)
-            body["sampling_params"] = current_sampling_params
-            output = await post(f"{base_url}/inference/v1/generate", body, headers=headers)
-            choice = output["choices"][0]
-            finish_reason = choice.get("finish_reason") or "stop"
-            new_tokens, new_logprobs = _inference_generate_tokens_and_logprobs(choice)
-
-            if not new_tokens:
-                if finish_reason in ("abort", "cancelled"):
-                    sample.status = Sample.Status.ABORTED
-                    break
-
-            response_text = state.tokenizer.decode(new_tokens, skip_special_tokens=False) if new_tokens else ""
-            train_tokens = list(new_tokens)
-            train_logprobs = list(new_logprobs)
-            train_loss_mask = [1] * len(train_tokens)
-            stop = current_sampling_params.get("stop")
-            eos_token_id = getattr(state.tokenizer, "eos_token_id", None)
-            append_stop_eos = (
-                stop
-                and eos_token_id is not None
-                and getattr(args, "append_eos_token_after_stop_str_in_multi_turn", True)
+def _validate_text_observation(message: dict[str, Any]) -> None:
+    content = message.get("content")
+    if isinstance(content, str):
+        return
+    if not isinstance(content, list):
+        raise TypeError("Geo3K observation content must be text or a list of text parts")
+    for index, part in enumerate(content):
+        if not isinstance(part, dict) or part.get("type") != "text" or not isinstance(part.get("text"), str):
+            raise ValueError(
+                "Geo3K suffix-only rollout supports text observations only; " f"content[{index}]={part!r}"
             )
-            if append_stop_eos:
-                stop_strings = (stop,) if isinstance(stop, str) else tuple(stop)
-                already_has_eos = bool(train_tokens and train_tokens[-1] == eos_token_id)
-                if stop_strings and response_text.endswith(stop_strings) and not already_has_eos:
-                    if getattr(args, "use_rollout_routing_replay", False):
-                        raise RuntimeError(
-                            "Routing replay is not supported when appending an artificial EOS after a stop string, "
-                            "because vLLM does not return routed experts for that extra token."
-                        )
-                    train_tokens.append(int(eos_token_id))
-                    train_logprobs.append(0.0)
-                    train_loss_mask.append(0)
 
-            response_tokens.extend(new_tokens)
-            append_response_window(train_tokens, train_loss_mask, train_logprobs)
-            _apply_vllm_routed_experts(args, sample, choice)
 
-            messages.append({"role": "assistant", "content": response_text})
+def _observation_token_ids(
+    tokenizer: Any,
+    message: dict[str, Any],
+    canonical_ids: list[int],
+    *,
+    tools: list[dict[str, Any]] | None,
+    template_kwargs: dict[str, Any] | None,
+) -> list[int]:
+    """Encode only the next user-turn boundary without re-rendering generated IDs."""
+    kwargs = dict(template_kwargs or {})
+    prefix = tokenizer.apply_chat_template(
+        list(DUMMY_MESSAGES),
+        tools=tools,
+        tokenize=True,
+        add_generation_prompt=False,
+        **kwargs,
+    )
+    rendered = tokenizer.apply_chat_template(
+        [*DUMMY_MESSAGES, message],
+        tools=tools,
+        tokenize=True,
+        add_generation_prompt=True,
+        **kwargs,
+    )
+    prefix_ids = _template_token_ids(prefix, field="dummy observation prefix")
+    rendered_ids = _template_token_ids(rendered, field="observation template")
+    if rendered_ids[: len(prefix_ids)] != prefix_ids:
+        raise ValueError("Observation template is not prefix-stable")
 
-            if finish_reason == "length":
-                sample.status = Sample.Status.TRUNCATED
-                break
-            if finish_reason in ("abort", "cancelled"):
-                sample.status = Sample.Status.ABORTED
-                break
+    eos_token_id = getattr(tokenizer, "eos_token_id", None)
+    if not isinstance(eos_token_id, int):
+        raise ValueError("tokenizer.eos_token_id must be an integer")
+    try:
+        eos_index = len(prefix_ids) - 1 - prefix_ids[::-1].index(eos_token_id)
+    except ValueError as exc:
+        raise ValueError(f"Dummy observation prefix lacks eos_token_id={eos_token_id}") from exc
+    boundary = prefix_ids[eos_index:] + rendered_ids[len(prefix_ids) :]
+    return boundary[1:] if canonical_ids and canonical_ids[-1] == eos_token_id else boundary
 
-            observation, done, _ = env.step(response_text)
-            if done:
-                sample.status = Sample.Status.COMPLETED
-                break
 
-            if turn_idx + 1 >= args.max_turns:
-                sample.status = Sample.Status.TRUNCATED
-                break
+def _decode_routing_metadata(args: Any, choice: dict[str, Any], *, expected_transitions: int) -> dict[str, Any] | None:
+    routed_experts = choice.get("routed_experts")
+    if routed_experts is None:
+        if getattr(args, "use_rollout_routing_replay", False):
+            raise RuntimeError("vLLM routing replay response is missing choices[0].routed_experts")
+        return None
+    if not isinstance(routed_experts, str):
+        raise TypeError("choice.routed_experts must be a base64 string")
+    raw = base64.b64decode(routed_experts.encode("ascii"), validate=True)
+    decoded = np.load(io.BytesIO(raw), allow_pickle=False)
+    if getattr(args, "use_rollout_routing_replay", False):
+        expected_size = expected_transitions * args.num_layers * args.moe_router_topk
+        if int(decoded.size) != expected_size:
+            raise ValueError(
+                "vLLM routed experts shape does not match the generated sequence: "
+                f"actual_size={decoded.size}, expected_size={expected_size}"
+            )
+    return {"routed_experts": decoded}
 
-            next_user_message = env.format_observation(observation)
-            messages.append(next_user_message)
-            render_prefix_len = len(input_ids) + len(new_tokens)
-            pending_obs_offset = render_prefix_len
-            rendered_body = await render()
-            rendered_ids = _coerce_flat_int_token_ids(rendered_body.get("token_ids"))
-            is_prefix_stable = rendered_ids[:pending_obs_offset] == sample.tokens[:pending_obs_offset]
-            sample.metadata["multiturn_render"] = {
-                "prefix_stable": is_prefix_stable,
-                "prefix_len": pending_obs_offset,
-                "sample_len": len(sample.tokens),
-                "rendered_len": len(rendered_ids),
+
+def _response_budget(sampling_params: dict[str, Any], context_limit: int | None, prompt_length: int) -> int | None:
+    budget = sampling_params.get("max_new_tokens")
+    if budget is not None and budget < 0:
+        raise ValueError(f"max_new_tokens must be non-negative, got {budget}")
+    if context_limit is None:
+        return budget
+    if context_limit < 0:
+        raise ValueError(f"rollout_max_context_len must be non-negative, got {context_limit}")
+    context_budget = max(0, context_limit - prompt_length)
+    return context_budget if budget is None else min(budget, context_budget)
+
+
+def _stop_eos_token_id(
+    text: str,
+    token_ids: list[int],
+    *,
+    finish: str,
+    stop: Any,
+    eos_token_id: Any,
+) -> int | None:
+    if finish != "stop" or not stop or not isinstance(eos_token_id, int):
+        return None
+    stop_strings = (stop,) if isinstance(stop, str) else tuple(stop)
+    if not text.endswith(stop_strings):
+        return None
+    if token_ids and token_ids[-1] == eos_token_id:
+        return None
+    return eos_token_id
+
+
+def _validate_rollout_request(args: Any, sample: Sample) -> None:
+    if args.partial_rollout:
+        raise ValueError("Partial rollout is not supported for interaction rollouts.")
+    if not isinstance(args.max_turns, int) or args.max_turns <= 0:
+        raise ValueError("max_turns must be a positive integer in the custom config file.")
+    if sample.status != Sample.Status.PENDING:
+        raise ValueError(f"Geo3K rollout requires a pending sample, got {sample.status.value}")
+    if sample.response or sample.response_length or sample.loss_mask or sample.rollout_log_probs:
+        raise ValueError("Geo3K rollout does not accept pre-existing response state")
+
+
+@dataclass(frozen=True, kw_only=True)
+class _Turn:
+    choice: dict[str, Any]
+    tokens: list[int]
+    log_probs: list[float]
+    text: str
+    finish: str
+
+
+class _Geo3kRollout:
+    def __init__(self, args: Any, sample: Sample, sampling_params: dict[str, Any]) -> None:
+        _validate_rollout_request(args, sample)
+        self.args = args
+        self.sample = sample
+        self.sample.metadata = dict(sample.metadata or {})
+        self.sampling_params = dict(sampling_params)
+        self.state = GenerateState(args)
+        self.base_url = f"http://{args.vllm_router_ip}:{args.vllm_router_port}"
+        self.headers: dict[str, str] | None = None
+        if getattr(args, "router_policy", None) == "consistent_hash":
+            sample.session_id = sample.session_id or str(uuid.uuid4())
+            self.headers = {"x-session-id": sample.session_id}
+        self.inference_params = _build_inference_sampling_params(self.sampling_params)
+        self.render_body: dict[str, Any] = {}
+        self.max_response_budget: int | None = None
+        self.response_tokens: list[int] = []
+
+    @property
+    def _remaining_budget(self) -> int | None:
+        if self.max_response_budget is None:
+            return None
+        return self.max_response_budget - self.sample.response_length
+
+    async def _initialize_prompt(self) -> None:
+        payload: dict[str, Any] = {
+            "model": self.args.hf_checkpoint,
+            "messages": _messages_for_render(_build_initial_messages(self.sample)),
+        }
+        tools = self.sample.metadata.get("tools")
+        if tools is not None:
+            payload["tools"] = tools
+        template_kwargs = getattr(self.args, "apply_chat_template_kwargs", None)
+        if template_kwargs:
+            payload["chat_template_kwargs"] = dict(template_kwargs)
+
+        render_data = await post(
+            f"{self.base_url}/v1/chat/completions/render",
+            payload,
+            headers=self.headers,
+        )
+        body = _mm_render_response_to_generate_body(render_data, self.args.hf_checkpoint)
+        prompt_ids = _coerce_flat_int_token_ids(body.get("token_ids"))
+        if not prompt_ids:
+            raise ValueError("vLLM render returned empty token_ids")
+        if self.sample.tokens and self.sample.tokens != prompt_ids:
+            raise ValueError("Initial render token_ids differ from sample.tokens")
+
+        self.sample.tokens = list(prompt_ids)
+        self.sample.loss_mask = []
+        self.sample.rollout_log_probs = []
+        self.sample.response_length = 0
+        self.render_body = body
+        self.max_response_budget = _response_budget(
+            self.sampling_params,
+            self.args.rollout_max_context_len,
+            len(prompt_ids),
+        )
+
+    async def _generate_turn(self, sampling_params: dict[str, Any]) -> _Turn:
+        body = dict(self.render_body)
+        body.pop("request_id", None)
+        body["token_ids"] = list(self.sample.tokens)
+        body["sampling_params"] = sampling_params
+        output = await post(
+            f"{self.base_url}/inference/v1/generate",
+            body,
+            headers=self.headers,
+        )
+        choices = output.get("choices") if isinstance(output, dict) else None
+        if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+            raise ValueError("vLLM generate response must contain choices[0]")
+
+        choice = choices[0]
+        finish, tokens, log_probs = _parse_choice(choice)
+        text = self.state.tokenizer.decode(tokens, skip_special_tokens=False) if tokens else ""
+        return _Turn(
+            choice=choice,
+            tokens=tokens,
+            log_probs=log_probs,
+            text=text,
+            finish=finish,
+        )
+
+    def _append_generated(self, turn: _Turn) -> bool:
+        remaining = self._remaining_budget
+        if remaining is not None and len(turn.tokens) > remaining:
+            raise ValueError(
+                "vLLM generated more tokens than requested: "
+                f"generated_tokens={len(turn.tokens)}, remaining_budget={remaining}"
+            )
+        meta = _decode_routing_metadata(
+            self.args,
+            turn.choice,
+            expected_transitions=len(self.sample.tokens) + len(turn.tokens) - 1,
+        )
+        eos_token_id = None
+        if getattr(self.args, "append_eos_token_after_stop_str_in_multi_turn", True):
+            eos_token_id = _stop_eos_token_id(
+                turn.text,
+                turn.tokens,
+                finish=turn.finish,
+                stop=self.inference_params.get("stop"),
+                eos_token_id=getattr(self.state.tokenizer, "eos_token_id", None),
+            )
+        if eos_token_id is not None and getattr(self.args, "use_rollout_routing_replay", False):
+            raise RuntimeError("Routing replay cannot append an artificial EOS after a stop string")
+
+        self.sample.append_response_tokens(
+            self.args,
+            tokens=turn.tokens,
+            log_probs=turn.log_probs,
+            trainable=True,
+            meta_info=meta,
+            update_terminal_info=False,
+        )
+        self.response_tokens.extend(turn.tokens)
+        if eos_token_id is None:
+            return False
+        remaining = self._remaining_budget
+        if remaining is not None and remaining <= 0:
+            self.sample.status = Sample.Status.TRUNCATED
+            self.sample.metadata["multiturn_truncation"] = {
+                "reason": "insufficient_budget_for_stop_eos",
+                "remaining_budget": remaining,
             }
-            if not is_prefix_stable:
-                raise RuntimeError(
-                    "Full conversation render is not prefix-stable with the generated token stream: "
-                    f"{sample.metadata['multiturn_render']}"
-                )
+            return True
+        self.sample.append_response_tokens(tokens=[eos_token_id], trainable=False)
+        return False
 
-        multimodal_train_inputs = _multimodal_train_inputs_from_features(latest_features)
-        _validate_multimodal_train_inputs(sample, state.tokenizer, state.processor, multimodal_train_inputs)
-        sample.multimodal_train_inputs = multimodal_train_inputs
-        sample.response = state.tokenizer.decode(response_tokens, skip_special_tokens=False)
-        sample.response_length = len(sample.loss_mask)
-        if sample.status == Sample.Status.PENDING:
-            sample.status = Sample.Status.COMPLETED
-        return sample
-    finally:
+    def _advance_environment(self, env: Any, turn: _Turn, turn_index: int) -> bool:
+        observation, done, _ = env.step(turn.text)
+        if done:
+            self.sample.status = Sample.Status.COMPLETED
+            return True
+        if turn_index + 1 >= self.args.max_turns:
+            self.sample.status = Sample.Status.TRUNCATED
+            return True
+
+        message = env.format_observation(observation)
+        _validate_text_observation(message)
+        token_ids = _observation_token_ids(
+            self.state.tokenizer,
+            message,
+            self.sample.tokens,
+            tools=self.sample.metadata.get("tools"),
+            template_kwargs=getattr(self.args, "apply_chat_template_kwargs", None),
+        )
+        remaining = self._remaining_budget
+        if remaining is None or len(token_ids) < remaining:
+            self.sample.append_response_tokens(tokens=token_ids, trainable=False)
+            return False
+        self.sample.status = Sample.Status.TRUNCATED
+        self.sample.metadata["multiturn_truncation"] = {
+            "reason": "insufficient_budget_for_next_turn",
+            "observation_tokens": len(token_ids),
+            "remaining_budget": remaining,
+        }
+        return True
+
+    def _finalize(self) -> Sample:
+        mm_inputs = _multimodal_train_inputs_from_features(self.render_body.get("features"))
+        _validate_multimodal_train_inputs(
+            self.sample,
+            self.state.tokenizer,
+            self.state.processor,
+            mm_inputs=mm_inputs,
+        )
+        self.sample.multimodal_train_inputs = mm_inputs
+        self.sample.response = self.state.tokenizer.decode(self.response_tokens, skip_special_tokens=False)
+        return self.sample
+
+    async def _run_turns(self, env: Any) -> None:
+        for turn_index in range(self.args.max_turns):
+            remaining = self._remaining_budget
+            if remaining is not None and remaining <= 0:
+                self.sample.status = Sample.Status.TRUNCATED
+                break
+            sampling_params = dict(self.inference_params)
+            if remaining is not None:
+                sampling_params["max_tokens"] = remaining
+
+            turn = await self._generate_turn(sampling_params)
+            if turn.finish == "abort":
+                self.sample.status = Sample.Status.ABORTED
+                break
+            if self._append_generated(turn):
+                break
+            if turn.finish == "length":
+                self.sample.status = Sample.Status.TRUNCATED
+                break
+            if self._advance_environment(env, turn, turn_index):
+                break
+
+    async def run(self) -> Sample:
+        env_module = _load_env_module(self.args.rollout_interaction_env_path)
+        build_env = getattr(env_module, "build_env", None)
+        if not callable(build_env):
+            raise ValueError("Environment module must expose a callable build_env(sample, args).")
+        env = build_env(sample=self.sample, args=self.args)
+        active_error: BaseException | None = None
         try:
-            env.close()
-        except Exception:
-            pass
+            env.reset()
+            await self._initialize_prompt()
+            await self._run_turns(env)
+            return self._finalize()
+        except BaseException as error:
+            active_error = error
+            raise
+        finally:
+            try:
+                env.close()
+            except BaseException as close_error:
+                if active_error is None:
+                    raise
+                raise active_error from close_error
+
+
+async def generate(args: Any, sample: Sample, sampling_params: dict[str, Any]) -> Sample:
+    return await _Geo3kRollout(args, sample, sampling_params).run()

--- a/examples/geo3k_vlm_multi_turn/run_geo3k_vlm_multi_turn.py
+++ b/examples/geo3k_vlm_multi_turn/run_geo3k_vlm_multi_turn.py
@@ -103,9 +103,6 @@ def execute():
         "--vllm-gpu-memory-utilization 0.9 "
         "--vllm-generation-config vllm "
         f"--vllm-cudagraph-capture-sizes {cudagraph_sizes} "
-        # vLLM 0.22.0 needs eager mode for Qwen3-VL logprob parity. This can be
-        # disabled after vLLM includes https://github.com/vllm-project/vllm/pull/43617.
-        "--vllm-enforce-eager "
         "--vllm-logprobs-mode processed_logprobs "
     )
 

--- a/tests/test_geo3k_vlm_multi_turn_e2e.py
+++ b/tests/test_geo3k_vlm_multi_turn_e2e.py
@@ -1,0 +1,281 @@
+"""Single-GPU end-to-end regression for Geo3K Issue #331."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shlex
+import subprocess
+import sys
+import time
+from argparse import Namespace
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError
+from urllib.parse import urlsplit
+from urllib.request import urlopen
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vllm.utils.system_utils import kill_process_tree
+
+import vime.utils.external_utils.command_utils as U
+from vime.utils.http_utils import is_port_available
+from vime.utils.misc import load_function
+
+NUM_GPUS = 1
+MODEL_NAME = "Qwen3-VL-2B-Instruct"
+MODEL_REVISION = "89644892e4d85e24eaac8bacfd4f463576704203"
+TEST_ROOT = Path(os.environ.get("VIME_TEST_ROOT", "/root"))
+MODEL_PATH = TEST_ROOT / "models" / MODEL_NAME
+DATASET_NAME = "VeraIsHere/geo3k_imgurl_processed"
+DATASET_REVISION = "53ff8fbb1f9758b9efbc005e9487e1fdd874364a"
+DATA_ROOT = TEST_ROOT / "datasets/geo3k_imgurl_processed"
+TRAIN_DATA_PATH = DATA_ROOT / "train.parquet"
+CUSTOM_GENERATE_PATH = "examples.geo3k_vlm_multi_turn.rollout.generate"
+HOST = "127.0.0.1"
+WORKER_PORT = 10090
+ROUTER_PORT = 30000
+PROMETHEUS_PORT = 29001
+WORKER_URL = f"http://{HOST}:{WORKER_PORT}"
+ROUTER_URL = f"http://{HOST}:{ROUTER_PORT}"
+RENDER_ENDPOINT = "/v1/chat/completions/render"
+GENERATE_ENDPOINT = "/inference/v1/generate"
+SEED = 331
+ROW_INDEX = 0
+MAX_NEW_TOKENS = 1024
+MAX_TURNS = 2
+TEMPERATURE = 0.0
+TOP_P = 1.0
+TOP_K = -1
+GPU_MEMORY_UTILIZATION = 0.70
+MAX_MODEL_LEN = 4096
+MAX_NUM_SEQS = 1
+ROUTER_REQUEST_TIMEOUT_S = 600
+HTTP_MAX_RETRIES = 60
+SERVICE_START_TIMEOUT_S = 180
+SERVICE_POLL_INTERVAL_S = 2
+PROCESS_STOP_TIMEOUT_S = 30
+WORKER_LOG = Path("/tmp/geo3k-vllm-worker.log")
+ROUTER_LOG = Path("/tmp/geo3k-vllm-router.log")
+WORKER_COMMAND = shlex.split(
+    f"vllm serve {MODEL_PATH} --host {HOST} --port {WORKER_PORT} --dtype bfloat16 "
+    f"--tensor-parallel-size {NUM_GPUS} --gpu-memory-utilization {GPU_MEMORY_UTILIZATION} "
+    f"--max-model-len {MAX_MODEL_LEN} --max-num-seqs {MAX_NUM_SEQS} --enforce-eager "
+    "--generation-config vllm --logprobs-mode processed_logprobs"
+)
+ROUTER_COMMAND = shlex.split(
+    f"vllm-router --host {HOST} --port {ROUTER_PORT} --worker-urls {WORKER_URL} "
+    f"--policy consistent_hash --prometheus-port {PROMETHEUS_PORT} --prometheus-host {HOST} "
+    f"--request-timeout-secs {ROUTER_REQUEST_TIMEOUT_S}"
+)
+
+
+@dataclass(frozen=True)
+class RequestEvent:
+    endpoint: str
+    request_token_ids: tuple[int, ...]
+    response_token_ids: tuple[int, ...]
+    has_features: bool
+
+
+class TwoTurnEnvironment:
+    def reset(self) -> None:
+        pass
+
+    def step(self, _response: str) -> tuple[str, bool, dict]:
+        return "Continue the reasoning.", False, {}
+
+    def format_observation(self, observation: str) -> dict[str, str]:
+        return {"role": "user", "content": observation}
+
+    def close(self) -> None:
+        pass
+
+
+def build_env(*, sample: Any, args: Namespace) -> TwoTurnEnvironment:
+    del sample, args
+    return TwoTurnEnvironment()
+
+
+def prepare() -> None:
+    MODEL_PATH.parent.mkdir(parents=True, exist_ok=True)
+    DATA_ROOT.parent.mkdir(parents=True, exist_ok=True)
+    U.exec_command(f"hf download Qwen/{MODEL_NAME} --revision {MODEL_REVISION} --local-dir {MODEL_PATH}")
+    U.exec_command(
+        f"hf download --repo-type dataset {DATASET_NAME} --revision {DATASET_REVISION} --local-dir {DATA_ROOT}"
+    )
+    if not TRAIN_DATA_PATH.is_file():
+        raise FileNotFoundError(f"Dataset not found at {TRAIN_DATA_PATH}")
+
+
+def _wait_for_health(process: subprocess.Popen, health_url: str, log_path: Path) -> None:
+    deadline = time.monotonic() + SERVICE_START_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            break
+        try:
+            with urlopen(f"{health_url}/health", timeout=SERVICE_POLL_INTERVAL_S):
+                return
+        except URLError:
+            time.sleep(SERVICE_POLL_INTERVAL_S)
+    logs = log_path.read_text(encoding="utf-8", errors="replace")
+    raise RuntimeError(f"Service failed to become healthy at {health_url}:\n{logs}")
+
+
+def _stop_process(process: subprocess.Popen | None) -> None:
+    if process is None or process.poll() is not None:
+        return
+    kill_process_tree(process.pid)
+    process.wait(timeout=PROCESS_STOP_TIMEOUT_S)
+
+
+def _start_process(
+    command: list[str],
+    health_url: str,
+    *,
+    log_path: Path,
+    env: dict[str, str] | None = None,
+) -> subprocess.Popen:
+    with log_path.open("w", encoding="utf-8") as log_file:
+        process = subprocess.Popen(command, stdout=log_file, stderr=subprocess.STDOUT, env=env)
+    try:
+        _wait_for_health(process, health_url, log_path)
+    except BaseException:
+        _stop_process(process)
+        raise
+    return process
+
+
+@contextmanager
+def _vllm_services() -> Iterator[None]:
+    ports = (WORKER_PORT, ROUTER_PORT, PROMETHEUS_PORT)
+    if unavailable := [port for port in ports if not is_port_available(port)]:
+        raise RuntimeError(f"Required test ports are already in use: {unavailable}")
+    worker_env = os.environ.copy()
+    worker_env.update(VLLM_SERVER_DEV_MODE="1", VLLM_BATCH_INVARIANT="1")
+    worker = _start_process(WORKER_COMMAND, WORKER_URL, log_path=WORKER_LOG, env=worker_env)
+    router: subprocess.Popen | None = None
+    try:
+        router = _start_process(ROUTER_COMMAND, ROUTER_URL, log_path=ROUTER_LOG)
+        yield
+    finally:
+        try:
+            _stop_process(router)
+        finally:
+            _stop_process(worker)
+
+
+@contextmanager
+def _trace_http_requests() -> Iterator[list[RequestEvent]]:
+    from vime.utils import http_utils
+
+    original_post = http_utils.post
+    events: list[RequestEvent] = []
+
+    async def traced_post(url, body, max_retries=HTTP_MAX_RETRIES, *, headers=None):
+        output = await original_post(url, body, max_retries=max_retries, headers=headers)
+        choices = output.get("choices") if isinstance(output, dict) else None
+        choice = choices[0] if isinstance(choices, list) and choices else {}
+        events.append(
+            RequestEvent(
+                endpoint=urlsplit(url).path,
+                request_token_ids=tuple(int(token) for token in body.get("token_ids") or ()),
+                response_token_ids=tuple(int(token) for token in choice.get("token_ids") or ()),
+                has_features=body.get("features") is not None,
+            )
+        )
+        return output
+
+    http_utils.post = traced_post
+    try:
+        yield events
+    finally:
+        http_utils.post = original_post
+
+
+def _load_sample() -> Any:
+    from vime.utils.data import Dataset
+    from vime.utils.processing_utils import load_processor, load_tokenizer
+
+    data_slice = f"{TRAIN_DATA_PATH}@[{ROW_INDEX}:{ROW_INDEX + 1}]"
+    tokenizer = load_tokenizer(str(MODEL_PATH), trust_remote_code=True)
+    processor = load_processor(str(MODEL_PATH), trust_remote_code=True)
+    dataset = Dataset(
+        data_slice,
+        tokenizer,
+        processor,
+        None,
+        prompt_key="problem",
+        multimodal_keys={"image": "images"},
+    )
+    return dataset[0]
+
+
+async def _run_rollout() -> tuple[Any, list[RequestEvent]]:
+    from vime.utils import http_utils
+
+    args = Namespace(
+        partial_rollout=False,
+        max_turns=MAX_TURNS,
+        rollout_interaction_env_path=__name__,
+        vllm_router_ip=HOST,
+        vllm_router_port=ROUTER_PORT,
+        router_policy="consistent_hash",
+        hf_checkpoint=str(MODEL_PATH),
+        rollout_max_context_len=None,
+        use_rollout_routing_replay=False,
+        vllm_server_concurrency=NUM_GPUS,
+        rollout_num_engines=NUM_GPUS,
+        use_distributed_post=False,
+        rollout_temperature=TEMPERATURE,
+        rollout_top_p=TOP_P,
+        rollout_top_k=TOP_K,
+        rollout_max_response_len=MAX_NEW_TOKENS,
+        rollout_stop=None,
+        rollout_stop_token_ids=None,
+        rollout_skip_special_tokens=False,
+        vllm_dp_size=NUM_GPUS,
+    )
+    sample = _load_sample()
+    http_utils.init_http_client(args)
+    sampling = {
+        "max_new_tokens": MAX_NEW_TOKENS,
+        "temperature": TEMPERATURE,
+        "top_p": TOP_P,
+        "top_k": TOP_K,
+        "skip_special_tokens": False,
+        "seed": SEED,
+    }
+    with _trace_http_requests() as events:
+        generate = load_function(CUSTOM_GENERATE_PATH)
+        result = await generate(args, sample, sampling)
+    return result, events
+
+
+def _validate_result(sample: Any, events: list[RequestEvent]) -> None:
+    assert [event.endpoint for event in events] == [RENDER_ENDPOINT, GENERATE_ENDPOINT, GENERATE_ENDPOINT]
+    first, second = events[1:]
+    assert first.request_token_ids and first.response_token_ids
+    generated_start = len(first.request_token_ids)
+    generated_end = generated_start + len(first.response_token_ids)
+    assert second.request_token_ids[:generated_start] == first.request_token_ids
+    assert second.request_token_ids[generated_start:generated_end] == first.response_token_ids
+    assert len(second.request_token_ids) > generated_end
+    assert sample.tokens == list(second.request_token_ids + second.response_token_ids)
+    assert first.has_features and second.has_features
+    assert sample.response_length == len(sample.loss_mask) == len(sample.rollout_log_probs)
+
+
+def execute() -> None:
+    with _vllm_services():
+        sample, events = asyncio.run(_run_rollout())
+    _validate_result(sample, events)
+
+
+if __name__ == "__main__":
+    prepare()
+    execute()


### PR DESCRIPTION
## Summary

Fixes #331.

- Remove the stale `_apply_vllm_routed_experts` and `_inference_generate_tokens_and_logprobs` imports left behind by #178.
- Render the initial multimodal prompt once and reuse the returned vLLM features for later turns.
- Preserve generated token IDs as the canonical conversation history and append only the chat-template observation suffix between turns.
- Add a deterministic single-GPU Geo3K custom-rollout E2E regression to the manual Buildkite `short` suite.

#178 removed or inlined two private helpers from `vime.rollout.vllm_rollout`, but the Geo3K example continued importing them, causing the module-level `ImportError` reported in #331.

Restoring those helpers alone was insufficient. The legacy implementation decoded the generated assistant response and re-rendered the complete conversation before every turn. Chat-template rendering can tokenize that decoded response differently from the exact token stream returned by vLLM, which caused the prefix-stability failure reported in #331.

The fixed path renders only the initial prompt. Later turns preserve the exact generated token IDs and append only the EOS-aware observation suffix.

## Validation

The E2E uses Qwen/Qwen3-VL-2B-Instruct, VeraIsHere/geo3k_imgurl_processed, one dataset row, two deterministic turns, and one GPU, against a real vLLM worker and router with one multimodal render request and two generation requests.

It verifies:

- public dotted-path loading of the Geo3K `generate` entry point
- exactly `render -> generate -> generate`
- first-turn generated token IDs are preserved verbatim in the second request
- both generation requests carry the render-derived multimodal features
- response tokens, loss masks, and rollout log probabilities remain aligned

Manual A/B validation reproduced the original `ImportError` and demonstrated the legacy re-render divergence: with the deleted helpers restored, the second-turn re-rendered request contained a duplicated EOS token that is absent from the vLLM-generated token stream, while the fixed path issues the canonical request. The rollout patch was applied to a fresh worktree at `b929921` (`origin/main`) and passed the single-GPU E2E; the vLLM worker, router, and engine processes were gone afterward. A later test-only cleanup removed redundant assertions and inlined test configuration without changing the rollout implementation.

## Scope

This test exercises the Geo3K model/data custom-rollout path. It is not a full training-step E2E and uses a deterministic two-turn test environment rather than the real `env_geo3k` behavior. Its assertions assume the pinned model's greedy trajectory completes two turns within the token budget on the CI image.