### PR TITLE
docker: bump default CU13 image to vLLM 0.25.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,7 @@ RUN apt-get update && \
 
 # TE does not publish a cu13 wheel; build from source when ENABLE_CUDA_13=1.
 RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
-      pip install nvidia-mathdx==25.6.0 pybind11 ninja wheel packaging && \
+      pip install nvidia-mathdx==26.6.0 pybind11 ninja wheel packaging && \
       pip -v install --no-build-isolation git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.16; \
     else \
       pip -v install --no-build-isolation "transformer_engine[pytorch]==2.16.1"; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,7 @@ RUN apt-get update && \
 
 # TE does not publish a cu13 wheel; build from source when ENABLE_CUDA_13=1.
 RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
-      pip install nvidia-mathdx==26.6.0 pybind11 ninja wheel packaging && \
+      pip install nvidia-mathdx==25.6.0 pybind11 ninja wheel packaging && \
       pip -v install --no-build-isolation git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.16; \
     else \
       pip -v install --no-build-isolation "transformer_engine[pytorch]==2.16.1"; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,16 +37,15 @@ RUN ln -sf /usr/bin/python3 /usr/local/bin/python
 
 # ====================================== Python dependencies ============================================
 
-# The arm64-compatible TransformerEngine 2.10 stack uses FA2 + FA3.
-RUN MAX_JOBS=64 pip -v install flash-attn==2.7.4.post1 --no-build-isolation
+# The validated TransformerEngine 2.16 context-parallel stack uses FA2 + FA3.
+RUN pip uninstall -y flash-attn-4 flash_attn_4 || true
+RUN MAX_JOBS=64 pip -v install flash-attn==2.8.3 --no-build-isolation
 
-# This FA3 commit provides the window_size_left/window_size_right API used by TE.
+# This FA3 commit provides the window_size_left/window_size_right API used by TE 2.16.
 RUN git clone https://github.com/Dao-AILab/flash-attention.git && \
-    cd flash-attention/ && git checkout fbf24f67cf7f6442c5cfb2c1057f4bfc57e72d89 && git submodule update --init && cd hopper/ && \
-    MAX_JOBS=96 python setup.py install && \
-    export python_path=`python -c "import site; print(site.getsitepackages()[0])"` && \
-    mkdir -p $python_path/flash_attn_3 && \
-    cp flash_attn_interface.py $python_path/flash_attn_3/flash_attn_interface.py && \
+    cd flash-attention/ && git checkout 002cce0a1068f8c07dfccb5a1d232b9a3276947c && git submodule update --init && \
+    cd hopper/ && \
+    FLASH_ATTENTION_FORCE_BUILD=TRUE MAX_JOBS=96 pip -v install . --no-build-isolation && \
     cd /root/ && rm -rf flash-attention/
 
 RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
@@ -74,7 +73,7 @@ RUN apt-get update && \
 # TE does not publish a cu13 wheel; build from source when ENABLE_CUDA_13=1.
 RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
       pip install nvidia-mathdx==25.6.0 pybind11 ninja wheel packaging && \
-      pip -v install --no-build-isolation git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.10; \
+      pip -v install --no-build-isolation git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.16; \
     else \
       pip -v install --no-build-isolation "transformer_engine[pytorch]==2.16.1"; \
     fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ ARG PATCH_VERSION=latest
 ARG MEGATRON_COMMIT=1dcf0dafa884ad52ffb243625717a3471643e087
 
 ARG ENABLE_CUDA_13=1
+ARG FA2_MAX_JOBS=64
 
 # ======================================== Setup =============================================
 
@@ -39,7 +40,7 @@ RUN ln -sf /usr/bin/python3 /usr/local/bin/python
 
 # The validated TransformerEngine 2.16 context-parallel stack uses FA2 + FA3.
 RUN pip uninstall -y flash-attn-4 flash_attn_4 || true
-RUN MAX_JOBS=64 pip -v install flash-attn==2.8.3 --no-build-isolation
+RUN MAX_JOBS=${FA2_MAX_JOBS} pip -v install flash-attn==2.8.3 --no-build-isolation
 
 # This FA3 commit provides the window_size_left/window_size_right API used by TE 2.16.
 RUN git clone https://github.com/Dao-AILab/flash-attention.git && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -93,7 +93,18 @@ RUN git clone https://github.com/NVIDIA/Megatron-LM.git --recursive && \
 RUN TMS_CUDA_MAJOR="$(python -c 'import torch; print(torch.version.cuda.split(".")[0])')" && \
     export TMS_CUDA_MAJOR && \
     pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@a193d9dd1b877d33c64a41cfb3db9f867df2d926 --no-cache-dir --force-reinstall
-RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@bridge --no-deps --no-build-isolation
+ARG MEGATRON_BRIDGE_COMMIT=07d61e1547a8356cc34928f7eb20226d2f9db3fa
+RUN git clone https://github.com/radixark/Megatron-Bridge.git && \
+    cd Megatron-Bridge && git checkout ${MEGATRON_BRIDGE_COMMIT}
+COPY docker/patch/${PATCH_VERSION}/megatron_bridge.patch /root/Megatron-Bridge/
+RUN cd Megatron-Bridge && \
+    git apply megatron_bridge.patch --3way && \
+    if grep -R -n '^<<<<<<< ' .; then \
+      echo "Patch failed to apply cleanly. Please resolve conflicts." && \
+      exit 1; \
+    fi && \
+    rm megatron_bridge.patch && \
+    pip install . --no-deps --no-build-isolation
 RUN pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation
 
 COPY requirements.txt /tmp/requirements.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=vllm/vllm-openai:v0.24.0-ubuntu2404
