### PR TITLE
Support online MTP draft weight updates

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=vllm/vllm-openai:v0.23.0-cu129-ubuntu2404
+ARG BASE_IMAGE=vllm/vllm-openai:v0.24.0-cu129-ubuntu2404
 FROM ${BASE_IMAGE}
 
 # ======================================== Arguments =============================================

--- a/docker/patch/latest/vllm.patch
+++ b/docker/patch/latest/vllm.patch
@@ -1,65 +1,41 @@
-diff --git a/vllm/v1/engine/core.py b/vllm/v1/engine/core.py
---- a/vllm/v1/engine/core.py
-+++ b/vllm/v1/engine/core.py
-@@ -775,8 +775,10 @@
-         if tags is None or tags:
-             self.model_executor.wake_up(tags)
- 
--        # Resume scheduling (applies to all levels)
--        self.resume_scheduler()
-+        # Partial wakes intentionally keep the remaining allocations asleep.
-+        # Resume scheduling only once all executor memory is resident again.
-+        if not self.model_executor.is_sleeping:
-+            self.resume_scheduler()
- 
-     def is_sleeping(self) -> bool:
-         """Check if engine is sleeping at any level."""
-@@ -1894,9 +1896,12 @@
-                     continue
- 
-                 # We are in a running state and so must execute a dummy pass
--                # if the model didn't execute any ready requests.
--                with self.log_iteration_details(None):
--                    self.execute_dummy_batch()
-+                # if the model didn't execute any ready requests -- unless the executor is
-+                # asleep (#44483: a decode-shaped dummy batch reads freed KV -> illegal memory
-+                # access). The finished-sync all-reduce below still runs (DP lockstep).
-+                if not self.is_sleeping():
-+                    with self.log_iteration_details(None):
-+                        self.execute_dummy_batch()
- 
-             # 3) All-reduce operation to determine global unfinished reqs.
-             self.engines_running = self._has_global_unfinished_reqs(
-diff --git a/vllm/model_executor/layers/fused_moe/all2all_utils.py b/vllm/model_executor/layers/fused_moe/all2all_utils.py
---- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
-+++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
-@@ -5,7 +5,6 @@ from typing import Any
- 
- import torch
- 
--from vllm.config import get_current_vllm_config
- from vllm.distributed import (
-     get_ep_group,
- )
-@@ -240,9 +239,7 @@ def maybe_make_prepare_finalize(
- 
-     elif moe.use_fi_nvl_one_sided_kernels:
-         assert quant_config is not None
--        max_num_tokens = (
--            get_current_vllm_config().scheduler_config.max_num_batched_tokens
--        )
-+        max_num_tokens = moe.max_num_tokens
-         if quant_config.quant_dtype is None:
-             dispatch_dtype_bytes_per_elem = 2
-             dispatch_scale_bytes_per_token = 0
+diff --git a/vllm/engine/protocol.py b/vllm/engine/protocol.py
+index 3f83734a5..c68f696ba 100644
+--- a/vllm/engine/protocol.py
++++ b/vllm/engine/protocol.py
+@@ -248,6 +248,10 @@ class EngineClient(ABC):
+         """Start a new weight update."""
+         raise NotImplementedError
 
++    async def start_draft_weight_update(self) -> None:
++        """Start a new weight update targeting the speculative draft model."""
++        raise NotImplementedError
++
+     async def update_weights(self, request: WeightTransferUpdateRequest) -> None:
+         """Batched weight update for RL training."""
+         raise NotImplementedError
+diff --git a/vllm/entrypoints/llm.py b/vllm/entrypoints/llm.py
+index 892e5035a..f3e5234d5 100644
+--- a/vllm/entrypoints/llm.py
++++ b/vllm/entrypoints/llm.py
+@@ -880,6 +880,10 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
+             kwargs={"is_checkpoint_format": is_checkpoint_format},
+         )
+
++    def start_draft_weight_update(self) -> None:
++        """Start a new weight update targeting the speculative draft model."""
++        self.llm_engine.collective_rpc("start_draft_weight_update")
++
+     def update_weights(self, request: WeightTransferUpdateRequest | dict) -> None:
+         """
+         Update the weights of the model.
 diff --git a/vllm/entrypoints/serve/dev/rlhf/api_router.py b/vllm/entrypoints/serve/dev/rlhf/api_router.py
+index 6237de877..fe40c012a 100644
 --- a/vllm/entrypoints/serve/dev/rlhf/api_router.py
 +++ b/vllm/entrypoints/serve/dev/rlhf/api_router.py
-@@ -91,6 +91,51 @@ async def resume_generation(raw_request: Request) -> JSONResponse:
+@@ -91,6 +91,47 @@ async def resume_generation(raw_request: Request) -> JSONResponse:
          )
- 
- 
+
+
 +@router.post("/abort_requests")
 +async def abort_requests(raw_request: Request) -> JSONResponse:
 +    """Abort in-flight requests without pausing the scheduler.
@@ -78,12 +54,8 @@ diff --git a/vllm/entrypoints/serve/dev/rlhf/api_router.py b/vllm/entrypoints/se
 +
 +    try:
 +        if request_ids:
-+            # Body ids are external (user-supplied) request ids.
 +            await engine.abort(request_ids)
 +        else:
-+            # The dev RL server runs AsyncLLM; abort everything it is tracking.
-+            # request_states is keyed by internal ids; parent_requests holds
-+            # parallel-sampling parents. Abort both as internal ids.
 +            from vllm.v1.engine.async_llm import AsyncLLM
 +
 +            assert isinstance(engine, AsyncLLM)
@@ -108,16 +80,224 @@ diff --git a/vllm/entrypoints/serve/dev/rlhf/api_router.py b/vllm/entrypoints/se
  @router.get("/is_paused")
  async def is_paused(raw_request: Request) -> JSONResponse:
      """Return the current pause status."""
-diff --git a/vllm/entrypoints/serve/disagg/protocol.py b/vllm/entrypoints/serve/disagg/protocol.py
-index 60d2a64..67f3f98 100644
---- a/vllm/entrypoints/serve/disagg/protocol.py
-+++ b/vllm/entrypoints/serve/disagg/protocol.py
-@@ -203,6 +203,8 @@ class GenerateResponse(BaseModel):
-     )
-     choices: list[GenerateResponseChoice]
- 
-+    usage: UsageInfo | None = Field(default=None)
+@@ -140,6 +181,12 @@ async def start_weight_update(raw_request: Request):
+     return JSONResponse(content={"message": "Weight update started"})
+
+
++@router.post("/start_draft_weight_update")
++async def start_draft_weight_update(raw_request: Request):
++    await engine_client(raw_request).start_draft_weight_update()
++    return JSONResponse(content={"message": "Draft weight update started"})
 +
