### PR TITLE
[Bugfix] Sync missing Slime runtime safeguards

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,7 +58,7 @@ steps:
         python:3.11 bash -c '
           set -euo pipefail
           pip install -q torch --index-url https://download.pytorch.org/whl/cpu
-          pip install -q pytest numpy packaging pyyaml omegaconf tqdm httpx requests ray pybase64 pylatexenc sympy aiohttp pillow safetensors transformers cloudpickle blake3 xxhash zstandard
+          pip install -q pytest numpy packaging pyyaml omegaconf tqdm httpx requests ray pybase64 pylatexenc sympy aiohttp pillow safetensors transformers cloudpickle blake3 xxhash zstandard psutil
           pip install -q -e . --no-deps
           python tests/test_megatron_argument_validation.py
           python tests/test_value_temperature.py
@@ -83,6 +83,7 @@ steps:
           python tests/test_cispo_loss.py
           python tests/test_logprob_response_spans.py
           python tests/test_empty_colocated_weight_bucket.py
+          python tests/test_reloadable_process_group_memory_check.py
           python tests/test_ppo_logprob_entropy.py
           python tests/utils/test_hf_checkpoint_saver.py
         '

--- a/tests/test_qwen3_4B_ckpt.py
+++ b/tests/test_qwen3_4B_ckpt.py
@@ -5,7 +5,7 @@ from shlex import quote
 import vime.utils.external_utils.command_utils as U
 
 
-ENABLE_EVAL = bool(int(os.environ.get("SLIME_TEST_ENABLE_EVAL", "1")))
+ENABLE_EVAL = bool(int(os.environ.get("VIME_TEST_ENABLE_EVAL", "1")))
 
 MODEL_NAME = "Qwen3-4B"
 MODEL_TYPE = "qwen3-4B"

--- a/tests/test_reloadable_process_group_memory_check.py
+++ b/tests/test_reloadable_process_group_memory_check.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import timedelta
+
 import pytest
 
 from vime.utils import reloadable_process_group as rpg
@@ -65,3 +67,140 @@ def test_wrap_low_level_call_checks_available_memory_by_default(monkeypatch):
         pass
 
     assert calls == ["available_memory"]
