### PR TITLE
[Doc] Document EPD (encoder-prefill disaggregation)

### DIFF
--- a/docs/en/advanced/external-rollout-engines.md
+++ b/docs/en/advanced/external-rollout-engines.md
@@ -15,7 +15,7 @@ This page is a roadmap. Use it to decide when to use `--rollout-external-engine-
 | Full checkpoints are too heavy for large-model cross-cluster or cross-DC sync | `--update-weight-mode delta --update-weight-transport disk` |
 | Rollout serving can use an independent vLLM environment, or even different GPU models/vendors | external engines + disk transport |
 | You want to validate delta wire/apply logic inside one datacenter | `--update-weight-mode delta --update-weight-transport nccl` |
-| You need frozen reference, reward, or tool-side models | Prefer `update_weights: false` in [vLLM Config](vllm-config.md#3-multi-model-serving) |
+| You need frozen reference, reward, or tool-side models | Prefer `update_weights: false` in [vLLM Config](vllm-config.md#4-multi-model-serving) |
 
 ## What External Engine Does
 

--- a/docs/en/advanced/pd-disaggregation.md
+++ b/docs/en/advanced/pd-disaggregation.md
@@ -30,7 +30,7 @@ This is the lightweight path used by simple scripts. It is convenient when you o
 
 ### Advanced Path: `--vllm-config`
 
-For production rollout topologies, use [vLLM Config](vllm-config.md). It lets you configure prefill and decode groups independently, and can also express EPD-style layouts, heterogeneous server groups, multi-model serving, and per-group vLLM overrides.
+For production rollout topologies, use [vLLM Config](vllm-config.md). It lets you configure prefill and decode groups independently, and can also express EPD layouts, heterogeneous server groups, multi-model serving, and per-group vLLM overrides.
 
 Example:
 
@@ -60,6 +60,31 @@ python train.py \
   ...
 ```
 