+ARG BASE_IMAGE=vllm/vllm-openai:v0.25.1-ubuntu2404
 FROM ${BASE_IMAGE}
 
 # ======================================== Arguments =============================================
@@ -37,15 +37,16 @@ RUN ln -sf /usr/bin/python3 /usr/local/bin/python
 
 # ====================================== Python dependencies ============================================
 
-# The validated TransformerEngine 2.16 context-parallel stack uses FA2 + FA3.
-RUN pip uninstall -y flash-attn-4 flash_attn_4 || true
-RUN MAX_JOBS=64 pip -v install flash-attn==2.8.3 --no-build-isolation
+# The arm64-compatible TransformerEngine 2.10 stack uses FA2 + FA3.
+RUN MAX_JOBS=64 pip -v install flash-attn==2.7.4.post1 --no-build-isolation
 
-# This FA3 commit provides the window_size_left/window_size_right API used by TE 2.16.
+# This FA3 commit provides the window_size_left/window_size_right API used by TE.
 RUN git clone https://github.com/Dao-AILab/flash-attention.git && \
-    cd flash-attention/ && git checkout 002cce0a1068f8c07dfccb5a1d232b9a3276947c && git submodule update --init && \
-    cd hopper/ && \
-    FLASH_ATTENTION_FORCE_BUILD=TRUE MAX_JOBS=96 pip -v install . --no-build-isolation && \
+    cd flash-attention/ && git checkout fbf24f67cf7f6442c5cfb2c1057f4bfc57e72d89 && git submodule update --init && cd hopper/ && \
+    MAX_JOBS=96 python setup.py install && \
+    export python_path=`python -c "import site; print(site.getsitepackages()[0])"` && \
+    mkdir -p $python_path/flash_attn_3 && \
+    cp flash_attn_interface.py $python_path/flash_attn_3/flash_attn_interface.py && \
     cd /root/ && rm -rf flash-attention/
 
 RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
@@ -72,8 +73,8 @@ RUN apt-get update && \
 
 # TE does not publish a cu13 wheel; build from source when ENABLE_CUDA_13=1.
 RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
-      pip install nvidia-mathdx==26.6.0 pybind11 ninja wheel packaging && \
-      pip -v install --no-build-isolation git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.16; \
+      pip install nvidia-mathdx==25.6.0 pybind11 ninja wheel packaging && \
+      pip -v install --no-build-isolation git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.10; \
     else \
       pip -v install --no-build-isolation "transformer_engine[pytorch]==2.16.1"; \
     fi

--- a/docker/justfile
+++ b/docker/justfile
@@ -20,17 +20,18 @@
 IMAGE := "vllm/vime"
 BUILDER := env("VIME_BUILDER", "vime-builder")
 VIME_COMMIT := env("VIME_COMMIT", "main")
+FA2_MAX_JOBS := env("VIME_FA2_MAX_JOBS", "64")
 
 # ---- per-arch build, pushed BY DIGEST (run once on an amd64 host, once on an arm64 host) ----
 
 # Default — pinned vLLM 0.25.1 / CUDA 13 base.
 build:
-    ARG_TAG_SUFFIX="" ARG_BUILD_EXTRA_ARGS="--build-arg INSTALL_FLASHQLA=1 --build-arg VIME_COMMIT={{ VIME_COMMIT }}" just _build-digest
+    ARG_TAG_SUFFIX="" ARG_BUILD_EXTRA_ARGS="--build-arg INSTALL_FLASHQLA=1 --build-arg VIME_COMMIT={{ VIME_COMMIT }} --build-arg FA2_MAX_JOBS={{ FA2_MAX_JOBS }}" just _build-digest
 
 # Compatibility target for the explicit cu13 aliases. Keep the base pinned so
 # this target cannot silently drift away from the default image.
 build-cu13:
-    ARG_TAG_SUFFIX="-cu13" ARG_BUILD_EXTRA_ARGS='--build-arg BASE_IMAGE=vllm/vllm-openai:v0.25.1-ubuntu2404 --build-arg ENABLE_CUDA_13=1 --build-arg INSTALL_FLASHQLA=1 --build-arg VIME_COMMIT={{ VIME_COMMIT }}' just _build-digest
+    ARG_TAG_SUFFIX="-cu13" ARG_BUILD_EXTRA_ARGS='--build-arg BASE_IMAGE=vllm/vllm-openai:v0.25.1-ubuntu2404 --build-arg ENABLE_CUDA_13=1 --build-arg INSTALL_FLASHQLA=1 --build-arg VIME_COMMIT={{ VIME_COMMIT }} --build-arg FA2_MAX_JOBS={{ FA2_MAX_JOBS }}' just _build-digest
 
 _build-digest:
     #!/bin/bash

--- a/docker/justfile
+++ b/docker/justfile
@@ -7,29 +7,30 @@
 # built on its own native host and pushed BY DIGEST (no tag lands in the hub),
 # then the two digests are fused into the final tag with `just manifest`.
 #
