### PR TITLE
[Bugfix][Core] Fix multimodal prompt building for rows without media

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -146,6 +146,7 @@ steps:
           for test_file in \
             tests/test_advantage_whiten_cp.py \
             tests/test_block_fp8_zero_block.py \
+            tests/test_build_messages.py \
             tests/test_deep_ep_tms_patch.py \
             tests/test_discounted_returns.py \
             tests/test_eval_config.py \

--- a/tests/test_build_messages.py
+++ b/tests/test_build_messages.py
@@ -53,6 +53,22 @@ def test_media_entries_may_be_rich_dicts():
 
 
 @pytest.mark.unit
+def test_single_media_entry_as_string_or_dict_is_wrapped():
+    # Test single string
+    messages = _build_messages(_row("What is in <image>?", images="a.png"), "text", True, IMAGE_KEYS)
+    assert _content(messages) == [
+        {"type": "text", "text": "What is in "},
+        {"type": "image", "image": "a.png"},
+        {"type": "text", "text": "?"},
+    ]
+
+    # Test single dict
+    item = {"type": "image", "image": "a.png", "max_pixels": 50176}
+    messages = _build_messages(_row("<image> here", images=item), "text", True, IMAGE_KEYS)
+    assert _content(messages) == [item, {"type": "text", "text": " here"}]
+
+
+@pytest.mark.unit
 def test_row_without_media_keeps_its_prompt_intact():
     """A mixed dataset has rows with no media; those prompts must stay intact.
 

--- a/tests/test_build_messages.py
+++ b/tests/test_build_messages.py
@@ -1,0 +1,115 @@
+"""CPU unit tests for ``vime.utils.data._build_messages``.
+
+``--multimodal-keys`` maps a media type name to the dataset column holding that
+media, and the prompt marks insertion points with the type's placeholder
+(``<image>``, ``<video>``, ``<audio>``). ``_build_messages`` rewrites a plain
+string prompt into the list-of-content-dicts form the VLM chat templates and
+``process_vision_info`` expect.
+
+The cases below pin down what happens at the edges of that rewrite: a row of a
+multimodal dataset that carries no media at all, a row that is already in
+list-of-dicts form, and a ``--multimodal-keys`` mapping that names a type vime
+does not support.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vime.utils.data import _build_messages
+
+
+NUM_GPUS = 0
+
+IMAGE_KEYS = {"image": "images"}
+
+
+def _row(prompt, **columns):
+    return {"text": prompt, **columns}
+
+
+def _content(messages):
+    assert len(messages) == 1, f"expected a single message, got {len(messages)}"
+    return messages[0]["content"]
+
+
+@pytest.mark.unit
+def test_media_placeholders_are_replaced():
+    messages = _build_messages(_row("What is in <image>?", images=["a.png"]), "text", True, IMAGE_KEYS)
+
+    assert _content(messages) == [
+        {"type": "text", "text": "What is in "},
+        {"type": "image", "image": "a.png"},
+        {"type": "text", "text": "?"},
+    ]
+
+
+@pytest.mark.unit
+def test_media_entries_may_be_rich_dicts():
+    item = {"type": "image", "image": "a.png", "max_pixels": 50176}
+    messages = _build_messages(_row("<image> here", images=[item]), "text", True, IMAGE_KEYS)
+
+    assert _content(messages) == [item, {"type": "text", "text": " here"}]
+
+
+@pytest.mark.unit
+def test_row_without_media_keeps_its_prompt_intact():
+    """A mixed dataset has rows with no media; those prompts must stay intact.
+
+    Building the split pattern from an empty placeholder set yields ``"()"``,
+    which matches the empty string at every position, so the prompt used to come
+    back as one ``{"type": "text"}`` dict per character.
+    """
+    prompt = "Describe this image."
+    messages = _build_messages(_row(prompt, images=None), "text", True, IMAGE_KEYS)
+
+    # Same representation a text-only dataset gets, i.e. no `--multimodal-keys`.
+    assert _content(messages) == prompt
+
+
+@pytest.mark.unit
+def test_row_with_an_empty_media_column_keeps_one_text_segment():
+    prompt = "Describe this image."
+    messages = _build_messages(_row(prompt, images=[]), "text", True, IMAGE_KEYS)
+
+    assert _content(messages) == [{"type": "text", "text": prompt}]
+
+
+@pytest.mark.unit
+def test_unknown_media_type_is_rejected():
+    """A typo like ``images`` used to be skipped silently: the media never made
+    it into the prompt and training ran text-only against a VLM dataset."""
+    with pytest.raises(ValueError, match="Unknown multimodal type 'images'"):
+        _build_messages(_row("What is in <image>?", images=["a.png"]), "text", True, {"images": "images"})
+
+
+@pytest.mark.unit
+def test_list_content_row_is_passed_through():
+    """Content already in list-of-dicts form embeds its media inline, so there
+    is no placeholder for this function to spend the row's media on."""
+    content = [{"type": "image", "image": "a.png"}, {"type": "text", "text": "What is in it?"}]
+    prompt = [{"role": "user", "content": list(content)}]
+
+    messages = _build_messages(_row(prompt, images=["a.png"]), "text", True, IMAGE_KEYS)
+
+    assert _content(messages) == content
+
+
+@pytest.mark.unit
+def test_more_media_than_placeholders_still_raises():
+    with pytest.raises(AssertionError, match="Multimodal data count mismatch"):
+        _build_messages(_row("What is in <image>?", images=["a.png", "b.png"]), "text", True, IMAGE_KEYS)
+
+
+@pytest.mark.unit
+def test_more_placeholders_than_media_still_raises():
+    with pytest.raises(AssertionError, match="Not enough image data"):
+        _build_messages(_row("<image> vs <image>", images=["a.png"]), "text", True, IMAGE_KEYS)
+
+
+@pytest.mark.unit
+def test_without_multimodal_keys_the_prompt_is_untouched():
+    prompt = "Describe this image."
+
+    assert _build_messages(_row(prompt), "text", False, None) == prompt
+    assert _content(_build_messages(_row(prompt), "text", True, None)) == prompt

