### PR TITLE
docker: bump base to vLLM 0.25.1, fix mathdx pin, rebase vllm.patch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=vllm/vllm-openai:v0.23.0-cu129-ubuntu2404
+ARG BASE_IMAGE=vllm/vllm-openai:v0.25.1
 FROM ${BASE_IMAGE}
 
 # ======================================== Arguments =============================================
@@ -6,7 +6,7 @@ FROM ${BASE_IMAGE}
 ARG PATCH_VERSION=latest
 ARG MEGATRON_COMMIT=1dcf0dafa884ad52ffb243625717a3471643e087
 
-ARG ENABLE_CUDA_13=0
+ARG ENABLE_CUDA_13=1
 
 # ======================================== Setup =============================================
 
@@ -38,15 +38,16 @@ RUN ln -sf /usr/bin/python3 /usr/local/bin/python
 # ====================================== Python dependencies ============================================
 
 # The validated TransformerEngine 2.16 context-parallel stack uses FA2 + FA3.
-RUN pip uninstall -y flash-attn-4 flash_attn_4 || true
-RUN MAX_JOBS=64 pip -v install flash-attn==2.8.3 --no-build-isolation
+RUN MAX_JOBS=64 pip -v install flash-attn==2.7.4.post1 --no-build-isolation
 
 # This FA3 commit provides the window_size_left/window_size_right API used by TE 2.16.
 RUN git clone https://github.com/Dao-AILab/flash-attention.git && \
-    cd flash-attention/ && git checkout 002cce0a1068f8c07dfccb5a1d232b9a3276947c && git submodule update --init && \
-    cd hopper/ && \
-    FLASH_ATTENTION_FORCE_BUILD=TRUE MAX_JOBS=96 pip -v install . --no-build-isolation && \
-    cd /root/ && rm -rf flash-attention/
+    cd flash-attention/ && git checkout fbf24f67cf7f6442c5cfb2c1057f4bfc57e72d89 && git submodule update --init && cd hopper/ && \
+    MAX_JOBS=96 python setup.py install && \
+    export python_path=`python -c "import site; print(site.getsitepackages()[0])"` && \
+    mkdir -p $python_path/flash_attn_3 && \
+    cp flash_attn_interface.py $python_path/flash_attn_3/flash_attn_interface.py && \
+    rm -rf flash-attention/
 
 RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
 
@@ -72,8 +73,8 @@ RUN apt-get update && \
 
 # TE does not publish a cu13 wheel; build from source when ENABLE_CUDA_13=1.
 RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
-      pip install nvidia-mathdx==26.6.0 pybind11 ninja wheel packaging && \
-      pip -v install --no-build-isolation git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.16; \
+      pip install nvidia-mathdx==25.6.0 pybind11 ninja wheel packaging && \
+      pip -v install --no-build-isolation git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.10; \
     else \
       pip -v install --no-build-isolation "transformer_engine[pytorch]==2.16.1"; \
     fi