+## EPD: Splitting the Vision Encoder
+
+For vision-language models, the vision tower is a third workload with its own profile — bursty, image-count-driven, and idle whenever a sample is text-only. Adding a `worker_type: encoder` group moves it onto dedicated engines that publish image embeddings to an encoder cache, which the language engines consume instead of running the vision tower themselves.
+
+EPD is orthogonal to PD, so the two compose:
+
+```yaml
+vllm:
+  - name: actor
+    update_weights: true
+    server_groups:
+      - worker_type: encoder
+        num_gpus: 2
+      - worker_type: prefill
+        num_gpus: 6
+      - worker_type: decode
+        num_gpus: 8
+```
+
+vime starts the encoder group first, then launches the prefill/decode groups with `language_only: true` and the encoder URLs injected. Encoder engines stay out of the router's worker registry — only prefill and decode serve routed traffic.
+
+Dropping the `decode` group gives you `encoder` + `regular`, which splits the vision tower without PD.
+
+See [EPD Disaggregation](vllm-config.md#3-epd-disaggregation-vision-encoder-split) for the full role matrix, the `prime_encoder` requirement for custom rollout functions, how to swap the encoder-cache connector, and current limitations.
+
 ## Why This Matters for RL
 
 RL rollout is often not a uniform batch of short completions. Agentic and verifier-based workloads commonly have:
@@ -77,7 +102,7 @@ PD lets vime keep the training loop unchanged while using a rollout topology tha
 - For new complex deployments, prefer `--vllm-config` over `--prefill-num-servers`.
 - Use router session affinity for multi-turn agents so turns from the same sample can reuse prefix cache. See [Session-Affinity Routing](vllm-config.md#session-affinity-routing-for-multi-turn-agents).
 - Keep `--rollout-num-gpus` equal to the total GPUs described by the vLLM config.
-- Do not mix `regular` workers with `prefill`/`decode` workers inside the same model entry.
+- Do not mix `regular` workers with `prefill`/`decode` workers inside the same model entry. `encoder` is the exception — it composes with either layout.
 - Tune prefill and decode TP separately when prompt processing and token generation have different bottlenecks.
 
 ## Related Docs

--- a/docs/en/advanced/vllm-config.md
+++ b/docs/en/advanced/vllm-config.md
@@ -1,6 +1,6 @@
 # vLLM Config: Advanced Engine Deployment
 
-`--vllm-config` is a YAML-based configuration system for fine-grained control over vLLM engine deployment in vime. It enables **multi-model serving**, **Prefill-Decode (PD) disaggregation**, **heterogeneous server groups**, and can even serve as a **standalone vLLM launcher** for complex inference topologies.
+`--vllm-config` is a YAML-based configuration system for fine-grained control over vLLM engine deployment in vime. It enables **multi-model serving**, **Prefill-Decode (PD) disaggregation**, **Encoder-Prefill-Decode (EPD) disaggregation** for vision-language models, **heterogeneous server groups**, and can even serve as a **standalone vLLM launcher** for complex inference topologies.
 
 ---
 
@@ -17,7 +17,7 @@ With `--vllm-config`, the vLLM deployment expands into a multi-model, multi-rout
 **Key design principles:**
 
 - **Each model gets its own router.** Models are isolated at the routing layer, allowing independent load balancing and fault tolerance.
-- **Server groups within a model can be heterogeneous.** Different groups can have different TP sizes, worker types (prefill/decode/regular), and vLLM engine argument overrides.
+- **Server groups within a model can be heterogeneous.** Different groups can have different TP sizes, worker types (prefill/decode/encoder/regular), and vLLM engine argument overrides.
 - **Weight sync is per-model.** Only models with `update_weights: true` receive weight updates from training. Frozen models (reference, reward, etc.) are served as-is.
 
 ---
@@ -33,7 +33,7 @@ vllm:
     update_weights: <bool>          # Optional. Whether to sync weights from training. Auto-inferred.
     num_gpus_per_engine: <int>      # Optional. Default TP size for all groups in this model.
     server_groups:                  # Required. List of server group configurations.
-      - worker_type: <type>         # Required. One of: regular, prefill, decode, placeholder.
+      - worker_type: <type>         # Required. One of: regular, prefill, decode, encoder, placeholder.
         num_gpus: <int>             # Required. Total GPUs allocated to this group.
         num_gpus_per_engine: <int>  # Optional. TP size override for this group.
         overrides: <dict>           # Optional. vLLM EngineArgs field overrides.
@@ -55,7 +55,7 @@ vllm:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `worker_type` | `str` | **Required** | Engine type: `regular` (standard), `prefill` (PD prefill worker), `decode` (PD decode worker), or `placeholder` (reserve GPU slots without launching engines). |
+| `worker_type` | `str` | **Required** | Engine type: `regular` (standard), `prefill` (PD prefill worker), `decode` (PD decode worker), `encoder` (EPD vision-encoder worker), or `placeholder` (reserve GPU slots without launching engines). |
 | `num_gpus` | `int` | **Required** | Total number of GPUs for this group. Must be > 0. |
 | `num_gpus_per_engine` | `int` | Model's `num_gpus_per_engine` | TP size override. Number of GPUs per engine instance. |
 | `overrides` | `dict` | `{}` | vLLM `EngineArgs` field overrides. Applied on top of `--vllm-*` CLI args with highest priority. |
@@ -67,6 +67,7 @@ vllm:
 | `regular` | Standard vLLM engine | Default mode, handles both prefill and decode |
 | `prefill` | PD disaggregation prefill worker | Dedicated to prompt processing; paired with `decode` workers |
 | `decode` | PD disaggregation decode worker | Dedicated to token generation; paired with `prefill` workers |
+| `encoder` | EPD disaggregation vision-encoder worker | Runs the vision tower for VLMs; paired with `prefill` or `regular` workers, which become `language_only` |
 | `placeholder` | Reserves GPU slots, no engine created | Reserve GPUs for training co-location or future use |
 
 ---
@@ -127,7 +128,73 @@ python train.py \
 
 > **Note:** PD disaggregation uses vllm-router with `pd_disaggregation=True`.
 
-### 3. Multi-Model Serving
+### 3. EPD Disaggregation (Vision Encoder Split)
+
+For vision-language models, `worker_type: encoder` moves the vision tower onto its own engines. Encoder engines compute image embeddings and publish them to an encoder cache; the language engines consume that cache instead of running the vision tower themselves.
+
+EPD composes with PD on an orthogonal axis. Pair `encoder` with `prefill` + `decode` for a full three-stage split:
+
+```yaml
+# vllm_epd.yaml
+vllm:
+  - name: actor
+    server_groups:
+      - worker_type: encoder
+        num_gpus: 1
+      - worker_type: prefill
+        num_gpus: 1
+      - worker_type: decode
+        num_gpus: 1
+```
+
+Or pair `encoder` with `regular` to split off the vision tower without PD:
+
+```yaml
+vllm:
+  - name: actor
+    server_groups:
+      - worker_type: encoder
+        num_gpus: 2
+      - worker_type: regular
+        num_gpus: 6
+```
+
+**Roles assigned automatically.** vime derives the encoder-cache (EC) wiring from the worker types, so you do not write `ec_transfer_config` by hand:
+
+| Worker type | `ec_role` | `kv_role` (when PD is also used) | Notes |
+|-------------|-----------|----------------------------------|-------|
+| `encoder` | `ec_producer` | — | Runs the vision tower. `enable_prefix_caching` is forced off (no language-model KV cache groups). Not registered with the router. |
+| `prefill` | `ec_consumer` | `kv_producer` | Started with `language_only: true` and `encoder_urls` pointing at the encoder engines. |
+| `regular` | `ec_consumer` | — | Same as prefill, when used without PD. |
+| `decode` | — | `kv_consumer` | Receives KV from prefill; never touches the encoder cache. |
+
+**Startup ordering.** Encoder groups are launched first and awaited synchronously, because their URLs must be injected into the language engines' server arguments before those engines start. The language engines then initialize in the usual deferred fashion.
+
+**Priming the encoder.** A request must reach the encoder before the language engines generate, so the embeddings are in the cache when the consumer looks them up. The built-in rollout paths do this for you — both `generate` and `generate_streaming` call `prime_encoder` on multimodal samples. In a custom rollout function, call it yourself before rendering:
+
+```python
+from vime.rollout.vllm_rollout import prime_encoder
+
+await prime_encoder(args, messages, model_name="actor")
+```
+
+`prime_encoder` is a no-op when the sample has no images or when the deployment has no encoder group, so it is safe to call unconditionally. Encoder endpoints are published at runtime on `args.vllm_model_encoder_endpoints`, a dict `{ model_name: (model_path, [endpoint, ...]) }`.
+
+**Swapping the connector.** By default vime uses upstream vLLM's `ECExampleConnector` over a per-deployment tmpfs directory (`/dev/shm/vime-ec-<uuid>`). An `ec_transfer_config` in a group's `overrides` **replaces** the generated one for that group, and is then layered over the auto-derived `ec_connector` / `ec_role` defaults — so your keys win, but nothing is deep-merged. Because the replacement is per-group, set it on *every* participating group (encoder and its consumers) with a matching `shared_storage_path`, or the producer and consumer will point at different caches:
+
+```yaml
+      - worker_type: encoder
+        num_gpus: 1
+        overrides:
+          ec_transfer_config:
+            ec_connector: MyProductionConnector
+            ec_connector_extra_config:
+              shared_storage_path: /mnt/shared/ec-cache
+```
+
+> **Limitations.** `ECExampleConnector` is upstream's reference implementation and is file-backed: the default `/dev/shm` path is node-local, so encoder and consumer engines must land on the same node unless you override `shared_storage_path` with a shared mount. EPD is also currently exercised in CI with `update_weights: false` (see [tests/test_qwen2.5_vl_3B_ep_disaggregation.py](https://github.com/vllm-project/vime/blob/main/tests/test_qwen2.5_vl_3B_ep_disaggregation.py)); weight sync into a split encoder/language-only deployment is not yet covered.
+
+### 4. Multi-Model Serving
 
 Deploy multiple models simultaneously, each behind its own router:
 
@@ -200,7 +267,7 @@ async def my_generate(args, sample, sampling_params):
 
 The `get_model_url()` helper reads from `args.vllm_model_routers`, a dict mapping model names to `(ip, port)` tuples that is automatically populated after engine startup.
 
-### 4. Multi-Model with PD Disaggregation
+### 5. Multi-Model with PD Disaggregation
 
 Combine multi-model and PD disaggregation for maximum flexibility:
 
@@ -226,7 +293,7 @@ vllm:
         num_gpus_per_engine: 2
 ```
 
-### 5. Placeholder Groups for GPU Reservation
+### 6. Placeholder Groups for GPU Reservation
 
 Use `placeholder` groups to reserve GPU slots without creating engines. This is useful for co-located training where some GPUs need to be reserved for training:
 
@@ -241,7 +308,7 @@ vllm:
         num_gpus: 2                   # reserve 2 GPUs (no engines created)
 ```
 
-### 6. Per-Group EngineArgs Overrides
+### 7. Per-Group EngineArgs Overrides
 
 Use `overrides` to apply vLLM `EngineArgs` fields to specific server groups without affecting others:
 
@@ -264,7 +331,7 @@ Overrides take **highest priority**, overriding both the base `--vllm-*` CLI arg
 - Different context lengths for prefill vs. decode
 - Enabling experimental features on specific groups
 
-### 7. Standalone vLLM Launcher
+### 8. Standalone vLLM Launcher
 
 While `--vllm-config` is designed for vime's training pipeline, it also works as a powerful launcher for pure inference scenarios using external engine addresses or by configuring vime to focus solely on serving.
 
@@ -449,6 +516,12 @@ async def generate_with_models(args, sample, sampling_params):
 ### Q: Can I mix PD and regular groups in the same model?
 
 No. PD disaggregation requires that a model's server groups are either all prefill/decode pairs or all regular. Mixing `regular` with `prefill`/`decode` in the same model is not supported.
+
+`encoder` is the exception: it is an orthogonal axis and may be added to either layout, giving `encoder` + `prefill` + `decode` (full EPD) or `encoder` + `regular` (vision split without PD). See [EPD Disaggregation](#3-epd-disaggregation-vision-encoder-split).
+
+### Q: Do encoder GPUs count toward `--rollout-num-gpus`?
+
+Yes. Total-GPU validation sums `num_gpus` across every group of every model, including `encoder` groups. A three-group EPD layout with one GPU each needs `--rollout-num-gpus 3`.
 
 ### Q: What happens if `num_gpus` is not divisible by `num_gpus_per_engine`?
 

--- a/docs/zh/advanced/external-rollout-engines.md
+++ b/docs/zh/advanced/external-rollout-engines.md
@@ -15,7 +15,7 @@ External rollout engine 指的是：vLLM engine 不由 vime 训练任务启动�
 | 大模型跨集群或跨数据中心同步，full checkpoint 太重 | `--update-weight-mode delta --update-weight-transport disk` |
 | rollout serving 想使用独立 vLLM 环境，甚至不同型号或不同厂家的 GPU | external engine + disk transport |
 | 想验证 delta wire/apply 逻辑，但仍在同一数据中心内 | `--update-weight-mode delta --update-weight-transport nccl` |
-| 需要 reference、reward、tool-side model 等冻结模型 | 优先用 [vLLM Config](vllm-config.md#3-多模型服务) 的 `update_weights: false` |
+| 需要 reference、reward、tool-side model 等冻结模型 | 优先用 [vLLM Config](vllm-config.md#4-多模型服务) 的 `update_weights: false` |
 
 ## External Engine 做了什么
 

--- a/docs/zh/advanced/pd-disaggregation.md
+++ b/docs/zh/advanced/pd-disaggregation.md
@@ -30,7 +30,7 @@ vime 支持两种 PD 配置方式。
 
 ### 高级路径：`--vllm-config`
 
-生产级 rollout topology 推荐使用 [vLLM Config](vllm-config.md)。它可以独立配置 prefill 和 decode group，也能表达 EPD-style layout、heterogeneous server group、multi-model serving 和 per-group vLLM override。
+生产级 rollout topology 推荐使用 [vLLM Config](vllm-config.md)。它可以独立配置 prefill 和 decode group，也能表达 EPD layout、heterogeneous server group、multi-model serving 和 per-group vLLM override。
 
 示例：
 
@@ -60,6 +60,31 @@ python train.py \
   ...
 ```
 
+## EPD：拆分视觉编码器
+
+对视觉语言模型来说，vision tower 是第三种独立的 workload：突发式、由图像数量驱动、遇到纯文本样本时完全空闲。加入 `worker_type: encoder` 组即可把它放到专门的引擎上，由这些引擎把图像 embedding 写入 encoder cache，language 引擎直接消费，不再自己跑 vision tower。
+
+EPD 与 PD 正交，两者可以组合：
+
+```yaml
+vllm:
+  - name: actor
+    update_weights: true
+    server_groups:
+      - worker_type: encoder
+        num_gpus: 2
+      - worker_type: prefill
+        num_gpus: 6
+      - worker_type: decode
+        num_gpus: 8
+```
+
+vime 会先启动 encoder 组，再启动 prefill/decode 组，并为后者注入 `language_only: true` 和 encoder URL。encoder 引擎不会注册到 router 的 worker 列表中——只有 prefill 和 decode 承接路由流量。
+
+去掉 `decode` 组就得到 `encoder` + `regular`，即只拆 vision tower、不做 PD。
+
+完整的角色矩阵、自定义 rollout function 需要调用的 `prime_encoder`、如何替换 encoder cache connector 以及当前限制，见 [EPD 分离](vllm-config.md#3-epd-分离视觉编码器拆分)。
+
 ## 为什么这对 RL 重要
 
 RL rollout 往往不是一批短 completion。Agentic 和 verifier-based workload 常见特征包括：
@@ -77,7 +102,7 @@ PD 让 vime 在不改变 training loop 的情况下，使用更贴合真实 serv
 - 新的复杂部署优先使用 `--vllm-config`，而不是 `--prefill-num-servers`。
 - multi-turn agent 建议开启 router session affinity，使同一 sample 的多轮请求可以复用 prefix cache。见 [Session-Affinity Routing](vllm-config.md#session-affinity-routing-for-multi-turn-agents)。
 - `--rollout-num-gpus` 应等于 vLLM config 中描述的 GPU 总数。
-- 不要在同一个 model entry 中混用 `regular` worker 和 `prefill`/`decode` worker。
+- 不要在同一个 model entry 中混用 `regular` worker 和 `prefill`/`decode` worker。`encoder` 是例外——它可以与任一布局组合。
 - 当 prompt processing 和 token generation 的瓶颈不同时，分别调 prefill 和 decode 的 TP。
 
 ## 相关文档

--- a/docs/zh/advanced/vllm-config.md
+++ b/docs/zh/advanced/vllm-config.md
@@ -1,6 +1,6 @@
 # vLLM Config：高级引擎部署
 
-`--vllm-config` 是一个基于 YAML 的配置系统，用于在 vime 中精细控制 vLLM 引擎的部署。它支持**多模型服务**、**Prefill-Decode (PD) 分离**、**异构服务器组**，甚至可以作为复杂推理拓扑的**独立 vLLM 启动器**。
+`--vllm-config` 是一个基于 YAML 的配置系统，用于在 vime 中精细控制 vLLM 引擎的部署。它支持**多模型服务**、**Prefill-Decode (PD) 分离**、面向视觉语言模型的 **Encoder-Prefill-Decode (EPD) 分离**、**异构服务器组**，甚至可以作为复杂推理拓扑的**独立 vLLM 启动器**。
 
 ---
 
@@ -17,7 +17,7 @@
 **核心设计原则：**
 
 - **每个模型拥有独立的 router。** 模型在路由层隔离，支持独立的负载均衡和容错。
-- **同一模型内的服务器组可以异构。** 不同组可以有不同的 TP 大小、worker 类型（prefill/decode/regular）和 vLLM server 参数覆盖。
+- **同一模型内的服务器组可以异构。** 不同组可以有不同的 TP 大小、worker 类型（prefill/decode/encoder/regular）和 vLLM server 参数覆盖。
 - **权重同步按模型维度。** 只有 `update_weights: true` 的模型会接收来自训练的权重更新。冻结的模型（reference、reward 等）保持原样。
 
 ---
@@ -33,7 +33,7 @@ vllm:
     update_weights: <bool>          # 可选。是否从训练同步权重。自动推断。
     num_gpus_per_engine: <int>      # 可选。该模型所有组的默认 TP 大小。
     server_groups:                  # 必填。服务器组配置列表。
-      - worker_type: <type>         # 必填。可选：regular、prefill、decode、placeholder。
+      - worker_type: <type>         # 必填。可选：regular、prefill、decode、encoder、placeholder。
         num_gpus: <int>             # 必填。分配给该组的 GPU 总数。
         num_gpus_per_engine: <int>  # 可选。该组的 TP 大小覆盖。
         overrides: <dict>           # 可选。vLLM EngineArgs 字段覆盖。
@@ -55,7 +55,7 @@ vllm:
 
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
-| `worker_type` | `str` | **必填** | 引擎类型：`regular`（标准）、`prefill`（PD prefill worker）、`decode`（PD decode worker）或 `placeholder`（占位，不启动引擎）。 |
+| `worker_type` | `str` | **必填** | 引擎类型：`regular`（标准）、`prefill`（PD prefill worker）、`decode`（PD decode worker）、`encoder`（EPD 视觉编码器 worker）或 `placeholder`（占位，不启动引擎）。 |
 | `num_gpus` | `int` | **必填** | 该组的 GPU 总数。必须 > 0。 |
 | `num_gpus_per_engine` | `int` | 模型的 `num_gpus_per_engine` | TP 大小覆盖。每个引擎实例的 GPU 数量。 |
 | `overrides` | `dict` | `{}` | vLLM `EngineArgs` 字段覆盖。优先级最高，覆盖 `--vllm-*` CLI 参数和模型级默认值。 |
@@ -67,6 +67,7 @@ vllm:
 | `regular` | 标准 vLLM 引擎 | 默认模式，同时处理 prefill 和 decode |
 | `prefill` | PD 分离的 prefill worker | 专门处理 prompt；与 `decode` worker 配对 |
 | `decode` | PD 分离的 decode worker | 专门生成 token；与 `prefill` worker 配对 |
+| `encoder` | EPD 分离的视觉编码器 worker | 为 VLM 运行 vision tower；与 `prefill` 或 `regular` worker 配对，后者会变为 `language_only` |
 | `placeholder` | 占位，不创建引擎 | 为训练共置预留 GPU 或留作未来使用 |
 
 ---
@@ -127,7 +128,73 @@ python train.py \
 
 > **注意：** PD 分离使用 vllm-router，并设置 `pd_disaggregation=True`。
 
-### 3. 多模型服务
+### 3. EPD 分离（视觉编码器拆分）
+
+对于视觉语言模型，`worker_type: encoder` 会把 vision tower 拆到独立的引擎上。encoder 引擎负责计算图像 embedding 并写入 encoder cache；language 引擎直接消费该 cache，不再自己跑 vision tower。
+
+EPD 与 PD 是正交的两个维度。把 `encoder` 与 `prefill` + `decode` 搭配即可得到完整的三段式拆分：
+
+```yaml
+# vllm_epd.yaml
+vllm:
+  - name: actor
+    server_groups:
+      - worker_type: encoder
+        num_gpus: 1
+      - worker_type: prefill
+        num_gpus: 1
+      - worker_type: decode
+        num_gpus: 1
+```
+
+也可以把 `encoder` 与 `regular` 搭配，只拆分 vision tower 而不做 PD：
+
+```yaml
+vllm:
+  - name: actor
+    server_groups:
+      - worker_type: encoder
+        num_gpus: 2
+      - worker_type: regular
+        num_gpus: 6
+```
+
+**角色自动分配。** vime 会根据 worker 类型推导 encoder cache (EC) 的连接配置，无需手写 `ec_transfer_config`：
+
+| Worker 类型 | `ec_role` | `kv_role`（同时使用 PD 时） | 说明 |
+|-------------|-----------|------------------------------|------|
+| `encoder` | `ec_producer` | — | 运行 vision tower。强制关闭 `enable_prefix_caching`（没有语言模型的 KV cache group）。不注册到 router。 |
+| `prefill` | `ec_consumer` | `kv_producer` | 启动时带上 `language_only: true` 和指向 encoder 引擎的 `encoder_urls`。 |
+| `regular` | `ec_consumer` | — | 不使用 PD 时与 prefill 相同。 |
+| `decode` | — | `kv_consumer` | 从 prefill 接收 KV；不接触 encoder cache。 |
+
+**启动顺序。** encoder 组会先启动并同步等待就绪，因为它们的 URL 必须在 language 引擎启动前注入其 server 参数。之后 language 引擎按常规的延迟初始化方式启动。
+
+**预热 encoder。** 请求必须先到达 encoder，language 引擎生成时 embedding 才已经在 cache 中。内置 rollout 路径已经帮你做了这件事——`generate` 和 `generate_streaming` 都会对多模态样本调用 `prime_encoder`。在自定义 rollout function 中，需要在 render 之前自行调用：
+
+```python
+from vime.rollout.vllm_rollout import prime_encoder
+
+await prime_encoder(args, messages, model_name="actor")
+```
+
+当样本不含图像、或部署中没有 encoder 组时，`prime_encoder` 是空操作，因此可以无条件调用。encoder endpoint 在运行时发布在 `args.vllm_model_encoder_endpoints` 上，格式为 `{ model_name: (model_path, [endpoint, ...]) }`。
+
+**替换 connector。** vime 默认使用上游 vLLM 的 `ECExampleConnector`，存储目录是每次部署独立的 tmpfs 路径（`/dev/shm/vime-ec-<uuid>`）。在某个组的 `overrides` 中写入 `ec_transfer_config` 会**整体替换**该组自动生成的配置，然后再叠加到自动推导的 `ec_connector` / `ec_role` 默认值之上——即你写的键优先生效，但不做深度合并。由于替换是按组进行的，请为**每一个**参与的组（encoder 及其 consumer）都设置，并保持 `shared_storage_path` 一致，否则 producer 和 consumer 会指向不同的 cache：
+
+```yaml
+      - worker_type: encoder
+        num_gpus: 1
+        overrides:
+          ec_transfer_config:
+            ec_connector: MyProductionConnector
+            ec_connector_extra_config:
+              shared_storage_path: /mnt/shared/ec-cache
+```
+
+> **限制。** `ECExampleConnector` 是上游的参考实现，基于文件存储：默认的 `/dev/shm` 路径是节点本地的，因此除非用共享挂载覆盖 `shared_storage_path`，encoder 与 consumer 引擎必须落在同一个节点上。此外，目前 CI 中的 EPD 用例使用 `update_weights: false`（见 [tests/test_qwen2.5_vl_3B_ep_disaggregation.py](https://github.com/vllm-project/vime/blob/main/tests/test_qwen2.5_vl_3B_ep_disaggregation.py)）；向 encoder / language-only 拆分部署做权重同步尚未覆盖。
+
+### 4. 多模型服务
 
 同时部署多个模型，每个模型拥有独立的 router：
 
@@ -200,7 +267,7 @@ async def my_generate(args, sample, sampling_params):
 
 `get_model_url()` 从 `args.vllm_model_routers`（一个将模型名称映射到 `(ip, port)` 元组的字典）中读取，该字典在引擎启动后自动填充。
 
-### 4. 多模型 + PD 分离
+### 5. 多模型 + PD 分离
 
 将多模型与 PD 分离结合，实现最大灵活性：
 
@@ -226,7 +293,7 @@ vllm:
         num_gpus_per_engine: 2
 ```
 
-### 5. 占位组用于 GPU 预留
+### 6. 占位组用于 GPU 预留
 
 使用 `placeholder` 组来预留 GPU 而不创建引擎。这在共置训练场景中很有用，部分 GPU 需要为训练预留：
 
@@ -241,7 +308,7 @@ vllm:
         num_gpus: 2                   # 预留 2 个 GPU（不创建引擎）
 ```
 
-### 6. 按组覆盖 EngineArgs
+### 7. 按组覆盖 EngineArgs
 
 使用 `overrides` 将 vLLM `EngineArgs` 字段应用到特定服务器组，而不影响其他组：
 
@@ -264,7 +331,7 @@ vllm:
 - prefill 和 decode 使用不同的 context length
 - 在特定组上启用实验性功能
 
-### 7. 独立 vLLM 启动器
+### 8. 独立 vLLM 启动器
 
 虽然 `--vllm-config` 是为 vime 的训练流水线设计的，但它也可以作为纯推理场景的强大启动器，通过外部 engine 地址或配置 vime 仅关注推理服务。
 
@@ -448,6 +515,12 @@ async def generate_with_models(args, sample, sampling_params):
 ### Q: 同一模型内可以混用 PD 和 regular 组吗？
 
 不可以。PD 分离要求一个模型的服务器组要么全部是 prefill/decode 对，要么全部是 regular。不支持在同一模型内混用 `regular` 与 `prefill`/`decode`。
+
+`encoder` 是例外：它属于正交维度，可以加入上述任一布局，组成 `encoder` + `prefill` + `decode`（完整 EPD）或 `encoder` + `regular`（只拆 vision，不做 PD）。见 [EPD 分离](#3-epd-分离视觉编码器拆分)。
+
+### Q: encoder 的 GPU 计入 `--rollout-num-gpus` 吗？
+
+计入。GPU 总数校验会累加所有模型、所有组的 `num_gpus`，包括 `encoder` 组。三组各 1 张卡的 EPD 布局需要 `--rollout-num-gpus 3`。
 
 ### Q: 如果 `num_gpus` 不能被 `num_gpus_per_engine` 整除怎么办？
 


### PR DESCRIPTION
## Summary

EPD landed in #370, but it has no user-facing documentation: `grep -rn encoder docs/` currently returns nothing, and `worker_type: encoder` is missing from every config reference table. This PR documents it.

Docs only — no behavior change.

### `docs/{en,zh}/advanced/vllm-config.md`

New usage-pattern section **"EPD Disaggregation (Vision Encoder Split)"**, covering:

- The two supported layouts: `encoder` + `prefill` + `decode` (full EPD), and `encoder` + `regular` (vision split without PD)
- The auto-derived role matrix, so users never hand-write `ec_transfer_config`:

  | Worker type | `ec_role` | `kv_role` (with PD) |
  |---|---|---|
  | `encoder` | `ec_producer` | — |
  | `prefill` | `ec_consumer` | `kv_producer` |
  | `regular` | `ec_consumer` | — |
  | `decode` | — | `kv_consumer` |

- Why encoder groups start first and synchronously (their URLs are injected into the language engines' server args before those engines launch)
- `prime_encoder` — automatic on the built-in rollout paths, required in custom rollout functions — plus the `args.vllm_model_encoder_endpoints` shape
- How to swap the encoder-cache connector, and the caveat that a group-level `ec_transfer_config` **replaces** rather than deep-merges the generated one, so it must be set on every participating group with a matching `shared_storage_path`
- Limitations: `ECExampleConnector` is file-backed and the default `/dev/shm` path is node-local, so producer and consumer must co-locate unless `shared_storage_path` points at a shared mount; and EPD is currently exercised in CI with `update_weights: false`, so weight sync into a split encoder/language-only deployment is not yet covered

Also updated the config-format comment, both `worker_type` reference tables, the Worker Types table, the intro paragraph, and the FAQ — the existing "can I mix PD and regular groups in the same model?" answer needed an `encoder` exception, since encoder composes with either layout. Added a FAQ entry noting encoder GPUs count toward `--rollout-num-gpus`.

### `docs/{en,zh}/advanced/pd-disaggregation.md`

New **"EPD: Splitting the Vision Encoder"** section framing the vision tower as a third workload profile and showing PD ∘ EPD composition, linking through to the config guide for detail. Updated the operational note that forbids mixing `regular` with `prefill`/`decode` to record the `encoder` exception.

### `docs/{en,zh}/advanced/external-rollout-engines.md`

Inserting EPD as section 3 renumbers the following usage patterns to 4–8, so the two links to `vllm-config.md#3-multi-model-serving` become `#4-multi-model-serving`. These are required by the renumbering, not drive-by edits.

## Test plan

- [x] `pre-commit run --files <the six .md files>` passes (all Python hooks skip; no markdown hooks configured)
- [x] Verified every in-repo `.md#anchor` link across `docs/**/*.md` still resolves, including the renumbered ones and the two new EPD anchors. One pre-existing broken link in `docs/zh/advanced/pd-disaggregation.md` (an English slug used on the Chinese page) is left untouched, as it is unrelated to this change
- [x] Every documented claim checked against the implementation in `vime/ray/rollout.py`, `vime/backends/vllm_utils/vllm_engine.py`, `vime/rollout/vllm_rollout.py`, and the assertions in `tests/test_qwen2.5_vl_3B_ep_disaggregation.py`

No code paths touched, so no CI suite is affected.

Related: #11 (roadmap), #370 (the EPD implementation).

## AI assistance disclosure

This PR was drafted with Claude Code. I reviewed every changed line and verified each documented claim against the implementation and the EPD test.