--- a/vime/utils/arguments.py
+++ b/vime/utils/arguments.py
@@ -673,7 +673,9 @@ def get_vime_extra_args_provider(add_custom_arguments=None):
                 type=json.loads,
                 default=None,
                 help=(
-                    'JSON string for multimodal data mapping media types to data keys. Example: \'{"image": "image_file"}\''
+                    "JSON string for multimodal data mapping media types to data keys. "
+                    "Supported media types are 'image', 'video' and 'audio'; each one substitutes the "
+                    'matching <image>/<video>/<audio> placeholder in the prompt. Example: \'{"image": "image_file"}\''
                 ),
             )
             parser.add_argument("--metadata-key", type=str, default="metadata", help="JSON dataset key")

--- a/vime/utils/data.py
+++ b/vime/utils/data.py
@@ -162,6 +162,8 @@ def _build_messages(data: dict, prompt_key: str, as_conversation: bool, multimod
                 )
             multimodal_data = data.get(data_key)
             if multimodal_data is not None:
+                if isinstance(multimodal_data, (str, dict)):
+                    multimodal_data = [multimodal_data]
                 multimodals[mt.placeholder] = (mt, list(multimodal_data))
 
     # Only rows that actually carry media need placeholder substitution. Running

--- a/vime/utils/data.py
+++ b/vime/utils/data.py
@@ -223,10 +223,11 @@ def _build_messages(data: dict, prompt_key: str, as_conversation: bool, multimod
 
         if expanded_any:
             for placeholder, (mt, remaining) in multimodals.items():
-                assert len(remaining) == 0, (
-                    f"Multimodal data count mismatch: {len(remaining)} more {mt.name}(s) "
-                    f"than '{placeholder}' placeholders in prompt"
-                )
+                if len(remaining) != 0:
+                    raise AssertionError(
+                        f"Multimodal data count mismatch: {len(remaining)} more {mt.name}(s) "
+                        f"than '{placeholder}' placeholders in prompt"
+                    )
 
     return prompt
 

--- a/vime/utils/data.py
+++ b/vime/utils/data.py
@@ -150,20 +150,36 @@ def _build_messages(data: dict, prompt_key: str, as_conversation: bool, multimod
         else:
             prompt = [{"role": "user", "content": prompt}]
 
+    multimodals = {}
     if multimodal_keys:
         # Build mapping: placeholder -> (MultimodalType, content_list)
-        multimodals = {}
         for type_name, data_key in multimodal_keys.items():
             mt = MultimodalTypes.get(type_name)
-            if mt:
-                multimodal_data = data.get(data_key)
-                if multimodal_data is not None:
-                    multimodals[mt.placeholder] = (mt, list(multimodal_data))
+            if mt is None:
+                raise ValueError(
+                    f"Unknown multimodal type '{type_name}' in --multimodal-keys; "
+                    f"supported types are {[m.name for m in MultimodalTypes.all()]}."
+                )
+            multimodal_data = data.get(data_key)
+            if multimodal_data is not None:
+                multimodals[mt.placeholder] = (mt, list(multimodal_data))
 
+    # Only rows that actually carry media need placeholder substitution. Running
+    # the split with an empty `multimodals` would build the pattern "()", which
+    # matches the empty string everywhere and shatters the prompt into one text
+    # segment per character.
+    if multimodals:
         pattern = "(" + "|".join(re.escape(p) for p in multimodals.keys()) + ")"
+
+        # Media is only consumed from messages whose content is a plain string.
+        # A row already in list-of-dicts form embeds its media inline, so the
+        # leftover check below would fire on media this function never had a
+        # placeholder to spend.
+        expanded_any = False
 
         for message in prompt:
             if isinstance(message["content"], str):
+                expanded_any = True
                 content_list = []
                 for segment in re.split(pattern, message["content"]):
                     if not segment:
@@ -203,11 +219,12 @@ def _build_messages(data: dict, prompt_key: str, as_conversation: bool, multimod
                     f"Unsupported content type: {type(message['content'])}, expected str or list of dicts"
                 )
 
-        for placeholder, (mt, remaining) in multimodals.items():
-            assert len(remaining) == 0, (
-                f"Multimodal data count mismatch: {len(remaining)} more {mt.name}(s)"
-                f"than '{placeholder}' placeholders in prompt"
-            )
+        if expanded_any:
+            for placeholder, (mt, remaining) in multimodals.items():
+                assert len(remaining) == 0, (
+                    f"Multimodal data count mismatch: {len(remaining)} more {mt.name}(s) "
+                    f"than '{placeholder}' placeholders in prompt"
+                )
 
     return prompt
 


### PR DESCRIPTION
I was poking at `--multimodal-keys` with a dataset that mixes image rows and plain
text rows, and ended up finding three separate problems in `_build_messages`.

### The prompt gets shattered when a row has no media

The placeholder split builds a regex alternation out of whatever media the row
actually carries. When the media column is `None` nothing goes into that set, the
pattern collapses to `"()"`, and that matches the empty string at every position:

```python
>>> from vime.utils.data import _build_messages
>>> _build_messages({"text": "Describe this image.", "images": None},
...                 "text", True, {"image": "images"})
[{'role': 'user', 'content': [{'type': 'text', 'text': 'D'},
                              {'type': 'text', 'text': 'e'},
                              {'type': 'text', 'text': 's'}, ...]}]
```

One content dict per character. These rows definitely reach here — `filter_long_prompt`
already has an explicit text-only branch for exactly this shape of dataset.

I want to be upfront that this is the least severe of the three. I checked
Qwen2-VL, Qwen3-VL and GLM-4.1V, and all three render the shattered content to
byte-identical text, so it's wasted work and a fragile representation rather than
corrupted training data. Still worth not doing.

### A typo in `--multimodal-keys` silently drops every image

`MultimodalTypes.get()` returns `None` for a name it doesn't know, and the old code
just skipped those. So `'{"images": "images"}'` — plural, which is an easy thing to
type given the column is usually called `images` — quietly attaches no media at all
and you train text-only against a VLM dataset with nothing in the logs to tell you.

This one I'd call the real bug. I made it raise, and listed the supported types in the
`--multimodal-keys` help text since they weren't written down anywhere.

This is the only behaviour change in the PR that could break a currently-working run,
so shout if you'd rather it stayed a warning.

### Rows already in list-of-dicts form abort the dataset load

If a message's content is already a list, the code deliberately passes it through
("no processing will be done"). But the leftover-media check afterwards doesn't know
that happened, so the row's media has no placeholder to be spent on and the whole
`Dataset` construction dies:

```
message['content'] is a list of dicts, no processing will be done.
AssertionError: Multimodal data count mismatch: 1 more image(s)than '<image>' placeholders in prompt
```

Now it only runs the check when placeholder expansion actually happened. (Also put the
missing space back in that message.)

### Tests

`tests/test_build_messages.py`, wired into the *synchronized upstream CPU tests* job
next to `test_filter_long_prompt.py`. Nine cases: three fail on `main`, the other six
pin the substitution behaviour that should not move.

One asymmetry I left alone and pinned instead: `images: None` leaves the content as a
plain string, `images: []` gives a single text dict. Collapsing `[]` into the no-media
path would be tidier but you'd lose the `Not enough image data` assert when a prompt
has `<image>` and an empty column, which seemed like the more useful behaviour to keep.

### Verification

CPU jobs all pass locally (~740 tests across *plugin contracts*, *upstream sync CPU*,
*utils* and *agent adapter*). `pre-commit` clean.

Two things I couldn't run on my machine, neither touched by this change: the GPU
suites, and `test_glm5_indexer_q_norm` / `test_rollout_metrics` /
`test_rollout_routing_replay_validation`, which need megatron and vllm from the
`vllm/vime:latest` image.

`test_cispo_loss` and `test_policy_loss` fail for me on clean `main` too — Windows box
with no C++ toolchain, so `torch.compile` can't get through `pick_vec_isa`. Unrelated.

---

AI-assisted, per CONTRIBUTING: the diff and tests were written by Claude Opus 5
(Anthropic, via Claude Code) working from my direction, and it's attributed in the
commit trailer. I've reviewed every changed line and run the tests above.