+
+
+@pytest.mark.unit
+def test_register_default_process_group_captures_rendezvous_state(monkeypatch):
+    timeout = timedelta(minutes=7)
+    monkeypatch.setattr(rpg, "default_process_group_states", {})
+    monkeypatch.setattr(rpg.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(rpg.dist, "get_backend", lambda: "nccl")
+    monkeypatch.setattr(rpg.dist, "get_rank", lambda: 3)
+    monkeypatch.setattr(rpg.dist, "get_world_size", lambda: 8)
+    monkeypatch.setattr(rpg, "_get_default_store", lambda: "rendezvous-store")
+
+    rpg.register_default_process_group(timeout=timeout)
+
+    state = rpg.default_process_group_states[rpg.os.getpid()]
+    assert state.backend == "nccl"
+    assert state.timeout == timeout
+    assert state.store == "rendezvous-store"
+    assert state.rank == 3
+    assert state.world_size == 8
+    assert not state.nccl_world_destroyed
+
+
+@pytest.mark.unit
+def test_world_and_subgroups_follow_destroy_reload_order(monkeypatch):
+    timeout = timedelta(minutes=2)
+    state = rpg._DefaultProcessGroupState(
+        backend="nccl",
+        timeout=timeout,
+        store="base-store",
+        rank=1,
+        world_size=4,
+    )
+    monkeypatch.setattr(rpg, "default_process_group_states", {rpg.os.getpid(): state})
+
+    events = []
+
+    def barrier(group=None):
+        events.append(("barrier", "WORLD" if group is None else group))
+
+    def init_process_group(**kwargs):
+        events.append(("init", kwargs))
+
+    monkeypatch.setattr(rpg.dist, "barrier", barrier)
+    monkeypatch.setattr(rpg.dist, "destroy_process_group", lambda: events.append(("destroy_world",)))
+    monkeypatch.setattr(rpg.dist, "init_process_group", init_process_group)
+    monkeypatch.setattr(rpg, "PrefixStore", lambda prefix, store: (prefix, store))
+    monkeypatch.setattr(rpg, "get_gloo_group", lambda: "canonical-gloo")
+    monkeypatch.setattr(rpg, "set_gloo_group", lambda group: events.append(("set_gloo", group)))
+    monkeypatch.setattr(rpg, "_get_default_group", lambda: "cpu-world")
+    monkeypatch.setattr(rpg, "init_gloo_group", lambda: events.append(("init_canonical_gloo",)))
+    monkeypatch.setattr(
+        rpg.ReloadableProcessGroup,
+        "destroy_process_groups",
+        staticmethod(lambda: events.append(("destroy_subgroups",))),
+    )
+    monkeypatch.setattr(
+        rpg.ReloadableProcessGroup,
+        "reload_process_groups",
+        staticmethod(lambda: events.append(("reload_subgroups",))),
+    )
+
+    rpg.destroy_process_groups()
+
+    assert state.nccl_world_destroyed
+    assert state.generation == 1
+    assert events == [
+        ("barrier", "canonical-gloo"),
+        ("destroy_subgroups",),
+        ("barrier", "canonical-gloo"),
+        ("destroy_world",),
+        ("set_gloo", None),
+        (
+            "init",
+            {
+                "backend": "gloo",
+                "store": ("vime-reloadable-world-1-gloo", "base-store"),
+                "rank": 1,
+                "world_size": 4,
+                "timeout": timeout,
+            },
+        ),
+        ("set_gloo", "cpu-world"),
+    ]
+
+    events.clear()
+    rpg.reload_process_groups()
+
+    assert not state.nccl_world_destroyed
+    assert state.generation == 2
+    assert events == [
+        ("barrier", "WORLD"),
+        ("destroy_world",),
+        ("set_gloo", None),
+        (
+            "init",
+            {
+                "backend": "nccl",
+                "store": ("vime-reloadable-world-2-nccl", "base-store"),
+                "rank": 1,
+                "world_size": 4,
+                "timeout": timeout,
+            },
+        ),
+        ("init_canonical_gloo",),
+        ("reload_subgroups",),
+    ]
+
+
+@pytest.mark.unit
+def test_unregistered_world_preserves_subgroup_only_behavior(monkeypatch):
+    events = []
+    monkeypatch.setattr(rpg, "default_process_group_states", {})
+    monkeypatch.setattr(
+        rpg.ReloadableProcessGroup,
+        "destroy_process_groups",
+        staticmethod(lambda: events.append("destroy_subgroups")),
+    )
+    monkeypatch.setattr(
+        rpg.ReloadableProcessGroup,
+        "reload_process_groups",
+        staticmethod(lambda: events.append("reload_subgroups")),
+    )
+    monkeypatch.setattr(
+        rpg.dist,
+        "destroy_process_group",
+        lambda: pytest.fail("unregistered WORLD must not be destroyed"),
+    )
+
+    rpg.destroy_process_groups()
+    rpg.reload_process_groups()
+
+    assert events == ["destroy_subgroups", "reload_subgroups"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/utils/test_vllm_arguments.py
+++ b/tests/utils/test_vllm_arguments.py
@@ -148,7 +148,7 @@ def test_add_vllm_router_arguments_defaults_to_cache_aware(args_mod):
 
 
 @pytest.mark.unit
-def test_add_vllm_arguments_sets_slime_balance_thresholds(args_mod, monkeypatch):
+def test_add_vllm_arguments_overrides_router_balance_threshold_defaults(args_mod, monkeypatch):
     _patch_device_config(monkeypatch)
     parser = argparse.ArgumentParser(add_help=False)
     args_mod.add_vllm_arguments(parser)

--- a/vime/backends/megatron_utils/actor.py
+++ b/vime/backends/megatron_utils/actor.py
@@ -2,6 +2,7 @@ import logging
 import os
 from argparse import Namespace
 from contextlib import nullcontext
+from datetime import timedelta
 from pathlib import Path
 
 import ray
@@ -18,7 +19,12 @@ from vime.utils.distributed_utils import get_gloo_group
 from vime.utils.logging_utils import init_tracking
 from vime.utils.memory_utils import clear_memory, print_memory
 from vime.utils.misc import Box
-from vime.utils.reloadable_process_group import destroy_process_groups, monkey_patch_torch_dist, reload_process_groups
+from vime.utils.reloadable_process_group import (
+    destroy_process_groups,
+    monkey_patch_torch_dist,
+    register_default_process_group,
+    reload_process_groups,
+)
 from vime.utils.routing_replay import RoutingReplay
 from vime.utils.timer import Timer, inverse_timer, timer, with_defer
 from vime.utils.types import RolloutBatch
@@ -57,6 +63,12 @@ class MegatronTrainRayActor(TrainRayActor):
 
         monkey_patch_torch_dist()
         super().init(args, role, with_ref, with_opd_teacher)
+        # Disable this when external code keeps raw dist.group.WORLD references
+        # across a train sleep/wake cycle.
+        if os.getenv("VIME_DESTROY_WORLD_PROCESS_GROUP", "1").lower() not in {"0", "false", "no"}:
+            register_default_process_group(timeout=timedelta(minutes=args.distributed_timeout_minutes))
+        else:
+            logger.info("Default WORLD process-group destruction is disabled")
 
         init(args)
 

--- a/vime/ray/train_actor.py
+++ b/vime/ray/train_actor.py
@@ -70,17 +70,20 @@ class TrainRayActor(RayActor):
         args.world_size = dist.get_world_size()
 
         try:
-            import pynvml
+            if torch.version.hip is not None:
+                logger.info("Detected ROCm/HIP environment, skipping NUMA affinity setup")
+            else:
+                import pynvml
 
-            pynvml.nvmlInit()
+                pynvml.nvmlInit()
 
-            local_rank = int(os.environ["RANK"]) % args.num_gpus_per_node
+                local_rank = int(os.environ["RANK"]) % args.num_gpus_per_node
 
-            handle = pynvml.nvmlDeviceGetHandleByIndex(local_rank)
-            pynvml.nvmlDeviceSetCpuAffinity(handle)
+                handle = pynvml.nvmlDeviceGetHandleByIndex(local_rank)
+                pynvml.nvmlDeviceSetCpuAffinity(handle)
 
-            logger.info(f"Set NUMA affinity for GPU {local_rank}")
-            pynvml.nvmlShutdown()
+                logger.info(f"Set NUMA affinity for GPU {local_rank}")
+                pynvml.nvmlShutdown()
 
         except ImportError:
             logger.info("Warning: pynvml not available, skipping NUMA affinity setup")

--- a/vime/utils/disk_delta.py
+++ b/vime/utils/disk_delta.py
@@ -12,10 +12,9 @@ import numpy as np
 # so a thread pool over tensors recovers the bandwidth one thread leaves idle.
 NUM_WORKERS = min(32, (os.cpu_count() or 8))
 
-# Trainer-side (publish) helpers for disk-level delta weight sync. The receive side —
-# materializing the host-local checkpoint and applying published deltas in place — lives in
-# the engine behind its /pull_weights endpoint (vllm.srt.weight_sync.disk_delta), so it
-# runs on every host of a multi-node engine while vime only talks to one endpoint.
+# Trainer-side helpers for disk-level delta weight sync. Vime's client calls a /pull_weights
+# receiver, but the current vLLM image patch does not install that endpoint. Argument validation
+# therefore keeps this mode disabled until the receiver is ported to vLLM and verified end to end.
 
 
 def overwrite_encode(new: np.ndarray, changed_mask: np.ndarray) -> np.ndarray:

--- a/vime/utils/distributed_utils.py
+++ b/vime/utils/distributed_utils.py
@@ -21,7 +21,10 @@ def init_gloo_group():
     """Initialize Gloo group for distributed communication."""
     global GLOO_GROUP
     if GLOO_GROUP is None:
-        GLOO_GROUP = dist.new_group(backend="gloo")
+        # This canonical CPU group synchronizes WORLD transitions and must not
+        # be tracked as a reloadable Megatron subgroup.
+        new_group = getattr(dist, "old_new_group", dist.new_group)
+        GLOO_GROUP = new_group(backend="gloo")
     return GLOO_GROUP
 
 
@@ -31,6 +34,12 @@ def get_gloo_group():
     if GLOO_GROUP is None:
         raise RuntimeError("Gloo group has not been initialized. Call _init_gloo_group() first.")
     return GLOO_GROUP
+
+
+def set_gloo_group(group):
+    """Replace the cached all-ranks Gloo group after a WORLD transition."""
+    global GLOO_GROUP
+    GLOO_GROUP = group
 
 
 # Copy from pytorch to allow creating multiple main groups.

--- a/vime/utils/reloadable_process_group.py
+++ b/vime/utils/reloadable_process_group.py
@@ -1,15 +1,110 @@
 import logging
 import os
 from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
 
 import torch
 import torch.distributed as dist
+from torch.distributed.distributed_c10d import PrefixStore, _get_default_group, _get_default_store
 
+from vime.utils.distributed_utils import get_gloo_group, init_gloo_group, set_gloo_group
 from vime.utils.memory_utils import available_memory, clear_memory, print_memory
 
 logger = logging.getLogger(__name__)
 
 old_new_group_dict = {}
+default_process_group_states = {}
+
+
+@dataclass
+class _DefaultProcessGroupState:
+    backend: str
+    timeout: timedelta
+    store: Any
+    rank: int
+    world_size: int
+    generation: int = 0
+    nccl_world_destroyed: bool = False
+
+
+def register_default_process_group(timeout: timedelta) -> None:
+    """Register WORLD's rendezvous state so it can be rebuilt after sleep."""
+    if not dist.is_initialized():
+        raise RuntimeError("Cannot register WORLD before torch.distributed is initialized")
+
+    pid = os.getpid()
+    backend = str(dist.get_backend())
+    state = _DefaultProcessGroupState(
+        backend=backend,
+        timeout=timeout,
+        store=_get_default_store(),
+        rank=dist.get_rank(),
+        world_size=dist.get_world_size(),
+    )
+    default_process_group_states[pid] = state
+    logger.info(
+        "Registered default WORLD process group for reload: backend=%s, rank=%s, world_size=%s",
+        backend,
+        state.rank,
+        state.world_size,
+    )
+
+
+def _uses_nccl(backend: str) -> bool:
+    return "nccl" in backend.lower()
+
+
+def _new_default_process_group(state: _DefaultProcessGroupState, backend: str) -> None:
+    state.generation += 1
+    store = PrefixStore(f"vime-reloadable-world-{state.generation}-{backend}", state.store)
+    dist.init_process_group(
+        backend=backend,
+        store=store,
+        rank=state.rank,
+        world_size=state.world_size,
+        timeout=state.timeout,
+    )
+
+
+def _destroy_default_nccl_process_group() -> None:
+    state = default_process_group_states.get(os.getpid())
+    if state is None or state.nccl_world_destroyed or not _uses_nccl(state.backend):
+        return
+
+    dist.barrier(group=get_gloo_group())
+    dist.destroy_process_group()
+    set_gloo_group(None)
+
+    _new_default_process_group(state, backend="gloo")
+    set_gloo_group(_get_default_group())
+    state.nccl_world_destroyed = True
+    logger.info(
+        "Destroyed default %s WORLD process group and initialized a temporary Gloo WORLD (generation %s)",
+        state.backend,
+        state.generation,
+    )
+
+
+def _reload_default_process_group() -> None:
+    state = default_process_group_states.get(os.getpid())
+    if state is None or not state.nccl_world_destroyed:
+        return
+
+    dist.barrier()
+    dist.destroy_process_group()
+    set_gloo_group(None)
+
+    _new_default_process_group(state, backend=state.backend)
+    init_gloo_group()
+    state.nccl_world_destroyed = False
+    logger.info(
+        "Reloaded default WORLD process group with backend %s (generation %s)",
+        state.backend,
+        state.generation,
+    )
+
 
 _COMM_MEMORY_CHECK_SKIP_OPS = {
     "all_gather_into_tensor",
@@ -41,8 +136,12 @@ def monkey_patch_torch_dist():
 
     def new_group(*args, **kwargs):
         group = old_new_group(*args, **kwargs)
-        # skip none nccl group.
-        if len(args) >= 3 and args[2] == "gloo" or "backend" in kwargs and kwargs["backend"] == "gloo":
+        explicit_backend = args[2] if len(args) >= 3 else kwargs.get("backend")
+        backend = str(explicit_backend) if explicit_backend is not None else str(dist.get_backend())
+
+        # Once WORLD is reloadable, destroying it invalidates every cached
+        # subgroup, including Gloo and singleton groups.
+        if backend == "gloo" and pid not in default_process_group_states:
             return group
 
         # Get ranks from arguments
@@ -54,10 +153,16 @@ def monkey_patch_torch_dist():
             # If no ranks specified, use all ranks in world
             ranks = list(range(dist.get_world_size()))
 
-        if len(ranks) == 1:
+        if len(ranks) == 1 and pid not in default_process_group_states:
             return group
 
-        group = ReloadableProcessGroup(group, ranks)
+        group = ReloadableProcessGroup(
+            group,
+            ranks,
+            creation_args=args,
+            creation_kwargs=kwargs,
+            backend=backend,
+        )
         return group
 
     dist.new_group = new_group
@@ -103,10 +208,14 @@ def monkey_patch_torch_dist():
     dist.reduce_scatter = get_new_comm_function(dist.reduce_scatter)
     dist.reduce_scatter_tensor = get_new_comm_function(dist.reduce_scatter_tensor, "reduce_scatter_tensor")
     dist.scatter = get_new_comm_function(dist.scatter)
+    dist.scatter_object_list = get_new_comm_function(dist.scatter_object_list)
     dist.gather = get_new_comm_function(dist.gather)
+    dist.gather_object = get_new_comm_function(dist.gather_object)
     dist.barrier = get_new_comm_function(dist.barrier, "barrier")
     dist.send = get_new_comm_function(dist.send)
+    dist.send_object_list = get_new_comm_function(dist.send_object_list)
     dist.recv = get_new_comm_function(dist.recv)
+    dist.recv_object_list = get_new_comm_function(dist.recv_object_list)
     dist._coalescing_manager = get_new_comm_function(dist._coalescing_manager)
 
     # p2p
@@ -140,7 +249,7 @@ def monkey_patch_torch_dist():
 class ReloadableProcessGroup(torch.distributed.ProcessGroup):
     GROUPS = {}
 
-    def __init__(self, group, ranks):
+    def __init__(self, group, ranks, *, creation_args=(), creation_kwargs=None, backend="nccl"):
         super().__init__(
             rank=dist.get_rank(group),
             size=dist.get_world_size(group),
@@ -148,6 +257,9 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
         self.group = group
         self.group_info = {
             "ranks": ranks,
+            "args": tuple(creation_args),
+            "kwargs": dict(creation_kwargs or {}),
+            "backend": backend,
         }
         pid = os.getpid()
         if pid not in ReloadableProcessGroup.GROUPS:
@@ -178,12 +290,24 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
     def reload_process_groups():
         pid = os.getpid()
         reloadable_groups = ReloadableProcessGroup.GROUPS.get(pid, [])
-        logger.info(f"Reloading {len(reloadable_groups)} process groups in pid {pid}")
+        backend_counts = {}
+        for reloadable_group in reloadable_groups:
+            backend = reloadable_group.group_info["backend"]
+            backend_counts[backend] = backend_counts.get(backend, 0) + 1
+        logger.info(
+            "Reloading %s process groups in pid %s: %s",
+            len(reloadable_groups),
+            pid,
+            backend_counts,
+        )
         old_new_group = old_new_group_dict.get(pid)
         for reloadable_group in reloadable_groups:
             if reloadable_group.group is not None:
                 continue
-            group = old_new_group(ranks=reloadable_group.group_info["ranks"], backend="nccl")
+            group = old_new_group(
+                *reloadable_group.group_info["args"],
+                **reloadable_group.group_info["kwargs"],
+            )
             reloadable_group.group = group
 
     def rank(self) -> int:
@@ -299,12 +423,17 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
 
 
 def destroy_process_groups():
-    """Destroy all reloadable process groups."""
+    """Destroy subgroups and replace NCCL WORLD with a temporary Gloo WORLD."""
+    state = default_process_group_states.get(os.getpid())
+    if state is not None and not state.nccl_world_destroyed and _uses_nccl(state.backend):
+        dist.barrier(group=get_gloo_group())
     ReloadableProcessGroup.destroy_process_groups()
+    _destroy_default_nccl_process_group()
 
 
 def reload_process_groups():
-    """Reload all reloadable process groups."""
+    """Restore NCCL WORLD and recreate all registered subgroups."""
+    _reload_default_process_group()
     ReloadableProcessGroup.reload_process_groups()
 
 


### PR DESCRIPTION
## Summary

- sync default WORLD process-group reload support from THUDM/slime#2208 while preserving Vime's low-level memory checks
- fix the stale `SLIME_TEST_ENABLE_EVAL` consumer, register the process-group regression test in CPU CI, and install its explicit `psutil` dependency
- restore the ROCm NVML guard that was missing from Vime
- document the actual state of the incomplete disk-pull migration instead of referring to the nonexistent `vllm.srt` module

## Audit scope

Vime PR #343 synced through Slime commit `680824dd5e01a2e83750bf87fc366ec6fa98766c`; current Slime main has one later runtime commit, `fb42ae456fac8166afb604f13b30d22bb3c75053` (THUDM/slime#2208). I compared common Python modules and then traced definitions, CLI flags, environment variables, HTTP endpoints, router lifecycle, and weight-sync calls to their implementations.

## Important incomplete migration found

Disk local-checkpoint pull is not currently end-to-end in Vime:

- trainer-side full/delta publishing and `UpdateWeightFromDiskDelta` exist
- `VLLMEngine.pull_weights()` POSTs `/pull_weights`
- docs and examples say the endpoint ships in Vime's vLLM patch
- current `docker/patch/latest/vllm.patch` does **not** install `/pull_weights`
- the old synchronized `vllm-pull_weights.patch` was only a mechanical SGLang path rewrite to nonexistent `python/vllm/srt/...`, so it could not be used
- delta mode is hard-disabled, but full disk sync with `--update-weight-local-checkpoint-dir` can still reach the missing endpoint

This PR does not pretend that gap is an intentional backend difference or enable the unverified mode. A real fix needs a native vLLM `/pull_weights` collective-RPC receiver plus end-to-end image validation.

The remaining audited differences are intentional backend boundaries: SGLang-specific generation/router settings and Vime's vLLM-native packed NCCL/IPC weight updates.

## Validation

- Buildkite #707 passed: pre-commit, plugin/CPU, agent adapter, utils, and all 3 `short` GPU E2E jobs (sync, async, fully async)
- `python tests/test_reloadable_process_group_memory_check.py` (6 passed)
- `pytest -q tests/utils` (168 passed)
- H200 2-rank NCCL smoke test: subgroup all-reduce succeeded before and after NCCL WORLD -> temporary Gloo WORLD -> NCCL WORLD reload