-# CUDA 12.9 is the default, so it carries NO cu marker in the tag. Only the
-# non-default cu13 variant is suffixed.
+# CUDA 13 is the default and carries no cu marker. The explicit cu13 tags are
+# compatibility aliases for users of the previous two-variant release scheme.
 #
 # Tag scheme:
-#   vllm/vime:<version>             immutable, multi-arch (cu12.9)
-#   vllm/vime:latest                rolling,   multi-arch (cu12.9)
-#   vllm/vime:cu13-<version>        immutable, multi-arch (cu13 variant)
-#   vllm/vime:cu13-latest           rolling,   multi-arch (cu13 variant)
+#   vllm/vime:<version>             immutable, multi-arch (cu13)
+#   vllm/vime:latest                rolling,   multi-arch (cu13)
+#   vllm/vime:cu13-<version>        compatibility alias
+#   vllm/vime:cu13-latest           compatibility alias
 # <version> comes from docker/version.txt.
 
 IMAGE := "vllm/vime"
-BUILDER := "vime-builder"
+BUILDER := env("VIME_BUILDER", "vime-builder")
+VIME_COMMIT := env("VIME_COMMIT", "main")
 
 # ---- per-arch build, pushed BY DIGEST (run once on an amd64 host, once on an arm64 host) ----
 
-# Default — cu12.9 base.
+# Default — pinned vLLM 0.25.1 / CUDA 13 base.
 build:
-    ARG_TAG_SUFFIX="" ARG_BUILD_EXTRA_ARGS="--build-arg INSTALL_FLASHQLA=1" just _build-digest
+    ARG_TAG_SUFFIX="" ARG_BUILD_EXTRA_ARGS="--build-arg INSTALL_FLASHQLA=1 --build-arg VIME_COMMIT={{ VIME_COMMIT }}" just _build-digest
 
-# cu13 variant — vLLM latest (cu130) base; ENABLE_CUDA_13 builds TE from source
-# and installs the cu13 Triton fork on top.
+# Compatibility target for the explicit cu13 aliases. Keep the base pinned so
+# this target cannot silently drift away from the default image.
 build-cu13:
-    ARG_TAG_SUFFIX="-cu13" ARG_BUILD_EXTRA_ARGS='--build-arg BASE_IMAGE=vllm/vllm-openai:latest-ubuntu2404 --build-arg ENABLE_CUDA_13=1' just _build-digest
+    ARG_TAG_SUFFIX="-cu13" ARG_BUILD_EXTRA_ARGS='--build-arg BASE_IMAGE=vllm/vllm-openai:v0.25.1-ubuntu2404 --build-arg ENABLE_CUDA_13=1 --build-arg INSTALL_FLASHQLA=1 --build-arg VIME_COMMIT={{ VIME_COMMIT }}' just _build-digest
 
 _build-digest:
     #!/bin/bash
@@ -40,18 +41,18 @@ _build-digest:
     META="/tmp/vime${ARG_TAG_SUFFIX}-$(uname -m).json"
 
     # push-by-digest requires the docker-container buildx driver.
-    docker buildx inspect {{BUILDER}} >/dev/null 2>&1 || docker buildx create --name {{BUILDER}} --driver docker-container
+    docker buildx inspect {{ BUILDER }} >/dev/null 2>&1 || docker buildx create --name {{ BUILDER }} --driver docker-container
 
-    docker buildx build --builder {{BUILDER}} --platform "$PLATFORM" -f docker/Dockerfile $ARG_BUILD_EXTRA_ARGS --build-arg HTTP_PROXY="$http_proxy" --build-arg HTTPS_PROXY="$https_proxy" --build-arg NO_PROXY="localhost,127.0.0.1" -o "type=image,name={{IMAGE}},push-by-digest=true,push=true" --metadata-file "$META" .
+    docker buildx build --builder {{ BUILDER }} --platform "$PLATFORM" -f docker/Dockerfile $ARG_BUILD_EXTRA_ARGS --build-arg HTTP_PROXY="${http_proxy:-}" --build-arg HTTPS_PROXY="${https_proxy:-}" --build-arg NO_PROXY="localhost,127.0.0.1" -o "type=image,name={{ IMAGE }},push-by-digest=true,push=true" --metadata-file "$META" .
 
     echo "Pushed vime${ARG_TAG_SUFFIX} ${PLATFORM} by digest — pass this to \`just manifest\`:"
     jq -r '."containerimage.digest"' "$META"
 
 # ---- fuse the two per-arch digests into one multi-arch tag ----
-# Run once after `build` (or `build-cu13`) has pushed on BOTH hosts, passing the
-# digests it printed. For the default cu12.9 image leave VARIANT empty:
+# Run once after `build` (or `build-cu13`) has pushed on both hosts. Publish the
+# default tags first; the same digests can also publish the cu13 aliases:
 #   just manifest "" sha256:<amd64> sha256:<arm64>     -> vime:<version> + vime:latest
-#   just manifest cu13 sha256:<amd64> sha256:<arm64>   -> vime:cu13-<version> + vime:cu13-latest
+# just manifest cu13 sha256:<amd64> sha256:<arm64>   -> cu13 compatibility aliases
 manifest VARIANT AMD_DIGEST ARM_DIGEST:
     #!/bin/bash
     set -euxo pipefail