-     prompt_logprobs: list[dict[int, Logprob] | None] | None = None
- 
-     kv_transfer_params: dict[str, Any] | None = Field(
++
+ @router.post("/update_weights")
+ async def update_weights(raw_request: Request):
+     try:
+diff --git a/vllm/model_executor/layers/fused_moe/all2all_utils.py b/vllm/model_executor/layers/fused_moe/all2all_utils.py
+index 1351e87b5..1a91cc6b6 100644
+--- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
++++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
+@@ -282,9 +282,7 @@ def maybe_make_prepare_finalize(
+
+     elif moe.use_fi_nvl_one_sided_kernels:
+         assert quant_config is not None
+-        max_num_tokens = (
+-            get_current_vllm_config().scheduler_config.max_num_batched_tokens
+-        )
++        max_num_tokens = moe.max_num_tokens
+         if quant_config.quant_dtype is None:
+             dispatch_dtype_bytes_per_elem = 2
+             dispatch_scale_bytes_per_token = 0
+diff --git a/vllm/v1/engine/async_llm.py b/vllm/v1/engine/async_llm.py
+index 419e15163..f39c9a6d5 100644
+--- a/vllm/v1/engine/async_llm.py
++++ b/vllm/v1/engine/async_llm.py
+@@ -1087,6 +1087,10 @@ class AsyncLLM(EngineClient):
+             kwargs={"is_checkpoint_format": is_checkpoint_format},
+         )
+
++    async def start_draft_weight_update(self) -> None:
++        """Start a new weight update targeting the speculative draft model."""
++        await self.collective_rpc("start_draft_weight_update")
++
+     async def update_weights(self, request: WeightTransferUpdateRequest) -> None:
+         """
+         Batched weight update for RL training.
+diff --git a/vllm/v1/worker/gpu/model_runner.py b/vllm/v1/worker/gpu/model_runner.py
+index 30ca2ddc5..853b9e51e 100644
+--- a/vllm/v1/worker/gpu/model_runner.py
++++ b/vllm/v1/worker/gpu/model_runner.py
+@@ -371,6 +371,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+     def get_model(self) -> nn.Module:
+         return self.model
+
++    def get_draft_model(self) -> nn.Module | None:
++        if not isinstance(self.speculator, DraftModelSpeculator):
++            return None
++        return self.speculator.model
++
+     def reload_weights(self, *args, **kwargs) -> None:
+         # TODO(Wentao): Use full version instead of import when fully migrated to v2
+         from vllm.v1.worker.gpu_model_runner import GPUModelRunner as GPUModelRunnerV1
+diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
+index 74938a823..65e223e38 100644
+--- a/vllm/v1/worker/gpu_model_runner.py
++++ b/vllm/v1/worker/gpu_model_runner.py
+@@ -3218,6 +3218,17 @@ class GPUModelRunner(
+             return self.model.unwrap()
+         return self.model
+
++    def get_draft_model(self) -> nn.Module | None:
++        drafter = getattr(self, "drafter", None)
++        if drafter is None:
++            return None
++        model = getattr(drafter, "model", None)
++        if isinstance(
++            model, (CUDAGraphWrapper, UBatchWrapper, BreakableCUDAGraphWrapper)
++        ):
++            return cast(nn.Module, model.unwrap())
++        return cast(nn.Module | None, model)
++
+     def apply_sparse_weight_patches(self, patches: Iterable[SparseWeightPatch]) -> None:
+         """Apply sparse flat-index patches directly to existing model params."""
+         model = self.get_model()
+diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
+index 5e266a313..8e8616111 100644
+--- a/vllm/v1/worker/gpu_worker.py
++++ b/vllm/v1/worker/gpu_worker.py
+@@ -147,6 +147,8 @@ class Worker(WorkerBase):
+         self.weight_transfer_engine: WeightTransferEngine | None = None
+         self._weight_update_active = False
+         self._is_checkpoint_format = True
++        self._weight_update_model: nn.Module | None = None
++        self._weight_update_model_config = None
+
+         # Torch/CUDA profiler. Enabled and configured through profiler_config.
+         # Profiler wrapper is created lazily in profile() when start is called,
+@@ -788,6 +790,32 @@ class Worker(WorkerBase):
+     def get_model(self) -> nn.Module:
+         return self.model_runner.get_model()
+
++    def get_draft_model(self) -> nn.Module | None:
++        return self.model_runner.get_draft_model()
++
++    def _select_weight_update_target(self, is_draft: bool) -> None:
++        if not is_draft:
++            self._weight_update_model = self.model_runner.model
++            self._weight_update_model_config = self.model_config
++            return
++
++        draft_model = self.get_draft_model()
++        if draft_model is None:
++            raise RuntimeError(
++                "Draft model weight update requested, but no draft model is configured."
++            )
++        speculative_config = self.speculative_config
++        if speculative_config is None or speculative_config.draft_model_config is None:
++            raise RuntimeError(
++                "Draft model weight update requested, but no draft model config is configured."
++            )
++        self._weight_update_model = draft_model
++        self._weight_update_model_config = speculative_config.draft_model_config
++
++    def _clear_weight_update_target(self) -> None:
++        self._weight_update_model = None
++        self._weight_update_model_config = None
++
+     def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
+         return self.model_runner.get_supported_tasks()
+
+@@ -1051,6 +1079,18 @@ class Worker(WorkerBase):
+                 format (need layerwise processing) or kernel format (direct
+                 copy / sparse patch application).
+         """
++        self._start_weight_update(
++            is_checkpoint_format=is_checkpoint_format,
++            is_draft=False,
++        )
++
++    def start_draft_weight_update(self) -> None:
++        """Start a checkpoint-format update targeting the speculative draft."""
++        self._start_weight_update(is_checkpoint_format=True, is_draft=True)
++
++    def _start_weight_update(
++        self, *, is_checkpoint_format: bool, is_draft: bool
++    ) -> None:
+         self._check_weight_transfer_engine()
+
+         if self._weight_update_active:
+@@ -1059,14 +1099,19 @@ class Worker(WorkerBase):
+                 "active. Call finish_weight_update first."
+             )
+
+-        if is_checkpoint_format:
+-            from vllm.model_executor.model_loader.reload import (
+-                initialize_layerwise_reload,
+-            )
++        try:
++            self._select_weight_update_target(is_draft)
++            if is_checkpoint_format:
++                from vllm.model_executor.model_loader.reload import (
++                    initialize_layerwise_reload,
++                )
+
+-            model = self.model_runner.model
+-            with torch.device(self.device):
+-                initialize_layerwise_reload(model)
++                assert self._weight_update_model is not None
++                with torch.device(self.device):
++                    initialize_layerwise_reload(self._weight_update_model)
++        except BaseException:
++            self._clear_weight_update_target()
++            raise
+
+         self._is_checkpoint_format = is_checkpoint_format
+         self._weight_update_active = True
+@@ -1104,7 +1149,8 @@ class Worker(WorkerBase):
+                             "`start_weight_update(is_checkpoint_format=False)`."
+                         )
+
+-                    model = self.model_runner.model
++                    assert self._weight_update_model is not None
++                    model = self._weight_update_model
+
+                     # Use layerwise reload pattern for checkpoint format weights
+                     self.weight_transfer_engine.receive_weights(
+@@ -1121,7 +1167,8 @@ class Worker(WorkerBase):
+                         apply_patches=self.model_runner.apply_sparse_weight_patches,
+                     )
+                 else:
+-                    model = self.model_runner.model
++                    assert self._weight_update_model is not None
++                    model = self._weight_update_model
+
+                     # Weights are already in kernel format, copy directly.
+                     def load_weights_direct(
+@@ -1144,6 +1191,7 @@ class Worker(WorkerBase):
+             if not update_succeeded:
+                 self._weight_update_active = False
+                 self._is_checkpoint_format = True
++                self._clear_weight_update_target()
+
+     def finish_weight_update(self) -> None:
+         """Finish the current weight update session."""
+@@ -1159,12 +1207,17 @@ class Worker(WorkerBase):
+                 finalize_layerwise_reload,
+             )
+
+-            model = self.model_runner.model
++            assert self._weight_update_model is not None
++            assert self._weight_update_model_config is not None
+             with torch.device(self.device):
+-                finalize_layerwise_reload(model, self.model_config)
++                finalize_layerwise_reload(
++                    self._weight_update_model,
++                    self._weight_update_model_config,
++                )
+
+         self._weight_update_active = False
+         self._is_checkpoint_format = True
++        self._clear_weight_update_target()
+
+     def shutdown(self) -> None:
+         gc.unfreeze()

