### PR TITLE
[Bugfix][Rollout] Fix IPv6 vLLM engine and health-check URLs

### DIFF
--- a/tests/utils/test_vllm_engine.py
+++ b/tests/utils/test_vllm_engine.py
@@ -478,6 +478,64 @@ def test_get_url_ipv6_host(vllm_engine):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("host", "expected_host"),
+    [
+        ("127.0.0.1", "127.0.0.1"),
+        ("2001:db8::1", "[2001:db8::1]"),
+        ("[2001:db8::1]", "[2001:db8::1]"),
+    ],
+)
+def test_init_formats_server_host_for_urls(vllm_engine, monkeypatch, host, expected_host):
+    monkeypatch.setattr(vllm_engine, "_init_external", lambda *args, **kwargs: None)
+
+    vllm_engine.init(
+        dist_init_addr="127.0.0.1:29500",
+        port=8765,
+        nccl_port=None,
+        host=host,
+    )
+
+    assert vllm_engine.server_host == expected_host
+    assert vllm_engine.get_url() == f"http://{expected_host}:8765"
+
+
+@pytest.mark.unit
+def test_launch_server_process_brackets_ipv6_health_url(vllm_args, monkeypatch):
+    class _FakeProcess:
+        def start(self):
+            pass
+
+        def is_alive(self):
+            return True
+
+    process = _FakeProcess()
+    base_urls = []
+
+    monkeypatch.setattr(mod, "_build_subprocess_env", lambda _: {})
+    monkeypatch.setattr(mod.multiprocessing, "set_start_method", lambda *args, **kwargs: None)
+    monkeypatch.setattr(mod.multiprocessing, "Process", lambda *args, **kwargs: process)
+
+    def fake_wait_server_healthy(base_url, is_process_alive):
+        assert is_process_alive()
+        base_urls.append(base_url)
+
+    monkeypatch.setattr(mod, "_wait_server_healthy", fake_wait_server_healthy)
+
+    mod.launch_server_process(
+        {
+            "_args": vllm_args,
+            "_visible_devices": "0",
+            "host": "2001:db8::1",
+            "port": 8000,
+            "node_rank": 0,
+        }
+    )
+
+    assert base_urls == ["http://[2001:db8::1]:8000"]
+
+
+@pytest.mark.unit
 def test_get_base_gpu_id_with_critic_offset(vllm_args):
     vllm_args.colocate = False
     vllm_args.debug_rollout_only = False

--- a/tests/utils/test_vllm_engine.py
+++ b/tests/utils/test_vllm_engine.py
@@ -472,12 +472,6 @@ def test_update_weights_from_distributed_posts_update_weights_without_checkpoint
 
 
 @pytest.mark.unit
-def test_get_url_ipv6_host(vllm_engine):
-    vllm_engine.server_host = "[2001:db8::1]"
-    assert vllm_engine.get_url() == "http://[2001:db8::1]:8765"
-
-
-@pytest.mark.unit
 @pytest.mark.parametrize(
     ("host", "expected_host"),
     [
@@ -486,52 +480,52 @@ def test_get_url_ipv6_host(vllm_engine):
         ("[2001:db8::1]", "[2001:db8::1]"),
     ],
 )
-def test_init_formats_server_host_for_urls(vllm_engine, monkeypatch, host, expected_host):
-    monkeypatch.setattr(vllm_engine, "_init_external", lambda *args, **kwargs: None)
+def test_init_formats_server_and_router_hosts_for_urls(vllm_engine, monkeypatch, host, expected_host):
+    server_args = {}
+    monkeypatch.setattr(vllm_engine, "_init_external", lambda args, **kwargs: server_args.update(args))
 
     vllm_engine.init(
         dist_init_addr="127.0.0.1:29500",
         port=8765,
         nccl_port=None,
         host=host,
+        router_ip=host,
+        router_port=30000,
     )
 