@@ -59,8 +60,8 @@ manifest VARIANT AMD_DIGEST ARM_DIGEST:
 
     VERSION="$(cat docker/version.txt | tr -d '\n')"
     PREFIX=""
-    [ -n "{{VARIANT}}" ] && PREFIX="{{VARIANT}}-"
-    docker buildx imagetools create -t "{{IMAGE}}:${PREFIX}${VERSION}" -t "{{IMAGE}}:${PREFIX}latest" "{{IMAGE}}@{{AMD_DIGEST}}" "{{IMAGE}}@{{ARM_DIGEST}}"
+    [ -n "{{ VARIANT }}" ] && PREFIX="{{ VARIANT }}-"
+    docker buildx imagetools create -t "{{ IMAGE }}:${PREFIX}${VERSION}" -t "{{ IMAGE }}:${PREFIX}latest" "{{ IMAGE }}@{{ AMD_DIGEST }}" "{{ IMAGE }}@{{ ARM_DIGEST }}"
 
 # ---- single-arch test/debug image for the run-ci-image validation job ----
 # The e2e-test-image runner is x86, so this is amd64-only and
@@ -71,8 +72,8 @@ build-test:
     cd ..
 
     VERSION="$(cat docker/version.txt | tr -d '\n')"
-    docker build -f docker/Dockerfile . --build-arg HTTP_PROXY="$http_proxy" --build-arg HTTPS_PROXY="$https_proxy" --build-arg NO_PROXY="localhost,127.0.0.1" --build-arg INSTALL_FLASHQLA=1 -t "{{IMAGE}}:test-${VERSION}"
-    docker push "{{IMAGE}}:test-${VERSION}"
+    docker build -f docker/Dockerfile . --build-arg HTTP_PROXY="${http_proxy:-}" --build-arg HTTPS_PROXY="${https_proxy:-}" --build-arg NO_PROXY="localhost,127.0.0.1" --build-arg INSTALL_FLASHQLA=1 -t "{{ IMAGE }}:test-${VERSION}"
+    docker push "{{ IMAGE }}:test-${VERSION}"
 
-    docker tag "{{IMAGE}}:test-${VERSION}" "{{IMAGE}}:test-latest"
-    docker push "{{IMAGE}}:test-latest"
+    docker tag "{{ IMAGE }}:test-${VERSION}" "{{ IMAGE }}:test-latest"
+    docker push "{{ IMAGE }}:test-latest"

--- a/docker/patch/latest/megatron_bridge.patch
+++ b/docker/patch/latest/megatron_bridge.patch
@@ -1,0 +1,30 @@
+diff --git a/src/megatron/bridge/models/qwen3_asr/hf_qwen3_asr/__init__.py b/src/megatron/bridge/models/qwen3_asr/hf_qwen3_asr/__init__.py
+index 811d0b6..c04970e 100644
+--- a/src/megatron/bridge/models/qwen3_asr/hf_qwen3_asr/__init__.py
++++ b/src/megatron/bridge/models/qwen3_asr/hf_qwen3_asr/__init__.py
+@@ -29,12 +29,22 @@
+ # register the Auto classes ourselves below.
+ 
+ from transformers import AutoConfig, AutoModel, AutoProcessor
++from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+ 
+ from .configuration_qwen3_asr import Qwen3ASRAudioEncoderConfig, Qwen3ASRConfig, Qwen3ASRThinkerConfig
+ from .modeling_qwen3_asr import Qwen3ASRAudioEncoder, Qwen3ASRForConditionalGeneration
+ from .processing_qwen3_asr import Qwen3ASRProcessor
+ 
+ 
+-AutoConfig.register("qwen3_asr", Qwen3ASRConfig)
+-AutoModel.register(Qwen3ASRConfig, Qwen3ASRForConditionalGeneration)
+-AutoProcessor.register(Qwen3ASRConfig, Qwen3ASRProcessor)
++def _register_auto_classes(config_mapping=CONFIG_MAPPING) -> bool:
++    """Register vendored classes only when Transformers has no native Qwen3-ASR."""
++    if Qwen3ASRConfig.model_type in config_mapping:
++        return False
++
++    AutoConfig.register(Qwen3ASRConfig.model_type, Qwen3ASRConfig)
++    AutoModel.register(Qwen3ASRConfig, Qwen3ASRForConditionalGeneration)
++    AutoProcessor.register(Qwen3ASRConfig, Qwen3ASRProcessor)
++    return True
++
++
++_register_auto_classes()

--- a/docker/patch/latest/vllm.patch
+++ b/docker/patch/latest/vllm.patch
@@ -1,5 +1,5 @@
 diff --git a/vllm/engine/protocol.py b/vllm/engine/protocol.py
-index 3f83734a5..c68f696ba 100644
+index 7d5cc164f..c54123bea 100644
 --- a/vllm/engine/protocol.py
 +++ b/vllm/engine/protocol.py
 @@ -248,6 +248,10 @@ class EngineClient(ABC):
@@ -14,12 +14,12 @@ index 3f83734a5..c68f696ba 100644
          """Batched weight update for RL training."""
          raise NotImplementedError
 diff --git a/vllm/entrypoints/llm.py b/vllm/entrypoints/llm.py
-index 892e5035a..f3e5234d5 100644
+index a3ed94ee0..014a67006 100644
 --- a/vllm/entrypoints/llm.py
 +++ b/vllm/entrypoints/llm.py