--- a/tests/utils/test_update_weight_from_distributed.py
+++ b/tests/utils/test_update_weight_from_distributed.py
@@ -711,8 +711,9 @@ def test_weight_update_session_calls_start_and_finish(upw, monkeypatch):
 def test_source_wraps_sync_with_weight_update_session(upw):
     src = inspect.getsource(upw.UpdateWeightFromDistributed.update_weights)
     assert "_begin_vllm_weight_update_session" in src
+    assert "start_draft_weight_update" in src
     assert "_end_vllm_weight_update_session" in src
-    assert "_send_weights" in src
+    assert src.count("_send_weights_to_rollout_engines") == 2
 
 
 @pytest.mark.unit

--- a/tests/utils/test_update_weight_from_tensor.py
+++ b/tests/utils/test_update_weight_from_tensor.py
@@ -127,6 +127,7 @@ class RecordingVLLMEngine:
     resume_memory_occupation: RecordingRemoteMethod = field(default_factory=RecordingRemoteMethod)
     init_weight_transfer_engine: RecordingRemoteMethod = field(default_factory=RecordingRemoteMethod)
     start_weight_update: RecordingRemoteMethod = field(default_factory=RecordingRemoteMethod)
+    start_draft_weight_update: RecordingRemoteMethod = field(default_factory=RecordingRemoteMethod)
     finish_weight_update: RecordingRemoteMethod = field(default_factory=RecordingRemoteMethod)
     update_weights_from_tensor: RecordingRemoteMethod = field(default_factory=RecordingRemoteMethod)
     pause_generation: RecordingRemoteMethod = field(default_factory=RecordingRemoteMethod)