+    assert server_args["host"] == expected_host
     assert vllm_engine.server_host == expected_host
+    assert vllm_engine.router_ip == expected_host
     assert vllm_engine.get_url() == f"http://{expected_host}:8765"
 
 
 @pytest.mark.unit
 def test_launch_server_process_brackets_ipv6_health_url(vllm_args, monkeypatch):
-    class _FakeProcess:
-        def start(self):
-            pass
-
-        def is_alive(self):
-            return True
-
-    process = _FakeProcess()
+    process = SimpleNamespace(start=lambda: None, is_alive=lambda: True)
     base_urls = []
+    subprocess_args = {}
 
     monkeypatch.setattr(mod, "_build_subprocess_env", lambda _: {})
     monkeypatch.setattr(mod.multiprocessing, "set_start_method", lambda *args, **kwargs: None)
-    monkeypatch.setattr(mod.multiprocessing, "Process", lambda *args, **kwargs: process)
+    monkeypatch.setattr(
+        mod.multiprocessing,
+        "Process",
+        lambda *, target, args: subprocess_args.update(args[0]) or process,
+    )
+    monkeypatch.setattr(mod, "_wait_server_healthy", lambda base_url, **_: base_urls.append(base_url))
 
-    def fake_wait_server_healthy(base_url, is_process_alive):
-        assert is_process_alive()
-        base_urls.append(base_url)
-
-    monkeypatch.setattr(mod, "_wait_server_healthy", fake_wait_server_healthy)
-
-    mod.launch_server_process(
+    launched_process = mod.launch_server_process(
         {
             "_args": vllm_args,
             "_visible_devices": "0",
-            "host": "2001:db8::1",
+            "host": "[2001:db8::1]",
             "port": 8000,
             "node_rank": 0,
         }
     )
 
+    assert launched_process is process
+    assert subprocess_args["host"] == "2001:db8::1"
     assert base_urls == ["http://[2001:db8::1]:8000"]
 
 

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -1,7 +1,6 @@
 import argparse
 import base64
 import dataclasses
-import ipaddress
 import logging
 import multiprocessing
 import os
@@ -15,7 +14,7 @@ from vllm.utils.system_utils import kill_process_tree
 
 from vime.backends.vllm_utils.external import get_server_info
 from vime.ray.ray_actor import RayActor
-from vime.utils.http_utils import get_host_info
+from vime.utils.http_utils import _wrap_ipv6, get_host_info
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +47,7 @@ def launch_server_process(server_args_dict: dict) -> multiprocessing.Process:
         return p
 
     _wait_server_healthy(
-        base_url=f"http://{(server_args_dict['host'] or '127.0.0.1').strip('[]')}:{server_args_dict['port']}",
+        base_url=f"http://{_wrap_ipv6(server_args_dict['host'] or '127.0.0.1')}:{server_args_dict['port']}",
         is_process_alive=lambda: p.is_alive(),
     )
 
@@ -147,19 +146,9 @@ class VLLMEngine(RayActor):
 
         host = host or get_host_info()[1]
 
-        def _format_v6_uri(addr):
-            if not addr or addr.startswith("["):
-                return addr
-            try:
-                if ipaddress.ip_address(addr).version == 6:
-                    return f"[{addr}]"
-            except ValueError:
-                pass
-            return addr
-
-        host = _format_v6_uri(host)
+        host = _wrap_ipv6(host)
         ip_part, port_part = dist_init_addr.rsplit(":", 1)
-        dist_init_addr = f"{_format_v6_uri(ip_part)}:{port_part}"
+        dist_init_addr = f"{_wrap_ipv6(ip_part)}:{port_part}"
 
         server_args_dict, external_engine_need_check_fields = _compute_server_args(
             self.args,
@@ -175,7 +164,7 @@ class VLLMEngine(RayActor):
         )
 
         self.node_rank = server_args_dict["node_rank"]
-        self.server_host = server_args_dict["host"]
+        self.server_host = _wrap_ipv6(server_args_dict["host"])
         self.server_port = server_args_dict["port"]
 
         if self.args.rollout_external:

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -37,6 +37,8 @@ def get_base_gpu_id(args, rank):
 def launch_server_process(server_args_dict: dict) -> multiprocessing.Process:
     env = _build_subprocess_env(server_args_dict)
     kwargs = {k: v for k, v in server_args_dict.items() if not k.startswith("_")}
+    host = _wrap_ipv6(kwargs.get("host") or "127.0.0.1")
+    kwargs["host"] = host.strip("[]")
     logger.info("Launching vLLM server: %s", kwargs)
 
     multiprocessing.set_start_method("spawn", force=True)
@@ -47,7 +49,7 @@ def launch_server_process(server_args_dict: dict) -> multiprocessing.Process:
         return p
 
     _wait_server_healthy(
-        base_url=f"http://{_wrap_ipv6(server_args_dict['host'] or '127.0.0.1')}:{server_args_dict['port']}",
+        base_url=f"http://{host}:{server_args_dict['port']}",
         is_process_alive=lambda: p.is_alive(),
     )
 
@@ -141,7 +143,7 @@ class VLLMEngine(RayActor):
     ):
         del nccl_port
 