--- a/docker/patch/latest/vllm.patch
+++ b/docker/patch/latest/vllm.patch
@@ -1,47 +1,6 @@
-diff --git a/vllm/v1/engine/core.py b/vllm/v1/engine/core.py
---- a/vllm/v1/engine/core.py
-+++ b/vllm/v1/engine/core.py
-@@ -775,8 +775,10 @@
-         if tags is None or tags:
-             self.model_executor.wake_up(tags)
- 
--        # Resume scheduling (applies to all levels)
--        self.resume_scheduler()
-+        # Partial wakes intentionally keep the remaining allocations asleep.
-+        # Resume scheduling only once all executor memory is resident again.
-+        if not self.model_executor.is_sleeping:
-+            self.resume_scheduler()
- 
-     def is_sleeping(self) -> bool:
-         """Check if engine is sleeping at any level."""
-@@ -1894,9 +1896,12 @@
-                     continue
- 
-                 # We are in a running state and so must execute a dummy pass
--                # if the model didn't execute any ready requests.
--                with self.log_iteration_details(None):
--                    self.execute_dummy_batch()
-+                # if the model didn't execute any ready requests -- unless the executor is
-+                # asleep (#44483: a decode-shaped dummy batch reads freed KV -> illegal memory
-+                # access). The finished-sync all-reduce below still runs (DP lockstep).
-+                if not self.is_sleeping():
-+                    with self.log_iteration_details(None):
-+                        self.execute_dummy_batch()
- 
-             # 3) All-reduce operation to determine global unfinished reqs.
-             self.engines_running = self._has_global_unfinished_reqs(
-diff --git a/vllm/model_executor/layers/fused_moe/all2all_utils.py b/vllm/model_executor/layers/fused_moe/all2all_utils.py
 --- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
 +++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
-@@ -5,7 +5,6 @@ from typing import Any
- 
- import torch
- 
--from vllm.config import get_current_vllm_config
- from vllm.distributed import (
-     get_ep_group,
- )
-@@ -240,9 +239,7 @@ def maybe_make_prepare_finalize(
+@@ -282,9 +282,7 @@
  
      elif moe.use_fi_nvl_one_sided_kernels:
          assert quant_config is not None
@@ -52,14 +11,16 @@ diff --git a/vllm/model_executor/layers/fused_moe/all2all_utils.py b/vllm/model_
          if quant_config.quant_dtype is None:
              dispatch_dtype_bytes_per_elem = 2
              dispatch_scale_bytes_per_token = 0
-
-diff --git a/vllm/entrypoints/serve/dev/rlhf/api_router.py b/vllm/entrypoints/serve/dev/rlhf/api_router.py
 --- a/vllm/entrypoints/serve/dev/rlhf/api_router.py
 +++ b/vllm/entrypoints/serve/dev/rlhf/api_router.py
-@@ -91,6 +91,51 @@ async def resume_generation(raw_request: Request) -> JSONResponse:
-         )
- 
- 
+@@ -87,6 +87,51 @@
+         logger.exception("Failed to resume generation")
+         return JSONResponse(
+             content={"error": f"Failed to resume generation: {err}"},
++            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
++        )
++
++
 +@router.post("/abort_requests")
 +async def abort_requests(raw_request: Request) -> JSONResponse:
 +    """Abort in-flight requests without pausing the scheduler.
@@ -101,23 +62,6 @@ diff --git a/vllm/entrypoints/serve/dev/rlhf/api_router.py b/vllm/entrypoints/se
 +        logger.exception("Failed to abort requests")
 +        return JSONResponse(
 +            content={"error": f"Failed to abort requests: {err}"},
-+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
-+        )
-+
-+
- @router.get("/is_paused")
- async def is_paused(raw_request: Request) -> JSONResponse:
-     """Return the current pause status."""
-diff --git a/vllm/entrypoints/serve/disagg/protocol.py b/vllm/entrypoints/serve/disagg/protocol.py
-index 60d2a64..67f3f98 100644
---- a/vllm/entrypoints/serve/disagg/protocol.py
-+++ b/vllm/entrypoints/serve/disagg/protocol.py
-@@ -203,6 +203,8 @@ class GenerateResponse(BaseModel):
-     )
-     choices: list[GenerateResponseChoice]
+             status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+         )
  
-+    usage: UsageInfo | None = Field(default=None)
-+
-     prompt_logprobs: list[dict[int, Logprob] | None] | None = None
- 
-     kv_transfer_params: dict[str, Any] | None = Field(


### PR DESCRIPTION
## Summary

Bump the default vLLM rollout image to **v0.25.1 (cu13)** and make the cu13 build reproducible again. Two files change: `docker/Dockerfile` and `docker/patch/latest/vllm.patch`.

## Changes & why

### `docker/Dockerfile`
| change | why |
|---|---|
| `ARG BASE_IMAGE` → `vllm/vllm-openai:v0.25.1`; `ARG ENABLE_CUDA_13` default → `1` | Bump to 0.25.1. `v0.25.1` is a cu13 image (torch 2.x+cu130), so the cu13 apt/header path must be the default. |
| `nvidia-mathdx` `26.6.0` → `25.6.0` | **`26.6.0` does not exist** on public PyPI *or* `pypi.nvidia.com` (both max out at `25.6.0`). The `==26.6.0` pin was synced from slime PR #1051 and breaks **any** fresh cu13 build (`No matching distribution`). `25.6.0` is what every working vllm/vime cu13 image actually ships (incl. `pr343-02df2fe-cu13`, which runs TE 2.16.1). |
| flash-attn `2.8.3`→`2.7.4.post1`, FA3 commit `002cce0a`→`fbf24f67` (+ `setup.py install`), TE `release_v2.16`→`release_v2.10`, drop `pip uninstall flash-attn-4` | flash-attn **2.8.3 fails the arm64/sbsa source build** under buildkit: silent `exit 255` at `build_ext` start, *no* compiler output (amd64 builds it fine). `2.7.4.post1 + TE 2.10.0` is the combo **proven in `vllm/vime:latest` (cu13)**. fa is coupled to TE (`2.8.3↔TE2.16`, `2.7.4↔TE2.10`), so both revert together. |

### `docker/patch/latest/vllm.patch` (rebased onto 0.25.1)
Verified against the installed vllm in the `v0.25.1` image:
- **dropped** `v1/engine/core.py` sleep/partial-wake guard — **upstreamed** in 0.25.1 (`core.py` already guards `resume_scheduler`/`execute_dummy_batch` with `is_sleeping`).
- **dropped** `serve/disagg/protocol.py` `GenerateResponse.usage` — **upstreamed**; `GenerateResponse` moved to `scale_out/token_in_token_out/protocol.py` and already has `usage: UsageInfo | None`.
- **kept + rebased**: `all2all_utils.py` `max_num_tokens = moe.max_num_tokens` and `serve/dev/rlhf/api_router.py` `/abort_requests` (both still needed; `patch -p1 --dry-run` clean on 0.25.1).

## Build status (in-flight at handoff)
Building multi-arch to staging tags, then fuse → `vllm/vime:latest`:
- **amd64** on h200-1: `tmux` session `amd64build`, log `/home/aoshen/vime-vllm0251-amd64-build.log`, launcher `/home/aoshen/build_amd64_0251.sh`, context `/home/aoshen/vime-router015-ctx-amd64`, tag `vllm/vime:vllm0251-amd64`. Was at flash-attn (step 9/29) compiling 2.7.4.
- **arm64** on gb200 (`ssh gcp-gb200-head`): `tmux` session `vimebuild`, log `/home/aoshen/vime-vllm0251-arm64-build.log`, launcher `/home/aoshen/build_arm64_0251.sh`, context `/home/aoshen/vime-router015-ctx`, tag `vllm/vime:vllm0251-arm64`.
- Both contexts contain this branch's Dockerfile + rebased patch (`--build-arg BASE_IMAGE=vllm/vllm-openai:v0.25.1 --build-arg ENABLE_CUDA_13=1 --build-arg VIME_COMMIT=main`).
- **Fuse step** (once both built): `docker buildx imagetools create -t vllm/vime:latest <amd64-digest> <arm64-digest>` (push per-arch by digest first).

## Open items for the next agent
1. **Finish the builds + push** `vllm/vime:latest` multi-arch. Watch for the flash-attn step (fa 2.7.4 builds on both arches).
2. **flash-attn 2.8.3 buildkit death (unresolved)**: 2.8.3 compiles fine when run *directly* on arm64 (`docker run … pip install flash-attn==2.8.3`, ran 28 min), but dies in ~5 s under buildkit. Root cause not found. If TE 2.16 is wanted back, this must be solved (then re-bump fa→2.8.3 + fa3 002cce0a + TE→2.16).
3. **`vllm-router>=0.1.15`** is required (already the case): 0.25.1 fresh install pulls it.
4. **Not folded in** (decide): vllm #45989 (MoE `enforce_eager` snapshot — not in 0.25.1, OPEN upstream) and #46725 (MTP draft-weight session, from vime #351). Neither blocks the build.
5. Separate WIP: router refactor **PR #350** (cache_aware default + `disable_circuit_breaker`); its A/B is validated (fixed a 25.8k/49.7k→0 `no_available_workers` storm caused by 0.25.1 routing `/inference/v1/generate` through the circuit breaker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