@@ -141,6 +142,8 @@ def _default_args(**kwargs) -> Namespace:
         rollout_num_gpus_per_engine=2,
         megatron_to_hf_mode="raw",
         update_weight_buffer_size=1 << 30,
+        enable_mtp_training=False,
+        vllm_speculative_config=None,
     )
     base.update(kwargs)
     return Namespace(**base)
@@ -189,7 +192,7 @@ def _run_update(obj, *, chunks=None, rank=0, slot_size=1) -> dict:
     """
     chunks = chunks or _chunks(1)
     obj._hf_weight_iterator = MagicMock()
-    obj._hf_weight_iterator.get_hf_weight_chunks.return_value = iter(chunks)
+    obj._hf_weight_iterator.get_hf_weight_chunks.side_effect = lambda *args, **kwargs: iter(chunks)
 
     counters = {"barrier": 0, "ipc_collect": 0}
 
@@ -234,6 +237,29 @@ def test_colocated_lifecycle_uses_pause_flush_and_weight_transfer_apis(upw_vllm)
     assert counters["ipc_collect"] == 2 + 1
     # lifecycle barriers (no per-chunk barrier).
     assert counters["barrier"] >= 4
+
+
+@pytest.mark.unit
+def test_colocated_mtp_updates_target_then_draft_from_fresh_weight_stream(upw_vllm):
+    obj = _make_instance(
+        upw_vllm,
+        args=_default_args(
+            enable_mtp_training=True,
+            vllm_speculative_config={"method": "mtp", "num_speculative_tokens": 2},
+        ),
+    )
+    engine = RecordingVLLMEngine()
+    _bind_single_slot(obj, engine, src=0)
+
+    dummy_info = {"names": ["w"], "dtype_names": ["bfloat16"], "shapes": [[2, 2]], "ipc_handles": []}
+    with patch(f"{MODULE_PATH}._build_ipc_update_info_from_named_tensors", return_value=(dummy_info, [])):
+        _run_update(obj, chunks=_chunks(2))
+
+    assert len(engine.start_weight_update.calls) == 1
+    assert len(engine.start_draft_weight_update.calls) == 1
+    assert len(engine.finish_weight_update.calls) == 2
+    assert len(engine.update_weights_from_tensor.calls) == 4
+    assert obj._hf_weight_iterator.get_hf_weight_chunks.call_count == 2
 
 
 @pytest.mark.unit

--- a/tests/utils/test_vllm_engine.py
+++ b/tests/utils/test_vllm_engine.py
@@ -338,6 +338,22 @@ def test_start_weight_update_posts_four_phase_endpoint(vllm_engine, monkeypatch)
 
 
 @pytest.mark.unit
+def test_start_draft_weight_update_posts_empty_body(vllm_engine, monkeypatch):
+    calls: list[tuple] = []
+
+    def fake_post(endpoint: str, payload: dict):
+        calls.append((endpoint, payload))
+        return {"ok": True}
+
+    monkeypatch.setattr(vllm_engine, "_make_request", fake_post)
+
+    result = vllm_engine.start_draft_weight_update()
+
+    assert result == {"ok": True}
+    assert calls == [("start_draft_weight_update", {})]
+
+
+@pytest.mark.unit
 def test_finish_weight_update_posts_empty_body(vllm_engine, monkeypatch):
     calls: list[tuple] = []
 

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -164,6 +164,15 @@ class UpdateWeightFromDistributed:
         finally:
             _end_vllm_weight_update_session(self.rollout_engines)
 
+        if self.args.enable_mtp_training and (self.args.vllm_speculative_config or {}).get("method") == "mtp":
+            if dist.get_rank() == 0:
+                ray.get([engine.start_draft_weight_update.remote() for engine in self.rollout_engines])
+            dist.barrier(group=get_gloo_group())
+            try:
+                self._send_weights_to_rollout_engines()
+            finally:
+                _end_vllm_weight_update_session(self.rollout_engines)
+
         dist.barrier(group=get_gloo_group())
         if dist.get_rank() == 0:
             # int4/fp4 post_process

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -317,6 +317,27 @@ class UpdateWeightFromTensor:
             ray.get(self._ipc_engine.finish_weight_update.remote())
         dist.barrier(group=get_gloo_group())
 
+        if (
+            not self.use_distribute
+            and self.args.enable_mtp_training
+            and (self.args.vllm_speculative_config or {}).get("method") == "mtp"
+        ):
+            if self._ipc_engine is not None and rank == self._ipc_gather_src:
+                ray.get(self._ipc_engine.start_draft_weight_update.remote())
+            dist.barrier(group=get_gloo_group())
+
+            for hf_named_tensors in self._hf_weight_iterator.get_hf_weight_chunks(megatron_local_weights):
+                refs, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+                ray.get(refs)
+                del long_lived_tensors, hf_named_tensors
+                torch.cuda.ipc_collect()
+
+            dist.barrier(group=get_gloo_group())
+            torch.cuda.ipc_collect()
+            if self._ipc_engine is not None and rank == self._ipc_gather_src:
+                ray.get(self._ipc_engine.finish_weight_update.remote())
+            dist.barrier(group=get_gloo_group())
+
         # int4/fp4 post_process
         if rank == 0:
             if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -364,6 +364,9 @@ class VLLMEngine(RayActor):
     def start_weight_update(self, is_checkpoint_format: bool = False) -> dict:
         return self._make_request("start_weight_update", {"is_checkpoint_format": is_checkpoint_format})
 
+    def start_draft_weight_update(self) -> dict:
+        return self._make_request("start_draft_weight_update", {})
+
     def finish_weight_update(self) -> dict:
         return self._make_request("finish_weight_update", {})
 


### PR DESCRIPTION
## What

- add a vLLM `start_draft_weight_update` client endpoint
- send a fresh HF weight stream to the built-in MTP draft after updating the target when `--enable-mtp-training` and `--vllm-speculative-config method=mtp` are enabled
- support both colocate IPC and non-colocate NCCL weight transfer
- update the default image to vLLM 0.24.0 and include the required semantic backport of vllm-project/vllm#46725 in `docker/patch/latest/vllm.patch`

## Why

The existing online update path refreshes only the target model. With a trained built-in MTP draft, the draft becomes stale after each optimizer step, causing speculative acceptance to collapse.

This uses the draft update session introduced by vllm-project/vllm#46725. The default Docker image applies the required vLLM patch during build.


## Validation

Tested with `XiaomiMiMo/MiMo-7B-RL` and its built-in `MiMoMTPModel` on 8x H200, using vLLM 0.24.0 with a semantic backport of vllm-project/vllm#46725.

| Variant | Weighted acceptance | Steady tok/GPU/s | vs. no-spec |
|---|---:|---:|---:|
| speculative decoding disabled | n/a | 168.2 | baseline |
| speculative enabled, target-only update | effectively 0% | 124.0 | -26.3% |
| speculative enabled, target + draft update | 58.6% | 252.9 | +50.4% |

### Topology validation

| Mode | GPU layout | Training parallelism | Rollout engines | Result | Observed draft acceptance |
|---|---|---|---|---|---:|
| colocate IPC | 8 shared training/rollout GPUs | TP2 / PP1 / CP1 / DP4 | 4 × TP2 | 3 rollouts passed; every update completed target then draft sessions | about 61% (57.6%–67.4%) |
| non-colocate NCCL | 4 training + 4 rollout GPUs | TP2 / PP1 / CP1 / DP2 | 2 × TP2 | 3 rollouts passed; target and draft each transferred 27 NCCL buckets per update | 58.2%–67.5% |

- MTP-only gradient check: 11 MTP parameters with non-zero gradients, 0 non-MTP parameters with non-zero gradients
- 82 focused CPU tests passed
- the consolidated vLLM patch applies cleanly to the v0.24.0 tag, and all eight patched Python files compile
- targeted Black and Ruff checks passed
- `git diff --check` passed

Host-specific validation workaround: `NCCL_NVLS_ENABLE=0`, because NVLS multicast is unavailable on this machine.