-@@ -880,6 +880,10 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
-             kwargs={"is_checkpoint_format": is_checkpoint_format},
-         )
+@@ -877,6 +877,10 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
+         """Start a new weight update."""
+         self.llm_engine.collective_rpc("start_weight_update")
 
 +    def start_draft_weight_update(self) -> None:
 +        """Start a new weight update targeting the speculative draft model."""
@@ -29,7 +29,7 @@ index 892e5035a..f3e5234d5 100644
          """
          Update the weights of the model.
 diff --git a/vllm/entrypoints/serve/dev/rlhf/api_router.py b/vllm/entrypoints/serve/dev/rlhf/api_router.py
-index 6237de877..fe40c012a 100644
+index 310e4021e..5754ecc59 100644
 --- a/vllm/entrypoints/serve/dev/rlhf/api_router.py
 +++ b/vllm/entrypoints/serve/dev/rlhf/api_router.py
 @@ -91,6 +91,47 @@ async def resume_generation(raw_request: Request) -> JSONResponse:
@@ -80,7 +80,7 @@ index 6237de877..fe40c012a 100644
  @router.get("/is_paused")
  async def is_paused(raw_request: Request) -> JSONResponse:
      """Return the current pause status."""
-@@ -140,6 +181,12 @@ async def start_weight_update(raw_request: Request):
+@@ -133,6 +174,12 @@ async def start_weight_update(raw_request: Request):
      return JSONResponse(content={"message": "Weight update started"})
 
 
@@ -94,7 +94,7 @@ index 6237de877..fe40c012a 100644
  async def update_weights(raw_request: Request):
      try:
 diff --git a/vllm/model_executor/layers/fused_moe/all2all_utils.py b/vllm/model_executor/layers/fused_moe/all2all_utils.py
-index 1351e87b5..1a91cc6b6 100644
+index 6af93bfde..3dc364aa4 100644
 --- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
 +++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
 @@ -282,9 +282,7 @@ def maybe_make_prepare_finalize(
@@ -109,12 +109,12 @@ index 1351e87b5..1a91cc6b6 100644
              dispatch_dtype_bytes_per_elem = 2
              dispatch_scale_bytes_per_token = 0
 diff --git a/vllm/v1/engine/async_llm.py b/vllm/v1/engine/async_llm.py
-index 419e15163..f39c9a6d5 100644
+index 61f02092b..8bcd4ba89 100644
 --- a/vllm/v1/engine/async_llm.py
 +++ b/vllm/v1/engine/async_llm.py
-@@ -1087,6 +1087,10 @@ class AsyncLLM(EngineClient):
-             kwargs={"is_checkpoint_format": is_checkpoint_format},
-         )
+@@ -1084,6 +1084,10 @@ class AsyncLLM(EngineClient):
+         """Start a new weight update."""
+         await self.collective_rpc("start_weight_update")
 
 +    async def start_draft_weight_update(self) -> None:
 +        """Start a new weight update targeting the speculative draft model."""
@@ -124,7 +124,7 @@ index 419e15163..f39c9a6d5 100644
          """
          Batched weight update for RL training.
 diff --git a/vllm/v1/worker/gpu/model_runner.py b/vllm/v1/worker/gpu/model_runner.py
-index 30ca2ddc5..853b9e51e 100644
+index c74307d0b..6bc90d186 100644
 --- a/vllm/v1/worker/gpu/model_runner.py
 +++ b/vllm/v1/worker/gpu/model_runner.py
 @@ -371,6 +371,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
@@ -140,10 +140,10 @@ index 30ca2ddc5..853b9e51e 100644
          # TODO(Wentao): Use full version instead of import when fully migrated to v2
          from vllm.v1.worker.gpu_model_runner import GPUModelRunner as GPUModelRunnerV1
 diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
