### PR TITLE
docs: surface agent workflows and fix vLLM response parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The vLLM community horizontally supports many LLM post-training frameworks, incl
   - [Table of Contents](#table-of-contents)
   - [Architecture Overview](#architecture-overview)
   - [Quick Start](#quick-start)
+    - [Agentic RL examples](#agentic-rl-examples)
   - [Arguments Walkthrough](#arguments-walkthrough)
   - [Developer Guide](#developer-guide)
   - [slime doc](#slime-doc)
@@ -46,8 +47,8 @@ The vLLM community horizontally supports many LLM post-training frameworks, incl
 **Module Descriptions**:
 
 - **training (Megatron)**: Responsible for the main training process, reads data from the Data Buffer, and synchronizes parameters to the rollout module after training.
-- **rollout (vLLM + router)**: Launches vLLM inference engines and routes generation requests; produces new data (including rewards/verifier outputs) and stores it in the Data Buffer.
-- **data buffer**: A bridge module that manages prompt initialization, custom data, and rollout generation methods.
+- **rollout (vLLM + router)**: Launches vLLM inference engines and routes generation requests; custom generate functions can wrap generation with multi-turn loops, tool calls, environment/sandbox interaction, and verifier-based rewards.
+- **data buffer**: A bridge module that manages prompt initialization, custom data, and rollout generation methods, including agentic workflows that produce samples through the same interface.
 
 ## Quick Start
 
@@ -56,6 +57,16 @@ For a comprehensive quick start guide covering environment setup, data preparati
 - [Quick Start Guide](./docs/en/get_started/quick_start.md)
 
 We also provide examples for some use cases not covered in the quick start guide; please check [examples](examples/).
+
+### Agentic RL examples
+
+Agentic workloads use the standard rollout / Data Buffer loop through Vime's customization interfaces; they are not a separate framework:
+
+- [`examples/multi_agent`](examples/multi_agent/README.md): Multi-agent generation through `--custom-generate-function-path`.
+- [`examples/fully_async`](examples/fully_async/README.md): Fully asynchronous rollout for long-tail agent generation.
+- [`examples/coding_agent_rl`](examples/coding_agent_rl/README.md): End-to-end coding-agent RL with Claude Code or Codex, sandboxed tool use, test-based rewards, and token-correct trajectory segments.
+
+See the [Agentic RL Training Roadmap](docs/en/get_started/agent.md) and [Customization Guide](docs/en/get_started/customization.md). The coding-agent example ships an E2B-compatible backend, while the shared `vime.agent.sandbox.Sandbox` contract can be implemented for Docker, Modal, or local VMs.
 
 ## Arguments Walkthrough
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -32,6 +32,7 @@ vLLM 社区横向支持许多 LLM post-training 框架，包括（按字母顺�
   - [目录](#目录)
   - [架构总览](#架构总览)
   - [快速开始](#快速开始)
+    - [Agentic RL 示例](#agentic-rl-示例)
   - [参数说明](#参数说明)
   - [开发指南](#开发指南)
   - [slime doc](#slime-doc)
@@ -46,8 +47,8 @@ vLLM 社区横向支持许多 LLM post-training 框架，包括（按字母顺�
 **模块说明**：
 
 - **training (Megatron)**：负责主训练流程，从 Data Buffer 读取数据，训练完后将参数同步至 rollout 模块；
-- **rollout (vLLM + router)**：启动 vLLM 推理引擎并路由生成请求，产出新数据（含 reward/verifier），存储至 Data Buffer；
-- **data buffer**：桥梁模块，管理 prompt 初始化、自定义数据与 rollout 生成方法。
+- **rollout (vLLM + router)**：启动 vLLM 推理引擎并路由生成请求；自定义生成函数可以在其上封装多轮循环、工具调用、环境/沙盒交互和基于 verifier 的奖励；
+- **data buffer**：桥梁模块，管理 prompt 初始化、自定义数据与 rollout 生成方法，包括通过同一接口产出样本的 agent 工作流。
 
 ## 快速开始
 
@@ -56,6 +57,16 @@ vLLM 社区横向支持许多 LLM post-training 框架，包括（按字母顺�
 - [快速开始指南](./docs/zh/get_started/quick_start.md)
 
 我们还提供了一些未在快速开始中覆盖的使用示例，请查看 [examples](examples/)。
+
+### Agentic RL 示例
+
+Agent 工作负载通过 Vime 的定制接口接入标准 rollout / Data Buffer 循环，并不是独立框架：
+
+- [`examples/multi_agent`](examples/multi_agent/README.md)：通过 `--custom-generate-function-path` 实现多 agent 生成；
+- [`examples/fully_async`](examples/fully_async/README.md)：面向长尾 agent 生成的全异步 rollout；
+- [`examples/coding_agent_rl`](examples/coding_agent_rl/README.md)：使用 Claude Code 或 Codex、沙盒工具、测试奖励和 token 精确轨迹片段的端到端 coding-agent RL；
+
+请参阅 [Agentic RL 训练路线图](docs/zh/get_started/agent.md)和[定制化指南](docs/zh/get_started/customization.md)。Coding-agent 示例内置 E2B 兼容后端；共享的 `vime.agent.sandbox.Sandbox` 协议也可以由 Docker、Modal 或本地虚拟机实现。
 
 ## 参数说明
 

--- a/docs/en/get_started/agent.md
+++ b/docs/en/get_started/agent.md
@@ -54,6 +54,10 @@ segments = await adapter.finish_session(session_id)
 
 For multi-turn agents, use a stable `session_id`. The adapters pass it as `X-SMG-Routing-Key` so vLLM can route one session to the same worker and reuse prefix cache.
 
+## Sandbox Backends
+
+The coding-agent example ships `vime.agent.sandbox.E2BSandbox` for E2B-compatible services. The rest of the agent lifecycle depends only on the provider-neutral `vime.agent.sandbox.Sandbox` protocol, so Docker, Modal, or local VM backends can implement the same contract without changing rollout logic. See [Porting to a New Sandbox Backend](../_examples_synced/coding_agent_rl/README.md#porting-to-a-new-sandbox-backend).
+
 ## Agent Serving And Performance
 
 Agentic rollouts tend to depend more heavily on serving configuration than ordinary single-turn generation: contexts are longer, requests are multi-turn, latency has a heavier tail, and the workflow may need actor, reference, reward, or tool-side models at the same time.

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -74,6 +74,7 @@ Start by Use Case
 
    _examples_synced/fully_async/README.md
    _examples_synced/multi_agent/README.md
+   _examples_synced/coding_agent_rl/README.md
 
 .. toctree::
    :maxdepth: 1

--- a/docs/zh/get_started/agent.md
+++ b/docs/zh/get_started/agent.md
@@ -54,6 +54,10 @@ segments = await adapter.finish_session(session_id)
 
 多轮 agent 应使用稳定的 `session_id`。adapter 会把它作为 `X-SMG-Routing-Key` 传给 vLLM，让同一个 session 尽量落到同一个 worker，复用 prefix cache。
 
+## 沙盒后端
+
+Coding-agent 示例内置面向 E2B 兼容服务的 `vime.agent.sandbox.E2BSandbox`。其余 agent 生命周期只依赖 provider-neutral 的 `vime.agent.sandbox.Sandbox` 协议，因此 Docker、Modal 或本地虚拟机后端可以实现同一协议，而无需修改 rollout 逻辑。参见[移植到新的沙盒后端](../_examples_synced/coding_agent_rl/README.md#porting-to-a-new-sandbox-backend)。
+
 ## Agent Serving 与性能配置
 
 agentic rollout 往往比普通单轮 generation 更依赖 serving 配置：上下文更长、多轮请求更多、请求时长分布更重尾，并且可能同时需要 actor、reference、reward 或工具侧模型。

--- a/docs/zh/index.rst
+++ b/docs/zh/index.rst
@@ -74,6 +74,7 @@ vime 构建于 `slime <https://github.com/THUDM/slime>`_ 之上，slime 正是 G
 
    _examples_synced/fully_async/README.md
    _examples_synced/multi_agent/README.md
+   _examples_synced/coding_agent_rl/README.md
 
 .. toctree::
    :maxdepth: 1

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,7 +15,5 @@ These examples provide concrete examples to leverage vime in your own RL workflo
 - **[on_policy_distillation](./on_policy_distillation)**: On-policy distillation (OPD) with an external vLLM teacher or a Megatron-loaded teacher.
 - **[delta_weight_sync](./delta_weight_sync)**: Non-colocated weight sync that ships only the changed bytes over a shared filesystem (training/inference disaggregation), reloading via the vanilla `update_weights_from_disk` path.
 - **[reproducibility](./reproducibility)**: Guides on achieving bitwise experiment reproduction using deterministic modes.
-- **[retool](./retool)**: Demonstrates the retool functionality for tool-enabled language model generation.
-- **[search-r1](./search-r1)**: A minimal reproduction of Search-R1, featuring multi-turn conversation and tool-calling.
 - **[tau-bench](./tau-bench)**: Multi-turn tool-use agent training in tau-bench environments.
 - **[train_infer_mismatch_helper](./train_infer_mismatch_helper)**: Algorithmic methods for rollout correction (e.g., TIS, MIS).

--- a/examples/mem_agent/rollout_client.py
+++ b/examples/mem_agent/rollout_client.py
@@ -5,11 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from vime.rollout.vllm_rollout import (
-    _align_engine_tokens_and_logprobs,
-    _build_inference_sampling_params,
-    _inference_generate_tokens_and_logprobs,
-)
+from vime.rollout.vllm_rollout import _build_inference_sampling_params, _inference_generate_tokens_and_logprobs
 from vime.utils.http_utils import post
 
 
@@ -66,7 +62,6 @@ class MemAgentRolloutClient:
         )
 
         token_ids, log_probs = _inference_generate_tokens_and_logprobs(choice)
-        token_ids, log_probs = _align_engine_tokens_and_logprobs(token_ids, log_probs)
 
         fr = choice.get("finish_reason") or "stop"
         if isinstance(fr, dict):

--- a/examples/multi_agent/agent_system.py
+++ b/examples/multi_agent/agent_system.py
@@ -50,7 +50,6 @@ async def generate_response(args, prompt, key):
             tokens=new_response_tokens,
             log_probs=new_response_log_probs,
             trainable=True,
-            meta_info=output["meta_info"],
         )
         assert len(sample.rollout_log_probs) == sample.response_length, (
             f"rollout logprob length mismatch: {len(sample.rollout_log_probs)} logprobs "

--- a/tests/test_vllm_rollout.py
+++ b/tests/test_vllm_rollout.py
@@ -247,6 +247,23 @@ def test_build_inference_sampling_params_forwards_disabled_top_k():
 
 
 @pytest.mark.unit
+def test_inference_generate_tokens_and_logprobs_aligns_partial_content():
+    token_ids, log_probs = mod._inference_generate_tokens_and_logprobs(
+        {
+            "token_ids": [11, 12, 13],
+            "logprobs": {"content": [{"logprob": -0.1}, {"logprob": -0.2}]},
+        }
+    )
+    assert token_ids == [11, 12, 13]
+    assert log_probs == [-0.1, -0.2, 0.0]
+
+
+@pytest.mark.unit
+def test_inference_generate_tokens_and_logprobs_rejects_invalid_token_ids():
+    assert mod._inference_generate_tokens_and_logprobs({"token_ids": [1, "2"]}) == ([], [])
+
+
+@pytest.mark.unit
 def test_mm_render_response_to_generate_body_flat_dict():
     body = mod._mm_render_response_to_generate_body(
         {"token_ids": [1, 2], "features": {"x": 1}},

--- a/vime/rollout/vllm_rollout.py
+++ b/vime/rollout/vllm_rollout.py
@@ -232,6 +232,22 @@ def _build_inference_sampling_params(sampling_params: dict[str, Any]) -> dict[st
     return sp
 
 
+def _inference_generate_tokens_and_logprobs(choice: dict[str, Any]) -> tuple[list[int], list[float]]:
+    """Extract aligned token ids and log probabilities from a vLLM choice."""
+    token_ids = choice.get("token_ids")
+    if not isinstance(token_ids, list) or not all(isinstance(token_id, int) for token_id in token_ids):
+        return [], []
+
+    logprobs = choice.get("logprobs")
+    content = logprobs.get("content") if isinstance(logprobs, dict) else []
+    content = content or []
+    log_probs = [
+        float(content[index].get("logprob", 0.0)) if index < len(content) and isinstance(content[index], dict) else 0.0
+        for index in range(len(token_ids))
+    ]
+    return token_ids, log_probs
+
+
 def _mm_render_response_to_generate_body(render_data: Any, model: str) -> dict[str, Any]:
     """Turn ``/v1/chat/completions/render`` JSON into a ``/inference/v1/generate`` request body."""
     if isinstance(render_data, dict) and isinstance(render_data.get("token_ids"), list):
@@ -395,16 +411,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
     choice = output["choices"][0]
 
     # Parse token_ids and logprobs from vLLM response
-    new_response_tokens = choice.get("token_ids") or []
-    new_response_log_probs: list[float] = []
-    lp = choice.get("logprobs")
-    if isinstance(lp, dict):
-        content_items = lp.get("content") or []
-        new_response_log_probs = [
-            float(item.get("logprob", 0.0)) if isinstance(item, dict) else 0.0 for item in content_items
-        ]
-    if not new_response_log_probs:
-        new_response_log_probs = [0.0] * len(new_response_tokens)
+    new_response_tokens, new_response_log_probs = _inference_generate_tokens_and_logprobs(choice)
 
     # Decode text from token_ids
     skip_sp = sampling_params.get("skip_special_tokens")


### PR DESCRIPTION
## Summary

- document Vime's existing agentic rollout, sandbox, and coding-agent workflows in English and Chinese
- centralize parsing of vLLM `token_ids` and token log probabilities
- fix stale SGLang response assumptions in the existing `mem_agent` and `multi_agent` examples
- keep `retool` and `search-r1` excluded after review

## Motivation

The agent examples already depended on a shared vLLM response parser that did not exist, and one still expected SGLang-only response metadata. This made the documented multi-turn examples fail at import/runtime even though the underlying vLLM rollout path was available.

For valid complete vLLM responses, the new parser is behaviorally equivalent to the previous inline logic. It additionally keeps token IDs and log probabilities aligned when content is partial and rejects malformed token ID lists.

## Sync audit

The complete Slime tree at cutoff `41014d1f` and all 243 files touched since the previous cutoff were reviewed. Engine-specific paths were mapped to their vLLM counterparts; remaining absent paths were classified as existing or explicit exclusions. No other shared runtime omission was found.

## Validation

- `pre-commit run --from-ref f1d3c6b81a --to-ref HEAD`
- `PYTHONPATH=$PWD pytest -q tests/test_vllm_rollout.py` (`36 passed`)
- `git diff --check`