-        self.router_ip = router_ip
+        self.router_ip = _wrap_ipv6(router_ip) if router_ip is not None else None
         self.router_port = router_port
 
         host = host or get_host_info()[1]
@@ -164,7 +166,7 @@ class VLLMEngine(RayActor):
         )
 
         self.node_rank = server_args_dict["node_rank"]
-        self.server_host = _wrap_ipv6(server_args_dict["host"])
+        self.server_host = server_args_dict["host"]  # with [] if ipv6
         self.server_port = server_args_dict["port"]
 
         if self.args.rollout_external:
@@ -553,13 +555,11 @@ def _compute_server_args(
         master_addr = ip_part.strip("[]")
         master_port = int(port_part)
 
-    host_for_subprocess = (host or "127.0.0.1").strip("[]")
-
     kwargs: dict[str, Any] = {
         "model": str(args.hf_checkpoint),
         "trust_remote_code": True,
         "seed": args.seed + rank,
-        "host": host_for_subprocess,
+        "host": _wrap_ipv6(host or "127.0.0.1"),
         "port": port,
         "nnodes": nnodes,
         "node_rank": node_rank,
@@ -651,6 +651,8 @@ def _compute_server_args(
             kwargs[normalized_key] = value
         if "model_path" in {k.replace("-", "_") for k in vllm_overrides}:
             kwargs["model"] = str(vllm_overrides.get("model_path") or vllm_overrides.get("model-path"))
+
+    kwargs["host"] = _wrap_ipv6(kwargs.get("host") or "127.0.0.1")
 
     # vLLM-specific: topology metadata consumed by launch_server_process / _build_subprocess_env.
     # These keys are stripped before passing to vLLM's argparse.


### PR DESCRIPTION
## Summary

Fix IPv6 URL construction in the vLLM engine control plane.

## Problem

The vLLM subprocess requires an unbracketed IPv6 address when binding
the server, while an IPv6 literal must be enclosed in brackets when
used as the host component of an HTTP URL.

Previously, the health-check path could construct an invalid URL such
as:

`http://2001:db8::1:8000/health`

instead of:

`http://[2001:db8::1]:8000/health`

The health check may then keep retrying failed requests, making engine
startup appear to be stuck.

## Changes

- Reuse the existing `_wrap_ipv6` helper when constructing vLLM
  control-plane URLs.
- Keep the subprocess bind address unbracketed.
- Preserve the existing behavior for IPv4 and already-bracketed IPv6
  addresses.
- Add CPU unit coverage for engine initialization and health-check URL
  construction.

## Testing

- `pytest tests/utils/test_vllm_engine.py -q`
- `pre-commit run --all-files`