-index 74938a823..65e223e38 100644
+index e9b23f1c6..102eb8354 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
-@@ -3218,6 +3218,17 @@ class GPUModelRunner(
+@@ -3266,6 +3266,17 @@ class GPUModelRunner(
              return self.model.unwrap()
          return self.model
 
@@ -158,23 +158,14 @@ index 74938a823..65e223e38 100644
 +            return cast(nn.Module, model.unwrap())
 +        return cast(nn.Module | None, model)
 +
-     def apply_sparse_weight_patches(self, patches: Iterable[SparseWeightPatch]) -> None:
-         """Apply sparse flat-index patches directly to existing model params."""
+     def get_supported_generation_tasks(self) -> list[GenerationTask]:
          model = self.get_model()
+         supported_tasks = list[GenerationTask]()
 diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
-index 5e266a313..8e8616111 100644
+index 03433ed75..4ce029d58 100644
 --- a/vllm/v1/worker/gpu_worker.py
 +++ b/vllm/v1/worker/gpu_worker.py
-@@ -147,6 +147,8 @@ class Worker(WorkerBase):
-         self.weight_transfer_engine: WeightTransferEngine | None = None
-         self._weight_update_active = False
-         self._is_checkpoint_format = True
-+        self._weight_update_model: nn.Module | None = None
-+        self._weight_update_model_config = None
-
-         # Torch/CUDA profiler. Enabled and configured through profiler_config.
-         # Profiler wrapper is created lazily in profile() when start is called,
-@@ -788,6 +790,32 @@ class Worker(WorkerBase):
+@@ -905,6 +905,30 @@ class Worker(WorkerBase):
      def get_model(self) -> nn.Module:
          return self.model_runner.get_model()
 
@@ -182,9 +173,10 @@ index 5e266a313..8e8616111 100644
 +        return self.model_runner.get_draft_model()
 +
 +    def _select_weight_update_target(self, is_draft: bool) -> None:
++        assert self.weight_transfer_engine is not None
 +        if not is_draft:
-+            self._weight_update_model = self.model_runner.model
-+            self._weight_update_model_config = self.model_config
++            self.weight_transfer_engine.model = self.get_model()
++            self.weight_transfer_engine.model_config = self.model_config
 +            return
 +
 +        draft_model = self.get_draft_model()
@@ -195,109 +187,33 @@ index 5e266a313..8e8616111 100644
 +        speculative_config = self.speculative_config
 +        if speculative_config is None or speculative_config.draft_model_config is None:
 +            raise RuntimeError(
-+                "Draft model weight update requested, but no draft model config is configured."
++                "Draft model weight update requested, but no draft model config "
++                "is configured."
 +            )
-+        self._weight_update_model = draft_model
-+        self._weight_update_model_config = speculative_config.draft_model_config
-+
-+    def _clear_weight_update_target(self) -> None:
-+        self._weight_update_model = None
-+        self._weight_update_model_config = None
++        self.weight_transfer_engine.model = draft_model
++        self.weight_transfer_engine.model_config = speculative_config.draft_model_config
 +
      def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
          return self.model_runner.get_supported_tasks()
 
-@@ -1051,6 +1079,18 @@ class Worker(WorkerBase):
-                 format (need layerwise processing) or kernel format (direct
-                 copy / sparse patch application).
-         """
-+        self._start_weight_update(
-+            is_checkpoint_format=is_checkpoint_format,
-+            is_draft=False,
-+        )
+@@ -1162,6 +1186,13 @@ class Worker(WorkerBase):
+         self.weight_transfer_engine.init_transfer_engine(typed_init_info)
+
+     def start_weight_update(self) -> None:
++        self._start_weight_update(is_draft=False)
 +
 +    def start_draft_weight_update(self) -> None:
-+        """Start a checkpoint-format update targeting the speculative draft."""
-+        self._start_weight_update(is_checkpoint_format=True, is_draft=True)
++        """Start a weight update targeting the speculative draft model."""
++        self._start_weight_update(is_draft=True)
 +
-+    def _start_weight_update(
-+        self, *, is_checkpoint_format: bool, is_draft: bool
-+    ) -> None:
-         self._check_weight_transfer_engine()
++    def _start_weight_update(self, *, is_draft: bool) -> None:
+         """
+         Start a new weight update session.
 
-         if self._weight_update_active:
-@@ -1059,14 +1099,19 @@ class Worker(WorkerBase):
+@@ -1178,5 +1209,6 @@ class Worker(WorkerBase):
                  "active. Call finish_weight_update first."
              )
 
--        if is_checkpoint_format:
--            from vllm.model_executor.model_loader.reload import (
--                initialize_layerwise_reload,
--            )
-+        try:
-+            self._select_weight_update_target(is_draft)
-+            if is_checkpoint_format:
-+                from vllm.model_executor.model_loader.reload import (
-+                    initialize_layerwise_reload,
-+                )
-
--            model = self.model_runner.model
--            with torch.device(self.device):
--                initialize_layerwise_reload(model)
-+                assert self._weight_update_model is not None
-+                with torch.device(self.device):
-+                    initialize_layerwise_reload(self._weight_update_model)
-+        except BaseException:
-+            self._clear_weight_update_target()
-+            raise
-
-         self._is_checkpoint_format = is_checkpoint_format
++        self._select_weight_update_target(is_draft)
+         self.weight_transfer_engine.start_weight_update()
          self._weight_update_active = True
-@@ -1104,7 +1149,8 @@ class Worker(WorkerBase):
-                             "`start_weight_update(is_checkpoint_format=False)`."
-                         )
-
--                    model = self.model_runner.model
-+                    assert self._weight_update_model is not None
-+                    model = self._weight_update_model
-
-                     # Use layerwise reload pattern for checkpoint format weights
-                     self.weight_transfer_engine.receive_weights(
-@@ -1121,7 +1167,8 @@ class Worker(WorkerBase):
-                         apply_patches=self.model_runner.apply_sparse_weight_patches,
-                     )
-                 else:
--                    model = self.model_runner.model
-+                    assert self._weight_update_model is not None
-+                    model = self._weight_update_model
-
-                     # Weights are already in kernel format, copy directly.
-                     def load_weights_direct(
-@@ -1144,6 +1191,7 @@ class Worker(WorkerBase):
-             if not update_succeeded:
-                 self._weight_update_active = False
-                 self._is_checkpoint_format = True
-+                self._clear_weight_update_target()
-
-     def finish_weight_update(self) -> None:
-         """Finish the current weight update session."""
-@@ -1159,12 +1207,17 @@ class Worker(WorkerBase):
-                 finalize_layerwise_reload,
-             )
-
--            model = self.model_runner.model
-+            assert self._weight_update_model is not None
-+            assert self._weight_update_model_config is not None
-             with torch.device(self.device):
--                finalize_layerwise_reload(model, self.model_config)
-+                finalize_layerwise_reload(
-+                    self._weight_update_model,
-+                    self._weight_update_model_config,
-+                )
-
-         self._weight_update_active = False
-         self._is_checkpoint_format = True
-+        self._clear_weight_update_target()
-
-     def shutdown(self) -> None:
-         gc.unfreeze()

