### PR TITLE
[NPU] fix: update MoE communication selector for colocated Ascend A3

### DIFF
--- a/.buildkite/npu_suites.py
+++ b/.buildkite/npu_suites.py
@@ -29,7 +29,8 @@ BUILDKITE_SOURCE = os.environ.get("BUILDKITE_SOURCE", "")
 SUITES = {
     "smk": [
         ("test_qwen3_4B_npu.py", "npu-8", "", {}),
-        ("test_qwen3_30B_A3B_npu.py", "npu-16", "", {}),
+        ("test_qwen3_30B_A3B_npu.py", "npu-8", "--colocate", {}),
+        ("test_qwen3_30B_A3B_npu.py", "npu-16", "--disaggregated", {}),
     ],
     "nightly": [],
 }

--- a/tests/test_qwen3_30B_A3B_npu.py
+++ b/tests/test_qwen3_30B_A3B_npu.py
@@ -1,8 +1,8 @@
+import argparse
 import os
 import shlex
 
 import vime.utils.external_utils.command_utils as U
-
 
 TEST_ROOT = os.environ.get("HF_HOME") or "/root"
 MODEL_DIR = f"{TEST_ROOT}/models/Qwen3-30B-A3B"
@@ -20,7 +20,7 @@ def prepare():
     U.exec_command("hf download --repo-type dataset zhuzilin/dapo-math-17k " f"--local-dir {dataset_dir}")
 
 
-def execute():
+def execute(*, colocate: bool):
     model_dir = shlex.quote(MODEL_DIR)
     prompt_data = shlex.quote(f"{DATASET_DIR}/dapo-math-17k.jsonl")
 
@@ -86,8 +86,10 @@ def execute():
         "--use-precision-aware-optimizer "
     )
 
+    # Keep two TP4/EP4 rollout engines in both modes so colocation is the only
+    # topology variable between the two NPU CI jobs.
     vllm_args = (
-        "--rollout-num-gpus-per-engine 8 "
+        "--rollout-num-gpus-per-engine 4 "
         "--vllm-enable-sleep-mode "
         "--vllm-enable-expert-parallel "
         "--vllm-gpu-memory-utilization 0.7 "
@@ -110,6 +112,8 @@ def execute():
         "--rollout-num-gpus 8 "
         "--ci-test "
     )
+    if colocate:
+        runtime_args += "--colocate "
 
     train_args = (
         checkpoint_args
@@ -123,7 +127,7 @@ def execute():
     )
     U.execute_train(
         train_args=train_args,
-        num_gpus_per_node=16,
+        num_gpus_per_node=8 if colocate else 16,
         megatron_model_type="qwen3-30B-A3B",
         extra_env_vars={
             "DISABLE_L2_CACHE": "1",
@@ -132,11 +136,20 @@ def execute():
     )
 
 
+def parse_args():
+    parser = argparse.ArgumentParser()
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--colocate", action="store_true", dest="colocate")
+    mode.add_argument("--disaggregated", action="store_false", dest="colocate")
+    return parser.parse_args()
+
+
 def main():
+    args = parse_args()
     prepare()
     for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
         os.environ.pop(proxy_var, None)
-    execute()
+    execute(colocate=args.colocate)
 
 
 if __name__ == "__main__":

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -4,7 +4,9 @@ Colocated vLLM weight sync using native IPC transfer engines.
 
 from __future__ import annotations
 
+import logging
 import os
+import sys
 from argparse import Namespace
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import asdict
@@ -25,6 +27,8 @@ from .update_weight_from_distributed import (
     post_process_weights,
     update_weights_from_distributed,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class UpdateWeightFromTensor:
@@ -284,6 +288,55 @@ class _VLLMHijack:
         NPUWorker._npu_worker_patched = True
 
     @staticmethod
+    def _patch_a3_moe_comm_selector() -> None:
+        """Force ALLGATHER for colocated MoE forwards on Ascend A3 (910C)."""
+        from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
+        if get_ascend_device_type() != AscendDeviceType.A3:
+            return
+
+        import vllm_ascend.ascend_forward_context as ascend_forward_context
+
+        original_selector = ascend_forward_context.select_moe_comm_method
+        if getattr(original_selector, "_vime_a3_moe_allgather_patched", False):
+            return
+
+        forced_moe_logged = False
+
+        def _select_allgather(num_tokens, vllm_config, is_draft_model=False):
+            nonlocal forced_moe_logged
+            native_moe_comm = original_selector(num_tokens, vllm_config, is_draft_model)
+            # The native selector returns None for non-MoE models. Keep that
+            # result unchanged so A3 colocated dense models are unaffected.
+            if native_moe_comm is None:
+                return None
+            if not forced_moe_logged:
+                logger.warning(
+                    "Colocated Ascend A3 MoE detected: forcing vLLM-Ascend communication "
+                    "from %s to MoECommType.ALLGATHER",
+                    native_moe_comm,
+                )
+                forced_moe_logged = True
+            return ascend_forward_context.MoECommType.ALLGATHER
+
+        _select_allgather._vime_a3_moe_allgather_patched = True
+
+        # model_runner_v1 imports the selector directly, so replacing only the
+        # defining module would leave its already-bound alias unchanged.
+        patched_modules = []
+        for module_name, module in tuple(sys.modules.items()):
+            if not module_name.startswith("vllm_ascend."):
+                continue
+            if getattr(module, "select_moe_comm_method", None) is original_selector:
+                module.select_moe_comm_method = _select_allgather
+                patched_modules.append(module_name)
+
+        logger.info(
+            "Colocated Ascend A3 detected: installed automatic MoE ALLGATHER selector in %s",
+            patched_modules,
+        )
+
+    @staticmethod
     def _patch_one_worker(worker_cls: type) -> None:
         import inspect
 
@@ -378,6 +431,7 @@ class vLLMColocateWorkerExtension:
 
     def __new__(cls, **kwargs):
         if is_npu():
+            _VLLMHijack._patch_a3_moe_comm_selector()
             _VLLMHijack._patch_npu_worker()
             _VLLMHijack._patch_npu_rotary_emb()
         return super().__new__(cls)


### PR DESCRIPTION
# Details
This PR fixes a MoE inference precision issue observed with Qwen3-30B-A3B on Ascend A3/910C in colocated RL deployments. After a live actor-to-vLLM weight update, rollout output could become incorrect from the first token, causing repetitive generation and a train_rollout_logprob_abs_diff greater than 0.1. The issue was not reproducible on 910B in colocated mode or on 910C in disaggregated mode. Weight probes confirmed that actor export, IPC transfer, expert loading, and final MoE parameter values were consistent, isolating the problem to the runtime MoE communication path. On 910C, vLLM-Ascend may select MC2, while the equivalent 910B configuration uses ALLGATHER. This change therefore forces MoECommType.ALLGATHER only when all three conditions are met: the device is A3/910C, the rollout engine is colocated, and the native selector identifies the model as MoE. Dense models, 910B devices, and disaggregated deployments retain the native communication selection. This prioritizes correctness over the MC2 performance optimization for the affected configuration.

# Testing
- [x] End-to-end Qwen3-30B-A3B colocated training on Ascend A3
<img width="603" height="321" alt="image" src="https://github.com/user-attachments/assets/16f7424f-2b84-4c5e-8885-dfe78ce88743" />

<img width="592" height="313" alt="image" src="https://github.com/user-attachments/assets/517cf761-a9e3-43de-9b99-e32fc285876e" />
