### PR TITLE
ci(rocm): AMD ROCm GPU CI on Buildkite

### DIFF
--- a/.buildkite/pipeline-rocm.yaml
+++ b/.buildkite/pipeline-rocm.yaml
@@ -1,0 +1,105 @@
+# Buildkite CI for vime — AMD ROCm GPU suites.
+#
+# Declarative ROCm pipeline in the style of vllm-omni's .buildkite/test-amd*.yaml
+# (one step per test on a self-hosted AMD agent queue; `soft_fail` for suites
+# that run but aren't green yet), adapted to vime:
+#   * tests run inside the prebuilt ROCm image (docker/Dockerfile.rocm) via
+#     `docker run` with the ROCm devices passed through, mirroring how the CUDA
+#     suites run in a prebuilt vllm/vime container;
+#   * GPUs are arbitrated across concurrent steps with tests/ci/gpu_lock_exec.py
+#     on HIP_VISIBLE_DEVICES (the AMD analogue of CUDA_VISIBLE_DEVICES);
+#   * tests take the U.is_rocm() path (HF->Megatron conversion, no bridge).
+#
+# One-time setup (see .buildkite/README.md):
+#   * a Buildkite agent on the gfx950 (MI350X) node tagged  queue=amd_gfx950
+#     with docker access and the ROCm devices (/dev/kfd, /dev/dri) available.
+#
+# Blocking vs soft_fail mirrors vllm-omni's `grade`: fully_async is validated
+# end-to-end on ROCm and gates the build; the gsm8k suites run but stay
+# non-blocking until the vLLM/ROCm NaN-logprob divergence is fixed.
+
+env:
+  # Prebuilt ROCm image (built from docker/Dockerfile.rocm). Override per-agent
+  # via a pipeline/agent env var if the image is published elsewhere.
+  VIME_ROCM_IMAGE: "vllm/vime-rocm:latest"
+
+steps:
+  # Manual gate — the GPU suites are expensive, so they run on demand rather
+  # than on every commit (matches the CUDA pipeline.yml gate).
+  - block: ":amd: Run AMD ROCm GPU suites?"
+    key: rocm-gate
+    blocked_state: passed
+
+  - group: ":amd: ROCm GPU Tests"
+    depends_on: rocm-gate
+    steps:
+      - label: ":fire: short · fully_async 0.5B (4 GPU)"
+        key: rocm-fully-async-short
+        agents:
+          queue: amd_gfx950
+        timeout_in_minutes: 360
+        soft_fail: false
+        retry:
+          automatic:
+            - exit_status: -1  # agent lost (fresh instance failed to boot)
+              limit: 2
+        env:
+          TEST_FILE: "test_qwen2.5_0.5B_fully_async_short.py"
+          NUM_GPUS: "4"
+        # $$VAR / $$PWD are escaped so the buildkite-agent expands them at run
+        # time (from the step env / checkout) instead of Buildkite interpolating
+        # them to empty at pipeline-upload time. The inner `bash -lc` script is
+        # single-quoted, so $TEST_FILE / $NUM_GPUS are expanded by the container
+        # shell from the forwarded (-e) env, not the host.
+        command: &rocm_gpu_test |
+          docker run --rm \
+            --device=/dev/kfd --device=/dev/dri --group-add video --privileged \
+            --security-opt seccomp=unconfined --ipc=host --shm-size=16g \
+            --ulimit memlock=-1 --ulimit stack=67108864 --ulimit nofile=1048576:1048576 \
+            -e VIME_AMD_ROCM=1 -e VIME_TEST_DEVICE=rocm -e VIME_SCRIPT_EXTERNAL_RAY=0 \
+            -e HF_HOME=/root/.cache/huggingface \
+            -e GITHUB_COMMIT_NAME="$$BUILDKITE_COMMIT" \
+            -e TEST_FILE -e NUM_GPUS \
+            -v "/root/.cache/huggingface:/root/.cache/huggingface" \
+            -v "$$PWD:/root/vime" -w /root/vime \
+            --entrypoint bash "$$VIME_ROCM_IMAGE" -lc '
+              set -euo pipefail
+              pip install -e . --no-deps --break-system-packages
+              python tests/ci/gpu_lock_exec.py \
+                --count "$$NUM_GPUS" --target-env-name HIP_VISIBLE_DEVICES \
+                -- python "tests/$$TEST_FILE"
+            '
+
+      # gsm8k suites run on ROCm but aren't green yet: vLLM rollout returns NaN
+      # logprobs for Qwen3.5-0.8B on ROCm, so the train-vs-rollout logprob check
+      # diverges. Kept visible (orange) and non-blocking until fixed; drop
+      # soft_fail once each passes on the U.is_rocm() path.
+      - label: ":warning: short · gsm8k 0.8B (4 GPU) [soft-fail]"
+        key: rocm-gsm8k-short
+        agents:
+          queue: amd_gfx950
+        timeout_in_minutes: 360
+        soft_fail: true
+        retry:
+          automatic:
+            - exit_status: -1
+              limit: 2
+        env:
+          TEST_FILE: "test_qwen3.5_0.8B_gsm8k_short.py"
+          NUM_GPUS: "4"
+        command: *rocm_gpu_test
+
+      - label: ":warning: short · gsm8k_async 0.8B (4 GPU) [soft-fail]"
+        key: rocm-gsm8k-async-short
+        agents:
+          queue: amd_gfx950
+        timeout_in_minutes: 360
+        soft_fail: true
+        retry:
+          automatic:
+            - exit_status: -1
+              limit: 2
+        env:
+          TEST_FILE: "test_qwen3.5_0.8B_gsm8k_async_short.py"
+          NUM_GPUS: "4"
+        command: *rocm_gpu_test