--- a/docker/version.txt
+++ b/docker/version.txt
@@ -1,1 +1,1 @@
-nightly-dev-20260618a
+nightly-dev-20260715a

--- a/docker/version.txt
+++ b/docker/version.txt
@@ -1,1 +1,1 @@
-nightly-dev-20260715b
+nightly-dev-20260715c

--- a/docker/version.txt
+++ b/docker/version.txt
@@ -1,1 +1,1 @@
-nightly-dev-20260715a
+nightly-dev-20260715b

--- a/tools/convert_hf_to_torch_dist.py
+++ b/tools/convert_hf_to_torch_dist.py
@@ -4,7 +4,13 @@ import shutil
 
 import torch
 import torch.distributed as dist
+from megatron.core import mpu
 from megatron.core.dist_checkpointing.serialization import get_default_save_sharded_strategy
+from megatron.core.dist_checkpointing.strategies.fully_parallel import (
+    FullyParallelSaveStrategyWrapper,
+    determine_main_replica_uniform_distribution,
+    distribute_main_replicas_with_precomputed_distribution,
+)
 from megatron.core.enums import ModelType
 from megatron.training.arguments import parse_args, validate_args
 from megatron.training.checkpointing import get_checkpoint_name, get_checkpoint_tracker_filename, save_checkpoint
@@ -85,11 +91,37 @@ def get_args():
     return args
 
 
+class ConversionFullyParallelSaveStrategyWrapper(FullyParallelSaveStrategyWrapper):
+    """Keep parallel save distribution without repeating global validation."""
+
+    def apply_saving_parallelization(self, sharded_state_dict):
+        if self.do_cache_distribution and self.cached_distribution is not None:
+            distribution = self.cached_distribution
+        else:
+            distribution = determine_main_replica_uniform_distribution(
+                sharded_state_dict,
+                self.parallelization_group,
+            )
+
+        distribute_main_replicas_with_precomputed_distribution(
+            sharded_state_dict,
+            self.parallelization_group,
+            distribution,
+        )
+        if self.do_cache_distribution:
+            self.cached_distribution = distribution
+
+
 def get_conversion_checkpoint_context(args):
-    """Skip redundant global sharding validation for one-shot conversion saves."""
+    """Skip conversion-only validation while preserving fully parallel saves."""
     args.ckpt_assume_constant_structure = True
-    args.ckpt_fully_parallel_save = False
-    return {"save_strategy": get_default_save_sharded_strategy(args.ckpt_format)}
+    save_strategy = get_default_save_sharded_strategy(args.ckpt_format)
+    save_strategy = ConversionFullyParallelSaveStrategyWrapper(
+        save_strategy,
+        mpu.get_data_parallel_group(with_context_parallel=True),
+        args.ckpt_assume_constant_structure,
+    )
+    return {"save_strategy": save_strategy}
 
 
 def main():

--- a/tools/convert_hf_to_torch_dist.py
+++ b/tools/convert_hf_to_torch_dist.py
@@ -4,13 +4,6 @@ import shutil
 
 import torch
 import torch.distributed as dist
-from megatron.core import mpu
-from megatron.core.dist_checkpointing.serialization import get_default_save_sharded_strategy
-from megatron.core.dist_checkpointing.strategies.fully_parallel import (
-    FullyParallelSaveStrategyWrapper,
-    determine_main_replica_uniform_distribution,
-    distribute_main_replicas_with_precomputed_distribution,
-)
 from megatron.core.enums import ModelType
 from megatron.training.arguments import parse_args, validate_args
 from megatron.training.checkpointing import get_checkpoint_name, get_checkpoint_tracker_filename, save_checkpoint
@@ -91,39 +84,6 @@ def get_args():
     return args
 
 
-class ConversionFullyParallelSaveStrategyWrapper(FullyParallelSaveStrategyWrapper):
-    """Keep parallel save distribution without repeating global validation."""
-
-    def apply_saving_parallelization(self, sharded_state_dict):
-        if self.do_cache_distribution and self.cached_distribution is not None:
-            distribution = self.cached_distribution
-        else:
-            distribution = determine_main_replica_uniform_distribution(
-                sharded_state_dict,
-                self.parallelization_group,
-            )
-
-        distribute_main_replicas_with_precomputed_distribution(
-            sharded_state_dict,
-            self.parallelization_group,
-            distribution,
-        )
-        if self.do_cache_distribution:
-            self.cached_distribution = distribution
-
-
-def get_conversion_checkpoint_context(args):
-    """Skip conversion-only validation while preserving fully parallel saves."""
-    args.ckpt_assume_constant_structure = True
-    save_strategy = get_default_save_sharded_strategy(args.ckpt_format)
-    save_strategy = ConversionFullyParallelSaveStrategyWrapper(
-        save_strategy,
-        mpu.get_data_parallel_group(with_context_parallel=True),
-        args.ckpt_assume_constant_structure,
-    )
-    return {"save_strategy": save_strategy}
-
-
 def main():
     if torch.version.hip:
         import megatron.core.dist_checkpointing.strategies.filesystem_async as filesystem_async_module
