### PR TITLE
[Rollout] Add vLLM encoder-prefill disaggregation

### DIFF
--- a/.buildkite/gpu_suites.py
+++ b/.buildkite/gpu_suites.py
@@ -80,6 +80,7 @@ SUITES = {
     "vime-customized": [
         ("test_qwen2_5_0_5B_non_colocate_pp.py", 4, "", {}),
         ("test_geo3k_vlm_multi_turn_e2e.py", 1, "", {}),
+        ("test_qwen2.5_vl_3B_ep_disaggregation.py", 3, "", {}),
     ],
     "precision": [
         ("test_qwen3_0.6B_parallel_check.py", 8, "", {}),

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -157,7 +157,7 @@ steps:
             value: vllm-config
           - label: "run-ci-megatron — up to 8 GPU, 20 runs"
             value: megatron
-          - label: "run-ci-vime-customized — 1–4 GPU, 2 tests"
+          - label: "run-ci-vime-customized — 1–4 GPU, 3 tests"
             value: vime-customized
           - label: "run-ci-precision — 8 GPU, 1 test"
             value: precision

--- a/examples/geo3k_vlm_multi_turn/rollout.py
+++ b/examples/geo3k_vlm_multi_turn/rollout.py
@@ -106,7 +106,7 @@ def _multimodal_train_inputs_from_features(features: Any) -> dict[str, torch.Ten
     if not isinstance(encoded_images, list):
         raise TypeError("vLLM features.kwargs_data.image must be a list")
 
-    from vllm.entrypoints.serve.disagg.mm_serde import decode_mm_kwargs_item as vllm_decode
+    from vllm.entrypoints.scale_out.token_in_token_out.mm_serde import decode_mm_kwargs_item as vllm_decode
 
     parts_by_key: dict[str, list[torch.Tensor]] = {}
     for encoded in encoded_images:

--- a/tests/test_qwen2.5_vl_3B_ep_disaggregation.py
+++ b/tests/test_qwen2.5_vl_3B_ep_disaggregation.py
@@ -1,0 +1,292 @@
+"""Three-GPU vLLM-only acceptance test for encoder-prefill disaggregation."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+import os
+import shutil
+import sys
+import tempfile
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import ray
+import requests
+import yaml
+from PIL import Image
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import vime.utils.external_utils.command_utils as U
+from vime.backends.vllm_utils.arguments import vllm_parse_args
+from vime.ray.placement_group import _create_placement_group
+from vime.ray.rollout import start_rollout_servers
+from vime.rollout import vllm_rollout
+from vime.utils.http_utils import init_http_client, is_port_available, post
+from vime.utils.processing_utils import load_tokenizer
+
+NUM_GPUS = 3
+MODEL_NAME = "Qwen2.5-VL-3B-Instruct"
+MODEL_REVISION = "66285546d2b821cf421d4f5eb2576359d3770cd3"
+TEST_ROOT = Path(os.environ.get("VIME_TEST_ROOT", "/root"))
+MODEL_PATH = TEST_ROOT / "models" / MODEL_NAME
+MAX_MODEL_LEN = 4096
+MAX_NEW_TOKENS = 32
+SEED = 2525
+
+GROUP_OVERRIDES = {
+    "gpu_memory_utilization": 0.55,
+    "max_model_len": MAX_MODEL_LEN,
+    "max_num_seqs": 4,
+    "enforce_eager": True,
+    "generation_config": "vllm",
+}
+
+
+def prepare() -> None:
+    MODEL_PATH.parent.mkdir(parents=True, exist_ok=True)
+    U.exec_command(f"hf download Qwen/{MODEL_NAME} --revision {MODEL_REVISION} --local-dir {MODEL_PATH}")
+
+
+def _write_config(worker_types: tuple[str, ...]) -> str:
+    config = {
+        "vllm": [
+            {
+                "name": "default",
+                "model_path": str(MODEL_PATH),
+                "update_weights": False,
+                "server_groups": [
+                    {
+                        "worker_type": worker_type,
+                        "num_gpus": 1,
+                        "num_gpus_per_engine": 1,
+                        "overrides": dict(GROUP_OVERRIDES),
+                    }
+                    for worker_type in worker_types
+                ],
+            }
+        ]
+    }
+    handle = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", prefix="vime_epd_", delete=False)
+    with handle:
+        yaml.safe_dump(config, handle)
+    return handle.name
+
+
+def _make_args(config_path: str, worker_types: tuple[str, ...]):
+    args = vllm_parse_args()
+    args.vllm_config = config_path
+    args.rollout_external = False
+    args.rollout_num_gpus = len(worker_types)
+    args.rollout_num_gpus_per_engine = 1
+    args.rollout_num_engines = max(1, sum(worker_type != "encoder" for worker_type in worker_types))
+    args.num_gpus_per_node = NUM_GPUS
+    args.debug_train_only = False
+    args.debug_rollout_only = True
+    args.colocate = False
+    args.actor_num_nodes = 0
+    args.actor_num_gpus_per_node = 0
+    args.offload_rollout = False
+    args.use_critic = False
+    args.critic_num_nodes = 0
+    args.critic_num_gpus_per_node = 0
+    args.hf_checkpoint = str(MODEL_PATH)
+    args.seed = SEED
+    args.fp16 = False
+    args.use_rollout_routing_replay = False
+    args.rollout_max_context_len = MAX_MODEL_LEN
+    args.use_distributed_post = False
+    args.vllm_server_concurrency = 4
+    args.vllm_enable_deterministic_inference = True
+    args.vllm_router_ip = None
+    args.vllm_router_port = None
+    args.vllm_pipeline_parallel_size = 1
+    args.vllm_data_parallel_size = 1
+    args.vllm_dp_size = 1
+    return args
+
+
+def _shutdown_servers(servers: dict[str, Any]) -> None:
+    engines = [engine for server in servers.values() for engine in server.all_engines if engine is not None]
+    try:
+        if engines:
+            ray.get([engine.shutdown.remote() for engine in engines], timeout=120)
+    finally:
+        for engine in engines:
+            try:
+                ray.kill(engine, no_restart=True)
+            except Exception:
+                pass
+
+    deadline = time.monotonic() + 60
+    while not is_port_available(15000) and time.monotonic() < deadline:
+        time.sleep(1)
+
+
+@contextmanager
+def _deployment(pg, worker_types: tuple[str, ...]):
+    config_path = _write_config(worker_types)
+    args = _make_args(config_path, worker_types)
+    servers: dict[str, Any] = {}
+    ec_path: Path | None = None
+    try:
+        servers, init_handles = start_rollout_servers(args, pg)
+        if init_handles:
+            ray.get(init_handles)
+        init_http_client(args)
+
+        for group in servers["default"].server_groups:
+            config = group.vllm_overrides.get("ec_transfer_config") or {}
+            extra = config.get("ec_connector_extra_config") or {}
+            if path := extra.get("shared_storage_path"):
+                ec_path = Path(path)
+                break
+        yield args, servers["default"]
+    finally:
+        try:
+            _shutdown_servers(servers)
+        finally:
+            if ec_path is not None:
+                shutil.rmtree(ec_path, ignore_errors=True)
+            Path(config_path).unlink(missing_ok=True)
+
+
+def _image_data_url() -> str:
+    image = Image.new("RGB", (64, 64))
+    pixels = image.load()
+    for y in range(64):
+        for x in range(64):
+            pixels[x, y] = (220, 40, 40) if (x // 16 + y // 16) % 2 == 0 else (30, 90, 220)
+    output = io.BytesIO()
+    image.save(output, format="PNG")
+    return "data:image/png;base64," + base64.b64encode(output.getvalue()).decode("ascii")
+
+
+async def _generate(args, messages: list[dict[str, Any]], *, epd_server=None) -> list[int]:
+    base_url = f"http://{args.vllm_router_ip}:{args.vllm_router_port}"
+    await vllm_rollout.prime_encoder(args, messages)
+    if epd_server is not None:
+        assert getattr(args, "vllm_model_encoder_endpoints", {}), "EPD deployment did not expose an encoder endpoint"
+        storage_paths = [
+            group.vllm_overrides["ec_transfer_config"]["ec_connector_extra_config"]["shared_storage_path"]
+            for group in epd_server.server_groups
+            if group.worker_type == "encoder"
+        ]
+        assert any(
+            Path(path).glob("*/encoder_cache.safetensors") for path in storage_paths
+        ), "encoder did not publish an external EC cache"
+    render_data = await post(
+        f"{base_url}/v1/chat/completions/render",
+        {"model": str(MODEL_PATH), "messages": messages},
+    )
+    body = vllm_rollout._mm_render_response_to_generate_body(render_data, str(MODEL_PATH))
+    body["sampling_params"] = vllm_rollout._build_inference_sampling_params(
+        {
+            "max_new_tokens": MAX_NEW_TOKENS,
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "top_k": -1,
+            "seed": SEED,
+            "skip_special_tokens": False,
+        }
+    )
+    output = await post(f"{base_url}/inference/v1/generate", body)
+    token_ids = output["choices"][0].get("token_ids") or []
+    assert token_ids, output
+    return [int(token_id) for token_id in token_ids]
+
+
+def _find_config(value: Any, key: str) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        candidate = value.get(key)
+        if isinstance(candidate, dict):
+            return candidate
+        for child in value.values():
+            if found := _find_config(child, key):
+                return found
+    elif isinstance(value, list):
+        for child in value:
+            if found := _find_config(child, key):
+                return found
+    return None
+
+
+def _engine_info(server) -> dict[str, tuple[str, dict[str, Any]]]:
+    result = {}
+    for group in server.server_groups:
+        endpoint = ray.get(group.engines[0].get_url.remote())
+        response = requests.get(f"{endpoint}/server_info?config_format=json", timeout=30)
+        response.raise_for_status()
+        result[group.worker_type] = (endpoint, response.json())
+    return result
+
+
+def _validate_epd_services(server) -> None:
+    info = _engine_info(server)
+    encoder_ec = _find_config(info["encoder"][1], "ec_transfer_config")
+    prefill_ec = _find_config(info["prefill"][1], "ec_transfer_config")
+    prefill_kv = _find_config(info["prefill"][1], "kv_transfer_config")
+    decode_ec = _find_config(info["decode"][1], "ec_transfer_config")
+    decode_kv = _find_config(info["decode"][1], "kv_transfer_config")
+
+    assert encoder_ec is not None
+    assert encoder_ec["ec_connector"] == "ECExampleConnector"
+    assert encoder_ec["ec_role"] == "ec_producer"
+    assert prefill_ec is not None
+    assert prefill_ec["ec_connector"] == "ECExampleConnector"
+    assert prefill_ec["ec_role"] == "ec_consumer"
+    assert prefill_kv is not None and prefill_kv["kv_role"] == "kv_producer"
+    assert decode_ec is None or decode_ec.get("ec_role") is None
+    assert decode_kv is not None and decode_kv["kv_role"] == "kv_consumer"
+
+    response = requests.get(f"http://{server.router_ip}:{server.router_port}/workers", timeout=30)
+    response.raise_for_status()
+    workers = response.json()["workers"]
+    assert {worker["worker_type"] for worker in workers} == {"prefill", "decode"}
+    assert info["encoder"][0] not in {worker["url"] for worker in workers}
+
+    config = server.server_groups[0].vllm_overrides["ec_transfer_config"]
+    path = Path(config["ec_connector_extra_config"]["shared_storage_path"])
+    assert path.is_dir()
+
+
+def execute() -> None:
+    ray.init()
+    pg = _create_placement_group(NUM_GPUS)
+    image_messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": _image_data_url()}},
+                {"type": "text", "text": "Name the two dominant colors. Answer briefly."},
+            ],
+        }
+    ]
+    try:
+        with _deployment(pg, ("regular",)) as (baseline_args, _):
+            baseline_tokens = asyncio.run(_generate(baseline_args, image_messages))
+
+        with _deployment(pg, ("encoder", "prefill", "decode")) as (epd_args, epd_server):
+            epd_tokens = asyncio.run(_generate(epd_args, image_messages, epd_server=epd_server))
+            assert epd_tokens == baseline_tokens
+            tokenizer = load_tokenizer(str(MODEL_PATH), trust_remote_code=True)
+            assert tokenizer.decode(epd_tokens, skip_special_tokens=False) == tokenizer.decode(
+                baseline_tokens, skip_special_tokens=False
+            )
+
+            _validate_epd_services(epd_server)
+    finally:
+        if pg[0] is not None:
+            ray.util.remove_placement_group(pg[0])
+        ray.shutdown()
+
+
+if __name__ == "__main__":
+    prepare()
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    execute()

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -533,6 +533,9 @@ def _compute_server_args(
     vllm_overrides: dict | None = None,
     num_gpus_per_engine: int | None = None,
 ):
+    vllm_overrides = dict(vllm_overrides or {})
+    ec_transfer_override = vllm_overrides.pop("ec_transfer_config", None)
+
     _gpus_per_engine = num_gpus_per_engine or args.rollout_num_gpus_per_engine
     nnodes = max(1, _gpus_per_engine // args.num_gpus_per_node)
     node_rank = rank % nnodes
@@ -597,6 +600,13 @@ def _compute_server_args(
             "kv_role": "kv_consumer",
         }
 
+    if ec_transfer_override is not None and worker_type in ("encoder", "regular", "prefill"):
+        kwargs["ec_transfer_config"] = {
+            "ec_connector": "ECExampleConnector",
+            "ec_role": "ec_producer" if worker_type == "encoder" else "ec_consumer",
+            **ec_transfer_override,
+        }
+
     if args.use_rollout_routing_replay:
         kwargs["enable_return_routed_experts"] = True
     if args.fp16:
@@ -616,6 +626,12 @@ def _compute_server_args(
         kwargs["weight_transfer_config"] = {"backend": "ipc"}
     else:
         kwargs["weight_transfer_config"] = {"backend": "nccl"}
+
+    if worker_type == "encoder":
+        # vLLM EPD producers have no language-model KV cache groups. Prefix
+        # caching must therefore be disabled; vLLM's EPD reference launcher
+        # uses the same setting.
+        kwargs["enable_prefix_caching"] = False
 
     external_engine_need_check_fields = [k for k in kwargs.keys() if k not in _EXTERNAL_ENGINE_SKIP_CHECK_FIELDS]
 

--- a/vime/ray/rollout.py
+++ b/vime/ray/rollout.py
@@ -5,6 +5,7 @@ import multiprocessing
 import os
 import random
 import time
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -1110,6 +1111,7 @@ def start_rollout_servers(args, pg) -> tuple[dict[str, Any], list[Any]]:
     config = _resolve_vllm_config(args)
 
     servers: dict[str, RolloutServer] = {}
+    encoder_metadata: dict[str, tuple[str, list[str]]] = {}
     pending_init_handles: list[Any] = []
     gpu_offset = 0
     engine_offset = 0
@@ -1193,35 +1195,44 @@ def start_rollout_servers(args, pg) -> tuple[dict[str, Any], list[Any]]:
             return group
 
         if has_epd:
-            # --- Phase 1: start encoder groups, wait, collect URLs ---
-            # Encoder URLs are injected into the non-encoder workers' server args,
-            # so this phase must stay synchronous even though final LLM init is deferred.
-            encoder_urls: list[str] = []
+            overrides_extra = {
+                "ec_transfer_config": {
+                    "ec_connector_extra_config": {
+                        "shared_storage_path": f"/dev/shm/vime-ec-{uuid.uuid4().hex}",
+                    },
+                },
+            }
+            encoder_endpoints: list[str] = []
             for group_cfg in model_cfg.server_groups:
                 if group_cfg.worker_type != "encoder":
                     continue
-                group = _make_group(group_cfg, engine_router_ip, engine_router_port)
+                group = _make_group(group_cfg, engine_router_ip, engine_router_port, overrides_extra)
                 handles, port_cursors = group.start_engines(port_cursors)
                 if handles:
                     ray.get(handles)
-                urls = ray.get([e.get_url.remote() for e in group.engines])
-                encoder_urls.extend(u for u in urls if u is not None)
+                endpoints = ray.get([engine.get_url.remote() for engine in group.engines])
+                encoder_endpoints.extend(endpoint for endpoint in endpoints if endpoint is not None)
                 server_groups.append(group)
 
-            logger.info(f"EPD phase 1 done: collected {len(encoder_urls)} encoder URLs: {encoder_urls}")
+            logger.info("EPD phase 1 done: collected %d encoder endpoints", len(encoder_endpoints))
 
-            # --- Phase 2: start non-encoder groups, injecting encoder URLs into
-            # language-only LLM workers. Prefill groups use this for full EPD,
-            # while regular groups allow encoder/LLM split without PD.
             non_encoder_handles: list = []
             for group_cfg in model_cfg.server_groups:
                 if group_cfg.worker_type == "encoder":
                     continue
-                overrides_extra = {}
-                if encoder_urls and group_cfg.worker_type in ("prefill", "regular"):
-                    overrides_extra["language_only"] = True
-                    overrides_extra["encoder_urls"] = encoder_urls
-                group = _make_group(group_cfg, engine_router_ip, engine_router_port, overrides_extra=overrides_extra)
+                non_encoder_overrides = overrides_extra if group_cfg.worker_type in ("regular", "prefill") else None
+                if non_encoder_overrides is not None and encoder_endpoints:
+                    non_encoder_overrides = {
+                        **overrides_extra,
+                        "language_only": True,
+                        "encoder_urls": encoder_endpoints,
+                    }
+                group = _make_group(
+                    group_cfg,
+                    engine_router_ip,
+                    engine_router_port,
+                    non_encoder_overrides,
+                )
                 handles, port_cursors = group.start_engines(port_cursors)
                 non_encoder_handles.extend(handles)
                 server_groups.append(group)
@@ -1269,9 +1280,12 @@ def start_rollout_servers(args, pg) -> tuple[dict[str, Any], list[Any]]:
             update_weights=model_cfg.update_weights,
             prometheus_port=prom_port,
         )
+        if has_epd:
+            encoder_metadata[model_cfg.name] = (server_groups[0].model_path, encoder_endpoints)
 
     # Expose per-model router info for custom rollout functions.
     args.vllm_model_routers = {name: (srv.router_ip, srv.router_port) for name, srv in servers.items()}
+    args.vllm_model_encoder_endpoints = encoder_metadata
 
     return servers, pending_init_handles
 

--- a/vime/rollout/vllm_rollout.py
+++ b/vime/rollout/vllm_rollout.py
@@ -34,7 +34,7 @@ from vime.utils.types import Sample
 
 from .rm_hub import async_rm, batched_async_rm
 
-__all__ = ["generate_rollout", "get_model_url"]
+__all__ = ["generate_rollout", "get_model_url", "prime_encoder"]
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +100,45 @@ def get_model_url(args: Namespace, model_name: str, endpoint: str = "/inference/
         ip, port = routers[model_name]
         return f"http://{ip}:{port}{endpoint}"
     return f"http://{args.vllm_router_ip}:{args.vllm_router_port}{endpoint}"
+
+
+def _get_image_urls(messages: list[dict[str, Any]]) -> list[str]:
+    return [
+        image_url["url"]
+        for message in messages
+        if isinstance(message.get("content"), list)
+        for part in message["content"]
+        if isinstance(part, dict) and part.get("type") == "image_url"
+        for image_url in [part.get("image_url")]
+        if isinstance(image_url, dict) and isinstance(image_url.get("url"), str)
+    ]
+
+
+async def prime_encoder(args: Namespace, messages: list[dict[str, Any]], *, model_name: str = "default") -> None:
+    """Make EC producers compute the images before their consumers generate."""
+    image_urls = _get_image_urls(messages)
+    encoders = (getattr(args, "vllm_model_encoder_endpoints", None) or {}).get(model_name)
+    if encoders is None and model_name == "default":
+        metadata = getattr(args, "vllm_model_encoder_endpoints", None) or {}
+        if len(metadata) == 1:
+            encoders = next(iter(metadata.values()))
+    if not image_urls or encoders is None or not encoders[1]:
+        return
+    model, endpoints = encoders
+
+    async def prime(index: int, image_url: str) -> None:
+        await post(
+            f"{endpoints[index % len(endpoints)].rstrip('/')}/v1/chat/completions",
+            {
+                "model": model,
+                "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": image_url}}]}],
+                "max_tokens": 1,
+                "stream": False,
+            },
+            headers={"x-request-id": str(uuid.uuid4())},
+        )
+
+    await asyncio.gather(*(prime(index, url) for index, url in enumerate(image_urls)))
 
 
 class GenerateState(metaclass=SingletonMeta):
@@ -329,6 +368,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
             "model": args.hf_checkpoint,
             "messages": [{"role": "user", "content": content}],
         }
+        await prime_encoder(args, render_payload["messages"])
         render_url = f"{base}/v1/chat/completions/render"
         with trace_span(sample, "vllm_mm_render", attrs={"model": args.hf_checkpoint}):
             render_data = await post(render_url, render_payload, headers=headers)

--- a/vime/rollout/vllm_streaming_rollout.py
+++ b/vime/rollout/vllm_streaming_rollout.py
@@ -41,6 +41,7 @@ from vime.rollout.vllm_rollout import (
     _coerce_flat_int_token_ids,
     _mm_render_response_to_generate_body,
     _prepare_prompt_ids,
+    prime_encoder,
 )
 from vime.utils import http_utils
 from vime.utils.processing_utils import build_processor_kwargs, encode_image_for_rollout_engine
@@ -124,6 +125,7 @@ async def generate_streaming(args: Namespace, sample: Sample, sampling_params: d
         for image in images:
             content.append({"type": "image_url", "image_url": {"url": encode_image_for_rollout_engine(image)}})
         render_payload = {"model": args.hf_checkpoint, "messages": [{"role": "user", "content": content}]}
+        await prime_encoder(args, render_payload["messages"])
         with trace_span(sample, "vllm_mm_render", attrs={"model": args.hf_checkpoint}):
             render_data = await http_utils.post(f"{base}/v1/chat/completions/render", render_payload, headers=headers)
         payload = _mm_render_response_to_generate_body(render_data, args.hf_checkpoint)


### PR DESCRIPTION
This PR adds native vLLM Encoder-Prefill Disaggregation (EPD) to Vime. It uses `worker_type: encoder` and composes with the existing regular and PD rollout paths.

The implementation has two main parts:

1. Compile the user topology and group overrides into vLLM EC configuration during rollout-server orchestration.
2. Prime encoder engines from the rollout layer before the existing multimodal render/generate flow.

Related to #11.

## 1. Deployment configuration and override flow

The supported topologies are:

```yaml
# Encoder + combined prefill/decode
server_groups:
  - worker_type: encoder
    num_gpus: 1
  - worker_type: regular
    num_gpus: 1
```

```yaml
# Encoder + separate prefill/decode
server_groups:
  - worker_type: encoder
    num_gpus: 1
  - worker_type: prefill
    num_gpus: 1
  - worker_type: decode
    num_gpus: 1
```

Vime rejects incomplete or mixed EPD topologies during config resolution.

For each EPD model, the Ray orchestration layer creates one model-scoped `/dev/shm/vime-ec-*` path. This path is the shared part of the EC configuration and is passed through the generated group overrides to encoder and EC-consumer groups.

`_compute_server_args()` then combines that shared component with worker-specific vLLM configuration:

| Worker type | Generated configuration |
| --- | --- |
| `encoder` | `ECExampleConnector`, `ec_producer`, `enable_prefix_caching=false`, and `mm_encoder_only=true` |
| `regular` | `ECExampleConnector` and `ec_consumer` |
| `prefill` | `ECExampleConnector` and `ec_consumer` |
| `decode` | No EC configuration; the existing KV consumer configuration is unchanged |

The startup order is also topology-aware. Encoder groups are started and health-checked first, then regular or prefill/decode groups are started. Encoder engines are not registered with the regular or PD router.

Group-level `overrides` remain the highest-priority user configuration. The orchestration layer first provides the generated shared EC component, then the current group's overrides are applied. At server-argument construction time, Vime supplies the default connector and worker-specific role, while explicitly provided native EC fields override those defaults. This keeps the existing per-group override mechanism available for advanced vLLM configuration.

The current default uses upstream vLLM's `ECExampleConnector`, so built-in EPD deployment is limited to one node. Vime removes only the automatically generated `/dev/shm/vime-ec-*` paths during shutdown.

## 2. Rollout-side encoder priming

Encoder routing is implemented in the rollout layer.

The rollout manager exposes model-scoped encoder endpoints separately from router endpoints. Before a multimodal request enters the existing render/generate path, the new `prime_encoder()` helper:

- extracts image URLs from chat messages;
- sends one image-only `/v1/chat/completions` request per image;
- sets `max_tokens=1`, `stream=false`, and a unique `x-request-id`;
- primes multiple images concurrently and distributes them round-robin across encoder endpoints;
- reuses the existing HTTP retry policy and propagates failures;
- becomes a no-op for text-only samples and non-EPD deployments.

After priming completes, the request follows the existing flow:

```text
/v1/chat/completions/render -> /inference/v1/generate
```

For E+P+D, the existing PD router and KVConnector continue to coordinate prefill and decode. The encoder remains outside that router and publishes embeddings through ECConnector.

The default multimodal rollout, streaming rollout, and the repository's Geo3K multi-turn rollout call `prime_encoder()` automatically. Custom multimodal rollout functions must call the same helper before render/generate:

```python
from vime.rollout.vllm_rollout import prime_encoder

await prime_encoder(args, messages, model_name='actor')
```

## Validation

Added CPU unit coverage for:

- supported and rejected EPD topologies;
- EC producer/consumer role construction;
- encoder-only option scoping and prefix-caching defaults;
- group override behavior;
- multi-image priming, unique request IDs, and round-robin endpoint selection.

Manual end-to-end validation was completed with `Qwen/Qwen2.5-VL-3B-Instruct` on 4 x RTX 4090 Plus using `1 encoder + 1 prefill + 1 decode + 1 placeholder`. Encoder priming, EC transfer, PD generation, training weight synchronization, and EC cache cleanup all completed successfully.

Added a vLLM-only multimodal GPU acceptance test to the `vllm-config` Buildkite suite. It runs a regular baseline and `1 encoder + 1 prefill + 1 decode` with `Qwen/Qwen2.5-VL-3B-Instruct` on three GPUs, then checks deterministic token parity, live EC/KV roles, PD router membership, text-only encoder bypass, and EC cache cleanup.

## Documentation

Added matching English and Chinese EPD guides covering topology, data flow, connector behavior, defaults, and the custom rollout contract. The vLLM configuration reference now documents the `encoder` worker type.

## AI assistance disclosure

This PR was developed with assistance from OpenAI Codex. I reviewed the changes and validated the implementation end to end.