--- a/.buildkite/pipeline-rocm.yaml
+++ b/.buildkite/pipeline-rocm.yaml
@@ -1,22 +1,12 @@
-# Buildkite CI for vime — AMD ROCm GPU suites.
+# Buildkite CI for vime — AMD ROCm GPU suites. See .buildkite/README.md.
 #
-# Declarative ROCm pipeline in the style of vllm-omni's .buildkite/test-amd*.yaml
-# (one step per test on a self-hosted AMD agent queue; `soft_fail` for suites
-# that run but aren't green yet), adapted to vime:
-#   * tests run inside the prebuilt ROCm image (docker/Dockerfile.rocm) via
-#     `docker run` with the ROCm devices passed through, mirroring how the CUDA
-#     suites run in a prebuilt vllm/vime container;
-#   * GPUs are arbitrated across concurrent steps with tests/ci/gpu_lock_exec.py
-#     on HIP_VISIBLE_DEVICES (the AMD analogue of CUDA_VISIBLE_DEVICES);
-#   * tests take the U.is_rocm() path (HF->Megatron conversion, no bridge).
+# One step per test on the self-hosted gfx950 (MI350X) queue (queue=amd_gfx950,
+# docker access + ROCm devices /dev/kfd, /dev/dri). Each test runs in the
+# prebuilt ROCm image and takes the U.is_rocm() path; GPUs are arbitrated with
+# tests/ci/gpu_lock_exec.py on HIP_VISIBLE_DEVICES.
 #
-# One-time setup (see .buildkite/README.md):
-#   * a Buildkite agent on the gfx950 (MI350X) node tagged  queue=amd_gfx950
-#     with docker access and the ROCm devices (/dev/kfd, /dev/dri) available.
-#
-# Blocking vs soft_fail mirrors vllm-omni's `grade`: fully_async is validated
-# end-to-end on ROCm and gates the build; the gsm8k suites run but stay
-# non-blocking until the vLLM/ROCm NaN-logprob divergence is fixed.
+# Grading: fully_async gates the build; the gsm8k suites soft_fail (non-blocking)
+# until the vLLM/ROCm NaN-logprob divergence is fixed.
 
 env:
   # Prebuilt ROCm image (built from docker/Dockerfile.rocm). Override per-agent

--- a/tests/test_qwen2.5_0.5B_fully_async_short.py
+++ b/tests/test_qwen2.5_0.5B_fully_async_short.py
@@ -12,21 +12,18 @@ existing 0.5B short tests.
 import os
 import vime.utils.external_utils.command_utils as U
 
+
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
 NUM_GPUS = 4
 
-HF_PATH = f"/root/models/{MODEL_NAME}"
-# ROCm converts HF->Megatron (no modelopt bridge). Write to a container-local
-# path so concurrent short tests sharing this model don't race on the output.
-MG_PATH = f"/tmp/{MODEL_NAME}_torch_dist"
-
 
 def prepare():
     U.exec_command("mkdir -p /root/models /root/datasets")
-    U.exec_command(f"hf download Qwen/{MODEL_NAME} --local-dir {HF_PATH}")
+    U.exec_command(f"hf download Qwen/{MODEL_NAME} --local-dir /root/models/{MODEL_NAME}")
     U.hf_download_dataset("zhuzilin/dapo-math-17k")
     if U.is_rocm():