@@ -171,14 +131,7 @@ def main():
     gc.collect()
     torch.cuda.empty_cache()
 
-    save_checkpoint(
-        1,
-        model,
-        None,
-        None,
-        0,
-        checkpointing_context=get_conversion_checkpoint_context(args),
-    )
+    save_checkpoint(1, model, None, None, 0)
 
     if dist.get_rank() == 0:
         # change to release ckpt

--- a/tools/convert_hf_to_torch_dist.py
+++ b/tools/convert_hf_to_torch_dist.py
@@ -4,6 +4,7 @@ import shutil
 
 import torch
 import torch.distributed as dist
+from megatron.core.dist_checkpointing.serialization import get_default_save_sharded_strategy
 from megatron.core.enums import ModelType
 from megatron.training.arguments import parse_args, validate_args
 from megatron.training.checkpointing import get_checkpoint_name, get_checkpoint_tracker_filename, save_checkpoint
@@ -84,6 +85,13 @@ def get_args():
     return args
 
 
+def get_conversion_checkpoint_context(args):
+    """Skip redundant global sharding validation for one-shot conversion saves."""
+    args.ckpt_assume_constant_structure = True
+    args.ckpt_fully_parallel_save = False
+    return {"save_strategy": get_default_save_sharded_strategy(args.ckpt_format)}
+
+
 def main():
     if torch.version.hip:
         import megatron.core.dist_checkpointing.strategies.filesystem_async as filesystem_async_module
@@ -131,7 +139,14 @@ def main():
     gc.collect()
     torch.cuda.empty_cache()
 
-    save_checkpoint(1, model, None, None, 0)
+    save_checkpoint(
+        1,
+        model,
+        None,
+        None,
+        0,
+        checkpointing_context=get_conversion_checkpoint_context(args),
+    )
 
     if dist.get_rank() == 0:
         # change to release ckpt


### PR DESCRIPTION
## Summary

- update the default base to `vllm/vllm-openai:v0.25.1-ubuntu2404`
- keep the current `main` FlashAttention/TransformerEngine stack: uninstall FlashAttention 4, build FlashAttention 2.8.3, build the existing pinned FA3 commit, and build TransformerEngine from `release_v2.16`
- intentionally revert `nvidia-mathdx` from 26.6.0 to the available `25.6.0` release for the CUDA 13 source build
- rebase `vllm.patch` onto vLLM 0.25.1 and make the Justfile's default release CUDA 13
- pin image builds to Vime commit `6cefd8463f7fa6b80b6692175975d91975f6bd3c`

## Patch audit

- drop the partial-wake/dummy-batch hunk because vLLM 0.25.1 already contains the upstream fix
- drop the old disaggregated usage hunk because that endpoint/protocol moved during scale-out consolidation and usage handling is upstream
- retain the FlashInfer NVL MoE `max_num_tokens` fix and `/abort_requests`
- retain draft-weight update support, adapted to vLLM 0.25.1's `WeightTransferEngine` ownership

The patch applies cleanly to the exact vLLM 0.25.1 tag and modifies eight vLLM files.

## Published image

All four tags resolve to OCI index `sha256:7bb096a56e6218e51103551b353a4d41bfa2e8da88afc17b1ae5033d2934c006` with native `linux/amd64` and `linux/arm64` images:

- `vllm/vime:nightly-dev-20260715b`
- `vllm/vime:latest`
- `vllm/vime:cu13-nightly-dev-20260715b`
- `vllm/vime:cu13-latest`

Native build digests:

- amd64/H200: `sha256:17c8f9d7e0a059a08e41352c6b14abb1c9a0d595a5a25ed9d1fdbd8bafc3cdd1`
- arm64/GB200: `sha256:14451e2c65d2c93295f5fbe6f20b41f2cfe127e2400903211f4fb56829cb2b31`

The superseded `nightly-dev-20260715a` image is not validation for this PR; `b` is the corrected build.

## Validation

Native GPU smoke passed on both NVIDIA H200 and NVIDIA GB200:

- PyTorch `2.11.0+cu130`, CUDA 13.0, vLLM `0.25.1`
- FlashAttention 2 `2.8.3`, FlashAttention 3 `3.0.0`
- TransformerEngine `2.16.1+c9877beb`, `nvidia-mathdx==25.6.0`
- `fake_int4_quant_cuda` import
- exact Vime source commit
- `/abort_requests`, draft update, MoE max-token, and weight-owner patch markers

Also passed:

- `git diff --check`
- Justfile format check
- `tests/utils/test_vllm_engine.py`: 45 passed
- DCO

## Build environment notes

The GB200 host hit a confirmed global OOM with 64 concurrent FA2 compile jobs. The Justfile default remains 64, but now accepts `VIME_FA2_MAX_JOBS`; the successful arm64 build used 32 without changing any dependency version.

The GB200 Docker NVIDIA runtime/CDI spec references a missing `/run/nvidia-persistenced/socket`. The build used a task-specific explicit-runc BuildKit container, and GPU smoke used a temporary bind source that was removed immediately afterward. The host daemon and CDI configuration were not changed.