+        # ROCm image has no modelopt bridge: convert HF->Megatron into a container-local dir.
         U.convert_checkpoint(
             MODEL_NAME,
             MODEL_TYPE,
@@ -38,7 +35,7 @@ def prepare():
 
 def execute():
     if U.is_rocm():
-        ckpt_args = f"--hf-checkpoint {HF_PATH}/ --ref-load {MG_PATH}/ "
+        ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}/ --ref-load /tmp/{MODEL_NAME}_torch_dist/ "
     else:
         ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}/ " f"--ref-load /root/models/{MODEL_NAME}/ "
 
@@ -93,8 +90,8 @@ def execute():
 
     vllm_args = (
         "--rollout-num-gpus-per-engine 1 "
-        f"--vllm-gpu-memory-utilization {'0.3' if U.is_rocm() else '0.65'} "
-        f"{'' if U.is_rocm() else '--vllm-max-cudagraph-capture-size 16 '}"
+        "--vllm-gpu-memory-utilization 0.65 "
+        "--vllm-max-cudagraph-capture-size 16 "
     )
 
     ci_args = "--ci-test "

--- a/tests/test_qwen2.5_0.5B_fully_async_short.py
+++ b/tests/test_qwen2.5_0.5B_fully_async_short.py
@@ -12,20 +12,35 @@ existing 0.5B short tests.
 import os
 import vime.utils.external_utils.command_utils as U
 
-
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
 NUM_GPUS = 4
 
+HF_PATH = f"/root/models/{MODEL_NAME}"
+# ROCm converts HF->Megatron (no modelopt bridge). Write to a container-local
+# path so concurrent short tests sharing this model don't race on the output.
+MG_PATH = f"/tmp/{MODEL_NAME}_torch_dist"
+
 
 def prepare():
     U.exec_command("mkdir -p /root/models /root/datasets")
-    U.exec_command(f"hf download Qwen/{MODEL_NAME} --local-dir /root/models/{MODEL_NAME}")
+    U.exec_command(f"hf download Qwen/{MODEL_NAME} --local-dir {HF_PATH}")
     U.hf_download_dataset("zhuzilin/dapo-math-17k")
+    if U.is_rocm():
+        U.convert_checkpoint(
+            MODEL_NAME,
+            MODEL_TYPE,
+            num_gpus_per_node=1,
+            extra_args="--no-gradient-accumulation-fusion --attention-backend flash",
+            dir_dst="/tmp",
+        )
 
 
 def execute():
-    ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}/ " f"--ref-load /root/models/{MODEL_NAME}/ "
+    if U.is_rocm():
+        ckpt_args = f"--hf-checkpoint {HF_PATH}/ --ref-load {MG_PATH}/ "
+    else:
+        ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}/ " f"--ref-load /root/models/{MODEL_NAME}/ "
 
     rollout_args = (
         # The only line that differs from test_qwen2.5_0.5B_async_short.py:
@@ -78,8 +93,8 @@ def execute():
 
     vllm_args = (
         "--rollout-num-gpus-per-engine 1 "
-        "--vllm-gpu-memory-utilization 0.65 "
-        "--vllm-max-cudagraph-capture-size 16 "
+        f"--vllm-gpu-memory-utilization {'0.3' if U.is_rocm() else '0.65'} "
+        f"{'' if U.is_rocm() else '--vllm-max-cudagraph-capture-size 16 '}"
     )
 
     ci_args = "--ci-test "
@@ -100,7 +115,8 @@ def execute():
         "--actor-num-nodes 1 "
         "--actor-num-gpus-per-node 1 "
         "--rollout-num-gpus 3 "
-        "--megatron-to-hf-mode bridge "
+        f'{"--megatron-to-hf-mode bridge " if not U.is_rocm() else ""}'
+        f'{"--no-gradient-accumulation-fusion --no-offload-train " if U.is_rocm() else ""}'
     )
 
     train_args = (

--- a/vime/utils/external_utils/command_utils.py
+++ b/vime/utils/external_utils/command_utils.py
@@ -18,6 +18,14 @@ _ = exec_command, dataclass_cli
 repo_base_dir = Path(os.path.abspath(__file__)).resolve().parents[3]
 
 
+def is_rocm() -> bool:
+    """True on AMD ROCm (torch built with HIP) — the same gate the framework
+    code uses (torch.version.hip)."""
+    import torch
+
+    return torch.version.hip is not None
+
+
 def convert_checkpoint(
     model_name,
     megatron_model_type,
@@ -166,15 +174,38 @@ def execute_train(
             if megatron_model_type is not None
             else ""
         )
-        exec_command(
-            f"export no_proxy=127.0.0.1 && export PYTHONUNBUFFERED=1 && "
-            f"{cmd_megatron_model_source}"
-            f'ray job submit --address="http://127.0.0.1:8265" '
-            f"--runtime-env-json='{runtime_env_json}' "
-            f"-- python3 {train_script} "
-            f"{'${MODEL_ARGS[@]}' if megatron_model_type is not None else ''} "
-            f"{train_args}"
-        )
+        model_args = "${MODEL_ARGS[@]}" if megatron_model_type is not None else ""
+        if is_rocm():
+            # ROCm: `ray job submit` intermittently hits a "No available agent"
+            # race in the ROCm container. Run the train script directly against
+            # the ray head started above; pass the ray runtime-env as exports.
+            amd_env = {
+                "no_proxy": f"127.0.0.1,{master_addr}",
+                "PYTHONUNBUFFERED": "1",
+                "PYTHONPATH": f"{repo_base_dir}:/root/Megatron-LM/",
+                "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+                "NCCL_NVLS_ENABLE": "0",
+                "MASTER_ADDR": master_addr,
+                "WANDB_MODE": "disabled",
+                **extra_env_vars,
+                **_parse_extra_env_vars(config.extra_env_vars),
+            }
+            amd_exports = " ".join(f"{k}={v}" for k, v in amd_env.items())
+            exec_command(
+                f"export {amd_exports} && "
+                f"{cmd_megatron_model_source}"
+                f"python3 {train_script} {model_args} {train_args}"
+            )
+        else:
+            exec_command(
+                f"export no_proxy=127.0.0.1 && export PYTHONUNBUFFERED=1 && "
+                f"{cmd_megatron_model_source}"
+                f'ray job submit --address="http://127.0.0.1:8265" '
+                f"--runtime-env-json='{runtime_env_json}' "
+                f"-- python3 {train_script} "
+                f"{model_args} "
+                f"{train_args}"
+            )
 
 
 def _parse_extra_env_vars(text: str):

--- a/vime/utils/external_utils/command_utils.py
+++ b/vime/utils/external_utils/command_utils.py
@@ -183,6 +183,7 @@ def execute_train(
                 "no_proxy": f"127.0.0.1,{master_addr}",
                 "PYTHONUNBUFFERED": "1",
                 "PYTHONPATH": f"{repo_base_dir}:/root/Megatron-LM/",
+                "RAY_USE_UVLOOP": "0",
                 "CUDA_DEVICE_MAX_CONNECTIONS": "1",
                 "NCCL_NVLS_ENABLE": "0",
                 "MASTER_ADDR": master_addr,
@@ -190,7 +191,9 @@ def execute_train(
                 **extra_env_vars,
                 **_parse_extra_env_vars(config.extra_env_vars),
             }
-            amd_exports = " ".join(f"{k}={v}" for k, v in amd_env.items())
+            import shlex
+
+            amd_exports = " ".join(f"{k}={shlex.quote(str(v))}" for k, v in amd_env.items())
             exec_command(
                 f"export {amd_exports} && "
                 f"{cmd_megatron_model_source}"

--- a/vime/utils/external_utils/command_utils.py
+++ b/vime/utils/external_utils/command_utils.py
@@ -185,9 +185,7 @@ def execute_train(
                 "PYTHONPATH": f"{repo_base_dir}:/root/Megatron-LM/",
                 "RAY_USE_UVLOOP": "0",
                 "CUDA_DEVICE_MAX_CONNECTIONS": "1",
-                "NCCL_NVLS_ENABLE": "0",
                 "MASTER_ADDR": master_addr,
-                "WANDB_MODE": "disabled",
                 **extra_env_vars,
                 **_parse_extra_env_vars(config.extra_env_vars),
             }


### PR DESCRIPTION
Adds an AMD ROCm CI path for vime on Buildkite.

- `.buildkite/pipeline-rocm.yaml` — declarative ROCm pipeline behind a manual block gate; each test runs the prebuilt ROCm image via docker and arbitrates GPUs with `gpu_lock_exec` on `HIP_VISIBLE_DEVICES`.
- Test-execution path: `U.is_rocm()` gate + a ROCm branch in `execute_train` (runs the train script directly against the ray head).
- `test_qwen2.5_0.5B_fully_async_short.py` adapted for the ROCm path (HF→Megatron convert, no bridge).

short suite grading (validated end-to-end on gfx950 / 8×MI350X):
- `fully_async` (0.5B) — gating, must pass; currently green.
- `gsm8k` / `gsm8k_async` (0.8B) — soft-fail, non-blocking: vLLM rollout returns NaN logprobs on ROCm, diverging the train-vs-rollout logprob check. Kept visible (orange) until fixed, then flipped to blocking.

Buildkite agent provisioning for queue `amd_gfx950` is complete; the suite runs on the self-hosted MI350X node.
