### PR TITLE
feat: support full weight sync over disk

### DIFF
--- a/.buildkite/npu_suites.py
+++ b/.buildkite/npu_suites.py
@@ -29,6 +29,7 @@ BUILDKITE_SOURCE = os.environ.get("BUILDKITE_SOURCE", "")
 SUITES = {
     "smk": [
         ("test_qwen3_4B_npu.py", "npu-8", "", {}),
+        ("test_qwen3_4B_npu.py", "npu-8", "", {"VIME_TEST_UPDATE_MODE": "delta"}),
         ("test_qwen3_30B_A3B_npu.py", "npu-16", "", {}),
         ("test_qwen3_vl_8B_npu.py", "npu-8", "", {}),
     ],

--- a/.buildkite/scripts/update-npu-environment.sh
+++ b/.buildkite/scripts/update-npu-environment.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Purpose: Updates an NPU test container to match the requested VIME commit.
 #          - Reads the image's persisted OLD patch series and exact patch bytes
-#          - Updates VIME, then reconciles OLD -> NEW in declared series order
+#          - Updates VIME, then reconciles OLD -> NEW in declared series orde
 #          - Installs the current VIME checkout and normalizes visible devices
 # Usage: Called by Buildkite pipeline during NPU test runs
 set -e -o pipefail
@@ -176,6 +176,10 @@ update_vime_code() {
 
 install_vime_code() {
     pip install -e "$VIME_DIR" --no-deps --break-system-packages || pip install -e "$VIME_DIR" --no-deps
+    # The pre-built smoke image can predate disk-delta dependencies. Keep the
+    # serving and trainer interpreters aligned before loading delta checkpoints.
+    pip install blake3 xxhash zstandard --break-system-packages || \
+        pip install blake3 xxhash zstandard
 }
 
 sort_ascend_visible_devices() {

--- a/docker/npu_patch/vllm-ascend.patch
+++ b/docker/npu_patch/vllm-ascend.patch
@@ -13,7 +13,7 @@ index 062b3ecd..dd87affb 100644
                  f"Free memory on device "
 @@ -535,15 +535,16 @@ class NPUWorker(WorkerBase):
          self.npugraph_memory_estimate = npugraph_memory_estimate
- 
+
          free_gpu_memory = profile_result.after_profile.free_memory
 -        assert self.init_snapshot.free_memory > free_gpu_memory, (
 -            "Error in memory profiling. "
@@ -50,4 +50,34 @@ index a35d9af8d..66a179cd6 100644
 +        # Source tensors may have been produced asynchronously on the caller's
 +        # stream. Wait before the packing stream reads them in torch.cat.
 +        streams[buffer_idx].wait_stream(source_stream)
-         # Start tasks for the new buffer in a new stream
+        # Start tasks for the new buffer in a new stream
+diff --git a/vllm_ascend/worker/worker.py b/vllm_ascend/worker/worker.py
+index 062b3ecd..f0d1e4a1 100644
+--- a/vllm_ascend/worker/worker.py
++++ b/vllm_ascend/worker/worker.py
+@@ -333,1 +333,25 @@ class NPUWorker(WorkerBase):
++    def pull_weights(
++        self,
++        local_checkpoint_dir: str,
++        source_dir: str,
++        target_version: int,
++        pre_read_hook: str | None = None,
++    ) -> dict:
++        """Materialize a full or delta checkpoint on this rollout host.
++
++        ``collective_rpc`` invokes this on all NPU workers. The checkpoint
++        helper serializes same-host ranks with a filesystem lock, so each host
++        applies a version exactly once before reload_weights is called.
++        """
++        from vllm.utils.local_checkpoint import pull_checkpoint
++
++        pull_checkpoint(
++            local_checkpoint_dir=local_checkpoint_dir,
++            base_dir=self.model_config.model,
++            source_dir=source_dir,
++            target_version=target_version,
++            pre_read_hook=pre_read_hook,
++        )
++        return {"success": True, "weight_version": str(target_version)}
++
+     def shutdown(self) -> None:

--- a/docker/npu_patch/vllm-ascend.patch
+++ b/docker/npu_patch/vllm-ascend.patch
@@ -55,7 +55,7 @@ diff --git a/vllm_ascend/worker/worker.py b/vllm_ascend/worker/worker.py
 index 062b3ecd..f0d1e4a1 100644
 --- a/vllm_ascend/worker/worker.py
 +++ b/vllm_ascend/worker/worker.py
-@@ -333,1 +333,25 @@ class NPUWorker(WorkerBase):
+@@ -333,1 +333,33 @@ class NPUWorker(WorkerBase):
 +    def pull_weights(
 +        self,
 +        local_checkpoint_dir: str,
@@ -71,9 +71,17 @@ index 062b3ecd..f0d1e4a1 100644
 +        """
 +        from vllm.utils.local_checkpoint import pull_checkpoint
 +
++        # reload_weights updates model_config.model to the materialized local
++        # checkpoint. Preserve the original model path as the immutable
++        # version-zero seed for retries and restarted training runs.
++        base_dir = getattr(self, "_local_checkpoint_base_dir", None)
++        if base_dir is None:
++            base_dir = self.model_config.model
++            self._local_checkpoint_base_dir = base_dir
++
 +        pull_checkpoint(
 +            local_checkpoint_dir=local_checkpoint_dir,
-+            base_dir=self.model_config.model,
++            base_dir=base_dir,
 +            source_dir=source_dir,
 +            target_version=target_version,
 +            pre_read_hook=pre_read_hook,
@@ -81,3 +89,33 @@ index 062b3ecd..f0d1e4a1 100644
 +        return {"success": True, "weight_version": str(target_version)}
 +
      def shutdown(self) -> None:
+diff --git a/tests/ut/worker/a2/test_worker_v1.py b/tests/ut/worker/a2/test_worker_v1.py
+index 812b757..06e3875 100644
+--- a/tests/ut/worker/a2/test_worker_v1.py
++++ b/tests/ut/worker/a2/test_worker_v1.py
+@@ -1560,2 +1560,25 @@ class TestNPUWorker(TestBase):
++    def test_pull_weights_preserves_initial_model_path(self):
++        """The version-zero seed must survive reload_weights path updates."""
++        from vllm_ascend.worker.worker import NPUWorker
++
++        with (
++            patch.object(NPUWorker, "__init__", lambda x, **kwargs: None),
++            patch("vllm.utils.local_checkpoint.pull_checkpoint") as pull_checkpoint,
++        ):
++            worker = NPUWorker()
++            worker.model_config = MagicMock()
++            worker.model_config.model = "/models/base"
++
++            worker.pull_weights("/local/checkpoint", "/shared/weights", 0)
++            worker.model_config.model = "/local/checkpoint"
++            worker.pull_weights("/local/checkpoint", "/shared/weights", 1)
++
++        assert pull_checkpoint.call_count == 2
++        assert [call.kwargs["base_dir"] for call in pull_checkpoint.call_args_list] == [
++            "/models/base",
++            "/models/base",
++        ]
++        assert pull_checkpoint.call_args.kwargs["target_version"] == 1
++
+ class TestNPUWorkerWeightUpdate(TestBase):
+     def _make_worker(self, engine=None):

--- a/docker/npu_patch/vllm.patch
+++ b/docker/npu_patch/vllm.patch
@@ -28,7 +28,7 @@ diff --git a/vllm/utils/local_checkpoint.py b/vllm/utils/local_checkpoint.py
 new file mode 100644
 --- /dev/null
 +++ b/vllm/utils/local_checkpoint.py
-@@ -0,0 +1,237 @@
+@@ -0,0 +1,240 @@
 +# SPDX-License-Identifier: Apache-2.0
 +"""Maintain a host-local HF checkpoint from full and delta weight versions."""
 +
@@ -66,11 +66,14 @@ new file mode 100644
 +        # therefore leave bytes changed even though state.json was not advanced;
 +        # discard that partial local state on the next retry.
 +        applied = None if os.path.exists(incomplete) else _read_applied_version(local_checkpoint_dir)
-+        floor = applied if applied is not None else 0
++        # A pull can legitimately restart a run at version zero or target an
++        # older published version. In that case the current checkpoint cannot
++        # be patched backwards, so search from the base checkpoint instead.
++        floor = applied if applied is not None and applied <= target_version else 0
 +        start = target_version
 +        while start > floor and _is_delta(_version_dir(source_dir, start)):
 +            start -= 1
-+        if applied is None or start > applied:
++        if applied is None or applied > target_version or start > applied:
 +            _reset_checkpoint(base_dir if start == 0 else _version_dir(source_dir, start), local_checkpoint_dir, start)
 +        else:
 +            start = applied

--- a/docker/npu_patch/vllm.patch
+++ b/docker/npu_patch/vllm.patch
@@ -22,5 +22,247 @@ index cb61bca..5c076d5 100644
 -        assert request.num_output_placeholders >= 0
 +        request.num_output_placeholders = max(0, request.num_output_placeholders)
  
-         # Cache the new tokens. Preempted requests should be skipped.
-         if status_before_update == RequestStatus.RUNNING:
+        # Cache the new tokens. Preempted requests should be skipped.
+        if status_before_update == RequestStatus.RUNNING:
+diff --git a/vllm/utils/local_checkpoint.py b/vllm/utils/local_checkpoint.py
+new file mode 100644
+--- /dev/null
++++ b/vllm/utils/local_checkpoint.py
+@@ -0,0 +1,237 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Maintain a host-local HF checkpoint from full and delta weight versions."""
++
++from __future__ import annotations
++
++import fcntl
++import glob
++import importlib
++import io
++import json
++import mmap
++import os
++import shutil
++import struct
++import threading
++import zlib
++from concurrent.futures import ThreadPoolExecutor
++from contextlib import ExitStack, contextmanager
++
++import numpy as np
++import zstandard
++
++NUM_WORKERS = min(32, os.cpu_count() or 8)
++SYNC_DIR = ".weight_sync"
++
++
++def pull_checkpoint(local_checkpoint_dir, base_dir, source_dir, target_version, pre_read_hook=None):
++    """Bring a host-local checkpoint to a published full or delta version."""
++    if target_version > 0 and pre_read_hook:
++        module_path, _, function_name = pre_read_hook.rpartition(".")
++        getattr(importlib.import_module(module_path), function_name)(source_dir, target_version)
++    with _pull_lock(local_checkpoint_dir):
++        incomplete = os.path.join(local_checkpoint_dir, SYNC_DIR, "incomplete")
++        # Deltas update mmap'ed safetensor regions in place. A failed apply can
++        # therefore leave bytes changed even though state.json was not advanced;
++        # discard that partial local state on the next retry.
++        applied = None if os.path.exists(incomplete) else _read_applied_version(local_checkpoint_dir)
++        floor = applied if applied is not None else 0
++        start = target_version
++        while start > floor and _is_delta(_version_dir(source_dir, start)):
++            start -= 1
++        if applied is None or start > applied:
++            _reset_checkpoint(base_dir if start == 0 else _version_dir(source_dir, start), local_checkpoint_dir, start)
++        else:
++            start = applied
++        try:
++            for version in range(start + 1, target_version + 1):
++                open(incomplete, "a").close()
++                _apply_delta(local_checkpoint_dir, _version_dir(source_dir, version))
++        except BaseException:
++            raise
++        else:
++            if os.path.exists(incomplete):
++                os.remove(incomplete)
++
++
++def _version_dir(source_dir, version):
++    return os.path.join(source_dir, f"weight_v{version:06d}")
++
++
++def _is_delta(version_dir):
++    if not os.path.isdir(version_dir):
++        raise FileNotFoundError(f"Published weight version missing: {version_dir}")
++    try:
++        with open(os.path.join(version_dir, "model.safetensors.index.json")) as index_file:
++            return "delta_encoding" in json.load(index_file).get("metadata", {})
++    except FileNotFoundError:
++        return False
++
++
++class _Adler32:
++    def __init__(self):
++        self._value = 1
++
++    def update(self, data):
++        self._value = zlib.adler32(data, self._value)
++
++    def hexdigest(self):
++        return f"{self._value:08x}"
++
++
++def _new_hasher(algorithm):
++    if algorithm == "xxh3-128":
++        import xxhash
++        return xxhash.xxh3_128()
++    if algorithm == "blake3":
++        import blake3
++        return blake3.blake3()
++    if algorithm == "adler32":
++        return _Adler32()
++    raise KeyError(f"Unknown checksum algorithm {algorithm!r}")
++
++
++@contextmanager
++def _pull_lock(local_checkpoint_dir):
++    sync_dir = os.path.join(local_checkpoint_dir, SYNC_DIR)
++    os.makedirs(sync_dir, exist_ok=True)
++    with open(os.path.join(sync_dir, "lock"), "w") as lock_file:
++        fcntl.flock(lock_file, fcntl.LOCK_EX)
++        try:
++            yield
++        finally:
++            fcntl.flock(lock_file, fcntl.LOCK_UN)
++
++
++def _read_applied_version(local_checkpoint_dir):
++    try:
++        with open(os.path.join(local_checkpoint_dir, SYNC_DIR, "state.json")) as state_file:
++            return int(json.load(state_file)["version"])
++    except FileNotFoundError:
++        return None
++
++
++def _write_applied_version(local_checkpoint_dir, version):
++    path = os.path.join(local_checkpoint_dir, SYNC_DIR, "state.json")
++    temporary = path + ".tmp"
++    with open(temporary, "w") as state_file:
++        json.dump({"version": f"{version:06d}"}, state_file)
++        state_file.flush()
++        os.fsync(state_file.fileno())
++    os.replace(temporary, path)
++
++
++def _reset_checkpoint(source_dir, local_checkpoint_dir, version):
++    os.makedirs(local_checkpoint_dir, exist_ok=True)
++    source_files = [entry for entry in os.scandir(source_dir) if entry.is_file()]
++    for entry in source_files:
++        shutil.copy2(entry.path, os.path.join(local_checkpoint_dir, entry.name))
++    source_names = {entry.name for entry in source_files}
++    for entry in os.scandir(local_checkpoint_dir):
++        if entry.is_file() and entry.name not in source_names:
++            os.remove(entry.path)
++    for entry in source_files:
++        copied = os.path.join(local_checkpoint_dir, entry.name)
++        if os.path.getsize(copied) != entry.stat().st_size:
++            raise RuntimeError(f"Size mismatch copying {entry.name}")
++    _write_applied_version(local_checkpoint_dir, version)
++
++
++def _tensor_locations(checkpoint_dir):
++    locations = {}
++    for path in glob.glob(os.path.join(checkpoint_dir, "*.safetensors")):
++        with open(path, "rb") as tensor_file:
++            (header_length,) = struct.unpack("<Q", tensor_file.read(8))
++            header = json.loads(tensor_file.read(header_length))
++        for name, info in header.items():
++            if name != "__metadata__":
++                begin, end = info["data_offsets"]
++                locations[name] = (path, 8 + header_length + begin, end - begin)
++    return locations
++
++
++@contextmanager
++def _writable_mmap(path):
++    with open(path, "r+b") as file_handle, mmap.mmap(file_handle.fileno(), 0) as mapped:
++        yield mapped
++
++
++def _apply_delta(local_checkpoint_dir, version_dir):
++    with open(os.path.join(version_dir, "model.safetensors.index.json")) as index_file:
++        metadata = json.load(index_file)["metadata"]
++    applied = _read_applied_version(local_checkpoint_dir)
++    version = int(metadata["version"])
++    if applied == version:
++        return
++    if applied != int(metadata["base_version"]):
++        raise RuntimeError(f"Out-of-order delta: local at {applied}, delta builds on {metadata['base_version']}")
++    if metadata["compression_format"] != "zstd":
++        raise NotImplementedError(f"Unsupported compression {metadata['compression_format']!r}")
++
++    locations = _tensor_locations(local_checkpoint_dir)
++    resources, mapped_files, items, mismatches = ExitStack(), {}, [], []
++    mismatch_lock = threading.Lock()
++    try:
++        for delta_path in sorted(glob.glob(os.path.join(version_dir, "*.safetensors"))):
++            with open(delta_path, "rb") as tensor_file:
++                blob = tensor_file.read()
++            (header_length,) = struct.unpack("<Q", blob[:8])
++            header = json.loads(blob[8 : 8 + header_length])
++            metadata_checksums = header.get("__metadata__", {})
++            data_start = 8 + header_length
++            for name, info in header.items():
++                if name == "__metadata__":
++                    continue
++                if name not in locations:
++                    raise KeyError(f"Delta tensor {name!r} is missing from local checkpoint")
++                path, offset, byte_count = locations[name]
++                if path not in mapped_files:
++                    mapped_files[path] = resources.enter_context(_writable_mmap(path))
++                begin, end = info["data_offsets"]
++                items.append((name, memoryview(blob)[data_start + begin : data_start + end], path, offset, byte_count, metadata_checksums.get(name)))
++
++        def mismatch(name):
++            with mismatch_lock:
++                mismatches.append(name)
++
++        def apply_xor(item):
++            name, compressed, path, offset, byte_count, expected = item
++            region = np.ndarray((byte_count,), dtype=np.uint8, buffer=mapped_files[path], offset=offset)
++            reader, position, hasher = zstandard.ZstdDecompressor().stream_reader(io.BytesIO(bytes(compressed))), 0, _new_hasher(metadata["checksum_format"])
++            while position < byte_count:
++                block = reader.read(min(2 << 20, byte_count - position))
++                if not block:
++                    break
++                chunk = np.frombuffer(block, dtype=np.uint8)
++                region[position : position + chunk.size] ^= chunk
++                hasher.update(region[position : position + chunk.size])
++                position += chunk.size
++            if position != byte_count or hasher.hexdigest() != expected:
++                mismatch(name)
++
++        def apply_overwrite(item):
++            name, compressed, path, offset, byte_count, expected = item
++            delta = np.frombuffer(zstandard.ZstdDecompressor().decompress(bytes(compressed)), dtype=np.uint8)
++            count = int.from_bytes(delta[:4].tobytes(), "little")
++            positions_end = 4 + 4 * count
++            positions = np.frombuffer(delta[4:positions_end].tobytes(), dtype="<u4")
++            region = np.ndarray((byte_count,), dtype=np.uint8, buffer=mapped_files[path], offset=offset)
++            region[positions] = delta[positions_end:]
++            hasher = _new_hasher(metadata["checksum_format"])
++            hasher.update(region)
++            if hasher.hexdigest() != expected:
++                mismatch(name)
++
++        if metadata["delta_encoding"] == "xor":
++            apply = apply_xor
++        elif metadata["delta_encoding"] == "overwrite":
++            apply = apply_overwrite
++        else:
++            raise NotImplementedError(f"Unsupported delta encoding {metadata['delta_encoding']!r}")
++        with ThreadPoolExecutor(max_workers=NUM_WORKERS) as executor:
++            list(executor.map(apply, items))
++    finally:
++        resources.close()
++    if mismatches:
++        raise RuntimeError(f"Checksum mismatch for {len(mismatches)} tensors after applying {version_dir}: {sorted(mismatches)[:20]}")
++    _write_applied_version(local_checkpoint_dir, version)

--- a/docs/weight-sync-benchmark-20260831.md
+++ b/docs/weight-sync-benchmark-20260831.md
@@ -1,0 +1,85 @@
+# Disk weight-sync benchmark (4B and 30B)
+
+## Scope
+
+- Branch: `feature/disk-full-weight-sync`
+- Transport: `disk`
+- Modes: `delta` and `full`
+- Rounds: 5 training updates. The initialization/baseline sync is excluded.
+- Steady mean: arithmetic mean after excluding the first training update.
+- 4B placement: 4 actor NPUs + 4 rollout NPUs.
+- 30B placement: 8 actor NPUs + 4 rollout NPUs.
+- Common workload: rollout batch 16, 4 samples/prompt, response length 2048,
+  global batch 16, learning rate `1e-6`, vLLM TP 4, eager mode.
+
+The earlier response-length-256 run was invalid: it produced all-zero rewards,
+zero gradients and empty Delta manifests. These results use response length 2048,
+contain non-zero gradients, and every Delta round has a non-zero payload.
+
+## End-to-end update time
+
+The total-time source is the outer `Timer update_weights` log. Values are in
+seconds; the steady mean excludes round 1.
+
+| Model | Mode | Round 1 | Round 2 | Round 3 | Round 4 | Round 5 | Steady mean |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Qwen3-4B | Disk + Delta | 6.7 | 5.4 | 5.1 | 5.4 | 4.9 | 5.2 |
+| Qwen3-4B | Disk + Full | 5.2 | 5.4 | 5.5 | 5.4 | 5.4 | 5.4 |
+| Qwen3-30B-A3B | Disk + Delta | 82.7 | 60.8 | 61.5 | 59.2 | 117.1 | 74.7 |
+| Qwen3-30B-A3B | Disk + Full | 67.7 | 52.3 | 62.5 | 55.0 | 56.6 | 56.6 |
+
+At 4B the two modes are close: Delta's steady mean is about 4.1% lower than
+Full's. At 30B, Full's steady mean is 24.2% lower than Delta's (equivalently,
+Delta is 31.9% higher than Full). The 30B Delta mean includes a real fifth-round
+outlier: reload rose to 46.8 seconds and total update time rose to 117.1 seconds.
+
+## Delta payload
+
+| Model | Round 1 | Round 2 | Round 3 | Round 4 | Round 5 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Qwen3-4B density | 1.47% | 1.43% | 1.04% | 1.03% | 0.97% |
+| Qwen3-4B payload | 0.29 GB | 0.28 GB | 0.21 GB | 0.21 GB | 0.20 GB |
+| Qwen3-30B-A3B density | 1.22% | 1.10% | 0.85% | 0.61% | 0.73% |
+| Qwen3-30B-A3B payload | 1.85 GB | 1.69 GB | 1.35 GB | 1.01 GB | 1.18 GB |
+
+## Stage breakdown and bottleneck
+
+For 4B Delta, steady encode is about 1.9-2.2 seconds, materialization about
+2.1 seconds, and reload about 0.7 seconds. Full writes the entire checkpoint in
+about 4.5-4.8 seconds and reloads in about 0.6-0.7 seconds. Delta only has a
+small advantage because it still scans/encodes the model and materializes a full
+rollout-side checkpoint.
+
+For 30B Delta, encode costs 25.9-41.6 seconds and rollout-side materialization
+costs 20.1-30.9 seconds. Reload normally costs 6.0-11.1 seconds, but reached
+46.8 seconds in round 5. The small 1.0-1.9 GB wire payload therefore does not
+translate into lower end-to-end time: full-model scanning/encoding plus full
+checkpoint materialization dominates.
+
+For 30B Full, full checkpoint writing is stable at 45.1-48.6 seconds and is the
+main cost. Reload varies from 5.9 to 20.7 seconds. Unlike Delta, Full avoids the
+extra encode + materialize pipeline, so it is faster in this implementation even
+though more bytes are written.
+
+## Validation evidence and logs
+
+All four jobs completed successfully. Representative non-zero gradients are
+`0.660258` for 30B Full and `0.485568` for 30B Delta. The benchmark script also
+rejects a completed job when no non-zero gradient exists, and rejects Delta when
+any round reports `density=0.00% wire=0.00 GB`.
+
+Original logs are retained on the remote host:
+
+- `/home/vllm/weight-sync-bench/logs/real-20260830-4B-delta.log`
+- `/home/vllm/weight-sync-bench/logs/real-20260830-4B-full.log`
+- `/home/vllm/weight-sync-bench/logs/real-20260830-30B-delta.log`
+- `/home/vllm/weight-sync-bench/logs/real-20260830-30B-full.log`
+
+Artifact directories are under `/home/vllm/weight-sync-bench/real-20260830-*`.
+
+## Reproduction
+
+Use `scripts/run-weight-sync-benchmark-npu.sh` and set `MODEL_SIZE` to `4B` or
+`30B`, and `UPDATE_WEIGHT_MODE` to `delta` or `full`. The script starts a clean
+Ray runtime, binds NPUs 0-11, writes a durable log, and validates that training
+actually mutated the model before accepting the run.

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,3 +10,6 @@ These examples provide concrete examples to leverage vime in your own RL workflo
 - **[geo3k_vlm_multi_turn](./geo3k_vlm_multi_turn)**: VLM multi-turn training on Geo3k dataset.
 - **[multi_agent](./multi_agent)**: Example of running multi-agent RL with `vime`.
 - **[train_infer_mismatch_helper](./train_infer_mismatch_helper)**: Algorithmic methods for rollout correction (e.g., TIS, MIS).
+# Weight synchronization
+
+- [delta_weight_sync](./delta_weight_sync): Ascend non-colocated disk delta weight sync.

--- a/examples/delta_weight_sync/README.md
+++ b/examples/delta_weight_sync/README.md
@@ -1,0 +1,24 @@
+# Ascend Delta Weight Sync
+
+This example enables non-colocated disk delta weight sync for Ascend rollout engines.
+The trainer writes only changed safetensor bytes to a filesystem shared with rollout
+hosts; each host applies them to a local HF safetensors checkpoint and vLLM reloads it.
+
+```bash
+--update-weight-mode delta \
+--update-weight-transport disk \
+--update-weight-disk-dir /shared/vime-delta \
+--update-weight-local-checkpoint-dir /local-nvme/vime-rollout-checkpoint \
+--update-weight-delta-encoding xor \
+--update-weight-delta-checksum xxh3-128
+```
+
+Only non-colocated rollout is supported. `--update-weight-disk-dir` must be a Linux
+POSIX filesystem visible to training and every rollout host. The local checkpoint
+directory is host-local storage and is seeded from `--hf-checkpoint` on the first sync.
+Reserve enough local capacity for one complete HF safetensors checkpoint plus temporary
+copy space during the initial seed. Both the trainer and every rollout image must include
+`blake3`, `xxhash`, and `zstandard`, and use the accompanying vLLM/vLLM-Ascend patches.
+Use `--custom-update-weight-post-write-path` and
+`--custom-update-weight-pre-read-path` for object-storage mounts that need explicit
+publish/refresh operations.

--- a/examples/delta_weight_sync/README_zh.md
+++ b/examples/delta_weight_sync/README_zh.md
@@ -1,0 +1,21 @@
+# Ascend 增量权重同步
+
+此示例用于非 colocate 场景。训练端只把发生变化的 safetensors 字节发布到共享文件系统；
+每个 rollout host 将 delta 原地应用到本地 HF checkpoint，再由 vLLM 热加载。
+
+```bash
+--update-weight-mode delta \
+--update-weight-transport disk \
+--update-weight-disk-dir /shared/vime-delta \
+--update-weight-local-checkpoint-dir /local-nvme/vime-rollout-checkpoint \
+--update-weight-delta-encoding xor \
+--update-weight-delta-checksum xxh3-128
+```
+
+`--update-weight-disk-dir` 必须是训练端和所有 rollout host 可见的 Linux POSIX
+共享文件系统；本地 checkpoint 路径应为 host-local 存储，并在首次同步时从
+`--hf-checkpoint` 初始化。对象存储挂载需要显式 publish/refresh 时，可分别使用
+`--custom-update-weight-post-write-path` 与 `--custom-update-weight-pre-read-path`。
+本地磁盘至少需要容纳一份完整的 HF safetensors checkpoint 及首次复制时的临时空间；训练端和
+所有 rollout 镜像还必须安装 `blake3`、`xxhash`、`zstandard`，并应用随本仓库提供的
+vLLM/vLLM-Ascend patch。

--- a/examples/delta_weight_sync/run-qwen3-4B-npu-delta.sh
+++ b/examples/delta_weight_sync/run-qwen3-4B-npu-delta.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run from an Ascend VIME environment. Adjust model/data paths and the shared/local
+# directories for your deployment. Training uses NPUs 0-3; rollout uses NPUs 4-7.
+python3 train.py \
+  --train-backend megatron \
+  --hf-checkpoint /path/to/Qwen3-4B \
+  --load /path/to/Qwen3-4B \
+  --ref-load /path/to/Qwen3-4B \
+  --megatron-to-hf-mode bridge \
+  --actor-num-nodes 1 --actor-num-gpus-per-node 4 \
+  --rollout-num-gpus 4 --rollout-num-gpus-per-engine 4 \
+  --tensor-model-parallel-size 4 \
+  --update-weight-mode delta \
+  --update-weight-transport disk \
+  --update-weight-disk-dir /shared/vime-delta \
+  --update-weight-local-checkpoint-dir /local-nvme/vime-rollout-checkpoint \
+  --update-weight-delta-encoding xor \
+  --update-weight-delta-checksum xxh3-128 \
+  "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 accelerate
 anthropic
+blake3
 blobfile
 cloudpickle
 datasets
@@ -22,3 +23,5 @@ tensorboard
 transformers
 vllm-router>=0.1.14
 wandb
+xxhash
+zstandard

--- a/scripts/run-qwen3-4B-npu.sh
+++ b/scripts/run-qwen3-4B-npu.sh
@@ -32,16 +32,20 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 source "${SCRIPT_DIR}/models/qwen3-4B.sh"
 
 DATA_ROOT="${DATA_ROOT:-/root}"
+MODEL_PATH="${MODEL_PATH:-/home/vllm/weights/Qwen3-4B}"
+PROMPT_DATA_PATH="${PROMPT_DATA_PATH:-/home/vllm/c00944022/datasets/dapo-math-17k/dapo-math-17k.jsonl}"
+UPDATE_WEIGHT_DISK_DIR="${UPDATE_WEIGHT_DISK_DIR:-/home/vllm/c00944022/0623/vime-delta-weights}"
+UPDATE_WEIGHT_LOCAL_CHECKPOINT_DIR="${UPDATE_WEIGHT_LOCAL_CHECKPOINT_DIR:-/tmp/vime-rollout-checkpoint}"
 
 CKPT_ARGS=(
-   --hf-checkpoint ${DATA_ROOT}/models/Qwen3-4B/
-   --load ${DATA_ROOT}/models/Qwen3-4B/
-   --ref-load ${DATA_ROOT}/models/Qwen3-4B/
+   --hf-checkpoint "${MODEL_PATH}"
+   --load "${MODEL_PATH}"
+   --ref-load "${MODEL_PATH}"
    --megatron-to-hf-mode bridge
 )
 
 ROLLOUT_ARGS=(
-   --prompt-data ${DATA_ROOT}/datasets/dapo-math-17k/dapo-math-17k.jsonl
+   --prompt-data "${PROMPT_DATA_PATH}"
    --input-key prompt
    --label-key label
    --apply-chat-template
@@ -97,6 +101,15 @@ VLLM_ARGS=(
    --vllm-gpu-memory-utilization 0.6
 )
 
+UPDATE_WEIGHT_ARGS=(
+   --update-weight-mode delta
+   --update-weight-transport disk
+   --update-weight-disk-dir "${UPDATE_WEIGHT_DISK_DIR}"
+   --update-weight-local-checkpoint-dir "${UPDATE_WEIGHT_LOCAL_CHECKPOINT_DIR}"
+   --update-weight-delta-encoding xor
+   --update-weight-delta-checksum xxh3-128
+)
+
 MISC_ARGS=(
    --attention-dropout 0.0
    --hidden-dropout 0.0
@@ -121,4 +134,5 @@ ${OPTIMIZER_ARGS[@]} \
 ${GRPO_ARGS[@]} \
 ${PERF_ARGS[@]} \
 ${VLLM_ARGS[@]} \
+${UPDATE_WEIGHT_ARGS[@]} \
 ${MISC_ARGS[@]}

--- a/scripts/run-qwen3-4B-npu.sh
+++ b/scripts/run-qwen3-4B-npu.sh
@@ -36,6 +36,9 @@ MODEL_PATH="${MODEL_PATH:-/home/vllm/weights/Qwen3-4B}"
 PROMPT_DATA_PATH="${PROMPT_DATA_PATH:-/home/vllm/c00944022/datasets/dapo-math-17k/dapo-math-17k.jsonl}"
 UPDATE_WEIGHT_DISK_DIR="${UPDATE_WEIGHT_DISK_DIR:-/home/vllm/c00944022/0623/vime-delta-weights}"
 UPDATE_WEIGHT_LOCAL_CHECKPOINT_DIR="${UPDATE_WEIGHT_LOCAL_CHECKPOINT_DIR:-/tmp/vime-rollout-checkpoint}"
+RAY_GCS_PORT="${RAY_GCS_PORT:-6399}"
+RAY_DASHBOARD_PORT="${RAY_DASHBOARD_PORT:-8267}"
+RAY_TEMP_DIR="${RAY_TEMP_DIR:-/tmp/ray-vime-delta}"
 
 CKPT_ARGS=(
    --hf-checkpoint "${MODEL_PATH}"
@@ -120,9 +123,11 @@ MISC_ARGS=(
    --use-flash-attn
 )
 
-ray start --head --node-ip-address 127.0.0.1 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+ray start --head --port="${RAY_GCS_PORT}" --temp-dir="${RAY_TEMP_DIR}" \
+--node-ip-address 127.0.0.1 --disable-usage-stats \
+--dashboard-host=0.0.0.0 --dashboard-port="${RAY_DASHBOARD_PORT}"
 
-ray job submit --address="http://127.0.0.1:8265" \
+ray job submit --address="http://127.0.0.1:${RAY_DASHBOARD_PORT}" \
 -- python3 train.py \
 --actor-num-nodes 1 \
 --actor-num-gpus-per-node 4 \

--- a/scripts/run-qwen3-4B-npu.sh
+++ b/scripts/run-qwen3-4B-npu.sh
@@ -24,7 +24,8 @@ export HYDRA_FULL_ERROR=1
 export DISABLE_L2_CACHE=1
 export VLLM_ASCEND_ENABLE_NZ=0
 export VLLM_USE_AOT_COMPILE=0
-export PYTHONPATH="/root/Megatron-Bridge/src:/root/Megatron-LM/:${PYTHONPATH:-}"
+VIME_WORKSPACE_ROOT="${VIME_WORKSPACE_ROOT:-/home/vllm/c00944022/0623}"
+export PYTHONPATH="${VIME_WORKSPACE_ROOT}/Megatron-Bridge/src:${VIME_WORKSPACE_ROOT}/Megatron-LM:${PYTHONPATH:-}"
 
 unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
 

--- a/scripts/run-weight-sync-benchmark-npu.sh
+++ b/scripts/run-weight-sync-benchmark-npu.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Reproducible Disk + Delta / Disk + Full benchmark for Qwen3-4B and
+# Qwen3-30B-A3B on the 12-NPU validation host.
+MODEL_SIZE="${MODEL_SIZE:-4B}"
+UPDATE_WEIGHT_MODE="${UPDATE_WEIGHT_MODE:-delta}"
+NUM_ROLLOUT="${NUM_ROLLOUT:-5}"
+ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:-16}"
+N_SAMPLES_PER_PROMPT="${N_SAMPLES_PER_PROMPT:-4}"
+ROLLOUT_MAX_RESPONSE_LEN="${ROLLOUT_MAX_RESPONSE_LEN:-2048}"
+GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:-16}"
+BENCHMARK_TAG="${BENCHMARK_TAG:-$(date +%Y%m%d-%H%M%S)}"
+
+case "${UPDATE_WEIGHT_MODE}" in
+  delta|full) ;;
+  *) echo "UPDATE_WEIGHT_MODE must be delta or full" >&2; exit 2 ;;
+esac
+
+case "${MODEL_SIZE}" in
+  4B)
+    MODEL_CONFIG="qwen3-4B.sh"
+    MODEL_PATH="${MODEL_PATH:-/home/vllm/weights/Qwen3-4B}"
+    ACTOR_GPUS=4
+    EXPERT_MODEL_PARALLEL_SIZE=1
+    VLLM_MEMORY_UTILIZATION="${VLLM_MEMORY_UTILIZATION:-0.3}"
+    SEQUENCE_PARALLEL_ARGS=()
+    ;;
+  30B)
+    MODEL_CONFIG="qwen3-30B-A3B.sh"
+    MODEL_PATH="${MODEL_PATH:-/home/vllm/weights/Qwen3-30B-A3B}"
+    ACTOR_GPUS=8
+    EXPERT_MODEL_PARALLEL_SIZE=8
+    VLLM_MEMORY_UTILIZATION="${VLLM_MEMORY_UTILIZATION:-0.4}"
+    SEQUENCE_PARALLEL_ARGS=(--sequence-parallel)
+    ;;
+  *) echo "MODEL_SIZE must be 4B or 30B" >&2; exit 2 ;;
+esac
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+source "${SCRIPT_DIR}/models/${MODEL_CONFIG}"
+
+PROMPT_DATA_PATH="${PROMPT_DATA_PATH:-/home/vllm/c00944022/datasets/dapo-math-17k/dapo-math-17k.jsonl}"
+UPDATE_WEIGHT_DISK_DIR="${UPDATE_WEIGHT_DISK_DIR:-/home/vllm/weight-sync-bench/${BENCHMARK_TAG}-${MODEL_SIZE}-${UPDATE_WEIGHT_MODE}}"
+UPDATE_WEIGHT_LOCAL_CHECKPOINT_DIR="${UPDATE_WEIGHT_LOCAL_CHECKPOINT_DIR:-/tmp/vime-bench-${MODEL_SIZE}-${UPDATE_WEIGHT_MODE}}"
+BENCHMARK_LOG="${BENCHMARK_LOG:-/home/vllm/weight-sync-bench/logs/${BENCHMARK_TAG}-${MODEL_SIZE}-${UPDATE_WEIGHT_MODE}.log}"
+RAY_GCS_PORT="${RAY_GCS_PORT:-6399}"
+RAY_DASHBOARD_PORT="${RAY_DASHBOARD_PORT:-8267}"
+RAY_TEMP_DIR="${RAY_TEMP_DIR:-/tmp/vb-${MODEL_SIZE}-${UPDATE_WEIGHT_MODE}}"
+VIME_WORKSPACE_ROOT="${VIME_WORKSPACE_ROOT:-/home/vllm/c00944022/0623}"
+
+mkdir -p "$(dirname -- "${BENCHMARK_LOG}")" "${UPDATE_WEIGHT_DISK_DIR}"
+
+cleanup_ray() {
+  ray stop --force >/dev/null 2>&1 || true
+  pkill -9 -f 'VLLM::' >/dev/null 2>&1 || true
+}
+trap cleanup_ray EXIT
+
+# These scripts are used on an exclusive validation host. Start from a clean
+# Ray/vLLM state so stale workers cannot consume NPU memory or skew timings.
+pkill -9 -f '[v]llm serve|VLL[M]::' || true
+pkill -9 -f VLLM || true
+ray stop --force || true
+pkill -9 ray || true
+pkill -9 python || true
+pkill -9 redis || true
+sleep 3
+
+export PYTHONUNBUFFERED=1
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11
+export RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export HCCL_HOST_SOCKET_PORT_RANGE=60000-60050
+export HCCL_NPU_SOCKET_PORT_RANGE=61000-61050
+export HYDRA_FULL_ERROR=1
+export DISABLE_L2_CACHE=1
+export VLLM_ASCEND_ENABLE_NZ=0
+export VLLM_USE_AOT_COMPILE=0
+export PYTHONPATH="${VIME_WORKSPACE_ROOT}/Megatron-Bridge/src:${VIME_WORKSPACE_ROOT}/Megatron-LM:${PYTHONPATH:-}"
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
+
+UPDATE_WEIGHT_ARGS=(
+  --update-weight-mode "${UPDATE_WEIGHT_MODE}"
+  --update-weight-transport disk
+  --update-weight-disk-dir "${UPDATE_WEIGHT_DISK_DIR}"
+  --update-weight-local-checkpoint-dir "${UPDATE_WEIGHT_LOCAL_CHECKPOINT_DIR}"
+)
+if [[ "${UPDATE_WEIGHT_MODE}" == delta ]]; then
+  UPDATE_WEIGHT_ARGS+=(
+    --update-weight-delta-encoding xor
+    --update-weight-delta-checksum xxh3-128
+  )
+fi
+
+ray start --head --port="${RAY_GCS_PORT}" --temp-dir="${RAY_TEMP_DIR}" \
+  --node-ip-address 127.0.0.1 --disable-usage-stats \
+  --dashboard-host=0.0.0.0 --dashboard-port="${RAY_DASHBOARD_PORT}"
+
+ray job submit --address="http://127.0.0.1:${RAY_DASHBOARD_PORT}" \
+  --runtime-env-json '{"env_vars":{"PYTORCH_NPU_ALLOC_CONF":"max_split_size_mb:128","VLLM_VERSION":"0.26.0"}}' \
+  -- python3 train.py \
+  --actor-num-nodes 1 \
+  --actor-num-gpus-per-node "${ACTOR_GPUS}" \
+  --rollout-num-gpus 4 \
+  "${MODEL_ARGS[@]}" \
+  --hf-checkpoint "${MODEL_PATH}" \
+  --load "${MODEL_PATH}" \
+  --ref-load "${MODEL_PATH}" \
+  --megatron-to-hf-mode bridge \
+  --prompt-data "${PROMPT_DATA_PATH}" \
+  --input-key prompt --label-key label --apply-chat-template --rollout-shuffle \
+  --rm-type math \
+  --num-rollout "${NUM_ROLLOUT}" \
+  --rollout-batch-size "${ROLLOUT_BATCH_SIZE}" \
+  --n-samples-per-prompt "${N_SAMPLES_PER_PROMPT}" \
+  --rollout-max-response-len "${ROLLOUT_MAX_RESPONSE_LEN}" \
+  --rollout-temperature 1 \
+  --global-batch-size "${GLOBAL_BATCH_SIZE}" \
+  --balance-data \
+  --optimizer adam --lr 1e-6 --lr-decay-style constant --weight-decay 0.1 \
+  --adam-beta1 0.9 --adam-beta2 0.98 \
+  --optimizer-cpu-offload --overlap-cpu-optimizer-d2h-h2d \
+  --use-precision-aware-optimizer \
+  --advantage-estimator grpo --kl-loss-coef 0.0 --kl-loss-type low_var_kl \
+  --kl-coef 0.0 --entropy-coef 0.0 --eps-clip 0.2 --eps-clip-high 0.28 \
+  --tensor-model-parallel-size 4 --pipeline-model-parallel-size 1 \
+  --context-parallel-size 1 \
+  --expert-model-parallel-size "${EXPERT_MODEL_PARALLEL_SIZE}" \
+  --expert-tensor-parallel-size 1 \
+  "${SEQUENCE_PARALLEL_ARGS[@]}" \
+  --recompute-granularity full --recompute-method uniform --recompute-num-layers 1 \
+  --use-dynamic-batch-size --max-tokens-per-gpu 8192 \
+  --rollout-num-gpus-per-engine 4 \
+  --vllm-gpu-memory-utilization "${VLLM_MEMORY_UTILIZATION}" \
+  --vllm-enforce-eager \
+  "${UPDATE_WEIGHT_ARGS[@]}" \
+  --attention-dropout 0.0 --hidden-dropout 0.0 \
+  --accumulate-allreduce-grads-in-fp32 --attention-softmax-in-fp32 \
+  --attention-backend flash --micro-batch-size 1 --use-flash-attn \
+  2>&1 | tee "${BENCHMARK_LOG}"
+
+# A completed transport benchmark is invalid when training did not mutate the
+# model. This catches truncated/all-zero-reward runs before their timings are
+# reported as real Delta results.
+if ! grep -Eq "'train/grad_norm': (0\.[0-9]*[1-9]|[1-9][0-9]*\.?[0-9]*|[1-9]\.[0-9]*e[-+]?[0-9]+)" "${BENCHMARK_LOG}"; then
+  echo "invalid benchmark: no non-zero train/grad_norm in ${BENCHMARK_LOG}" >&2
+  exit 3
+fi
+if [[ "${UPDATE_WEIGHT_MODE}" == delta ]] && grep -q 'density=0.00% wire=0.00 GB' "${BENCHMARK_LOG}"; then
+  echo "invalid benchmark: at least one Delta round has an empty payload" >&2
+  exit 4
+fi
+
+echo "validated benchmark log: ${BENCHMARK_LOG}"

--- a/tests/test_megatron_argument_validation.py
+++ b/tests/test_megatron_argument_validation.py
@@ -39,6 +39,64 @@ def load_arguments_module(monkeypatch):
     return module
 
 
+def load_vime_arguments_module(monkeypatch):
+    """Load VIME argument validation without importing the full runtime stack."""
+    router_pkg_mod = types.ModuleType("vllm_router")
+    router_launch_mod = types.ModuleType("vllm_router.launch_router")
+    vllm_arguments_mod = types.ModuleType("vime.backends.vllm_utils.arguments")
+    common_mod = types.ModuleType("vime.utils.common")
+    logging_utils_mod = types.ModuleType("vime.utils.logging_utils")
+    router_launch_mod.RouterArgs = object
+    vllm_arguments_mod.vllm_parse_args = lambda *args, **kwargs: None
+    vllm_arguments_mod.validate_args = lambda args: args
+    common_mod.is_npu = lambda: True
+    logging_utils_mod.configure_logger = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "vllm_router", router_pkg_mod)
+    monkeypatch.setitem(sys.modules, "vllm_router.launch_router", router_launch_mod)
+    monkeypatch.setitem(sys.modules, "vime.backends.vllm_utils.arguments", vllm_arguments_mod)
+    monkeypatch.setitem(sys.modules, "vime.utils.common", common_mod)
+    monkeypatch.setitem(sys.modules, "vime.utils.logging_utils", logging_utils_mod)
+    module_path = Path(__file__).resolve().parents[1] / "vime" / "utils" / "arguments.py"
+    module_name = "test_vime_argument_validation_module"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_vime_validate_args(**overrides):
+    values = dict(
+        eval_config=None, eval_prompt_data=None, kl_coef=0, use_kl_loss=False,
+        ref_load=None, use_opd=False, opd_type=None, opd_teacher_load=None,
+        load=None, hf_checkpoint="/tmp/hf", megatron_to_hf_mode="bridge", ref_ckpt_step=None, ckpt_step=None,
+        no_load_optim=False, no_load_rng=False, finetune=False, start_rollout_id=None,
+        eval_interval=None, save_interval=None, save=None, kl_loss_coef=0,
+        advantage_estimator="grpo", normalize_advantages=False, use_rollout_logprobs=False,
+        use_tis=False, get_mismatch_metrics=False, custom_tis_function_path=None,
+        use_dynamic_batch_size=False, max_tokens_per_gpu=None, log_probs_max_tokens_per_gpu=None,
+        balance_by_flops=False, balance_data=False, eps_clip_high=None, eps_clip=0.2,
+        eval_reward_key=None, reward_key="reward", dump_details=None,
+        save_debug_rollout_data=None, save_debug_train_data=None, load_debug_rollout_data=None,
+        rollout_external_engine_addrs=None, debug_train_only=False, actor_num_gpus_per_node=8,
+        actor_num_nodes=1, num_gpus_per_node=8, offload=False, offload_train=None,
+        offload_rollout=None, debug_rollout_only=False, colocate=False, rollout_num_gpus=8,
+        eval_function_path=None, rollout_function_path="custom.rollout", num_steps_per_rollout=None,
+        rollout_batch_size=1, n_samples_per_prompt=1, global_batch_size=None,
+        grpo_std_normalization=True, over_sampling_batch_size=None, num_epoch=None,
+        num_rollout=1, rollout_global_dataset=False, enable_mtp_training=False,
+        mtp_num_layers=None, use_rollout_routing_replay=False, use_routing_replay=False,
+        custom_config_path=None, eval_max_context_len=None, rollout_max_context_len=None,
+        rollout_max_prompt_len=None, train_backend="megatron", release_train=False,
+        keep_old_actor=False, only_train_params_name_list=None, freeze_params_name_list=None,
+        update_weight_transport="nccl", update_weight_disk_dir=None,
+        update_weight_local_checkpoint_dir=None, update_weight_mode="full", qkv_format="sbhd",
+    )
+    values.update(overrides)
+    return types.SimpleNamespace(**values)
+
+
 def make_qwen3_6_args(**overrides):
     values = dict(
         hidden_size=2048,
@@ -137,6 +195,50 @@ def test_allgather_cp_ignores_cp_size_one(monkeypatch):
     args = make_allgather_cp_args(context_parallel_size=1)
 
     module._validate_allgather_cp_supported(args)
+
+
+@pytest.mark.unit
+def test_update_weight_delta_disk_is_valid(monkeypatch):
+    module = load_vime_arguments_module(monkeypatch)
+    module.vime_validate_args(
+        make_vime_validate_args(
+            update_weight_mode="delta",
+            update_weight_transport="disk",
+            update_weight_disk_dir="/shared/delta",
+            update_weight_local_checkpoint_dir="/local/delta",
+        )
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("overrides", "error"),
+    [
+        ({"update_weight_mode": "delta"}, "requires --update-weight-transport=disk"),
+        (
+            {
+                "update_weight_mode": "delta",
+                "update_weight_transport": "disk",
+                "update_weight_disk_dir": "/shared/delta",
+                "colocate": True,
+            },
+            "not supported with --colocate",
+        ),
+        (
+            {
+                "update_weight_mode": "delta",
+                "update_weight_transport": "disk",
+                "update_weight_disk_dir": "/shared/delta",
+            },
+            "requires --update-weight-local-checkpoint-dir",
+        ),
+        ({"update_weight_transport": "disk"}, "supported only with --update-weight-mode=delta"),
+    ],
+)
+def test_update_weight_disk_rejects_invalid_combinations(monkeypatch, overrides, error):
+    module = load_vime_arguments_module(monkeypatch)
+    with pytest.raises(ValueError, match=error):
+        module.vime_validate_args(make_vime_validate_args(**overrides))
 
 
 if __name__ == "__main__":

--- a/tests/test_megatron_argument_validation.py
+++ b/tests/test_megatron_argument_validation.py
@@ -211,6 +211,18 @@ def test_update_weight_delta_disk_is_valid(monkeypatch):
 
 
 @pytest.mark.unit
+def test_update_weight_full_disk_is_valid(monkeypatch):
+    module = load_vime_arguments_module(monkeypatch)
+    module.vime_validate_args(
+        make_vime_validate_args(
+            update_weight_mode="full",
+            update_weight_transport="disk",
+            update_weight_disk_dir="/shared/full",
+        )
+    )
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("overrides", "error"),
     [
@@ -232,7 +244,15 @@ def test_update_weight_delta_disk_is_valid(monkeypatch):
             },
             "requires --update-weight-local-checkpoint-dir",
         ),
-        ({"update_weight_transport": "disk"}, "supported only with --update-weight-mode=delta"),
+        ({"update_weight_transport": "disk"}, "requires --update-weight-disk-dir"),
+        (
+            {
+                "update_weight_transport": "disk",
+                "update_weight_disk_dir": "/shared/full",
+                "colocate": True,
+            },
+            "not supported with --colocate",
+        ),
     ],
 )
 def test_update_weight_disk_rejects_invalid_combinations(monkeypatch, overrides, error):

--- a/tests/test_qwen3_4B_npu.py
+++ b/tests/test_qwen3_4B_npu.py
@@ -1,5 +1,7 @@
 import os
 import shlex
+import tempfile
+from pathlib import Path
 
 import vime.utils.external_utils.command_utils as U
 
@@ -23,6 +25,7 @@ def prepare():
 def execute():
     model_dir = shlex.quote(MODEL_DIR)
     prompt_data = shlex.quote(f"{DATASET_DIR}/dapo-math-17k.jsonl")
+    update_mode = os.environ.get("VIME_TEST_UPDATE_MODE", "full")
 
     checkpoint_args = (
         f"--hf-checkpoint {model_dir} "
@@ -66,7 +69,7 @@ def execute():
         "--kl-loss-coef 0.0 "
         "--kl-loss-type low_var_kl "
         "--kl-coef 0.00 "
-        "--entropy-coef 0.0 "
+        f"--entropy-coef {'0.01' if update_mode == 'delta' else '0.0'} "
         "--eps-clip 0.2 "
         "--eps-clip-high 0.28 "
     )
@@ -109,22 +112,44 @@ def execute():
         "--ci-test "
     )
 
-    train_args = (
-        checkpoint_args
-        + rollout_args
-        + parallel_args
-        + grpo_args
-        + optimizer_args
-        + vllm_args
-        + model_args
-        + runtime_args
-    )
-    U.execute_train(
-        train_args=train_args,
-        num_gpus_per_node=8,
-        megatron_model_type="qwen3-4B",
-        extra_env_vars={},
-    )
+    with tempfile.TemporaryDirectory(prefix="vime_npu_delta_shared_") as shared_dir, tempfile.TemporaryDirectory(
+        prefix="vime_npu_delta_local_"
+    ) as local_dir:
+        disk_args = ""
+        if update_mode == "delta":
+            disk_args = (
+                "--update-weight-mode delta "
+                "--update-weight-transport disk "
+                f"--update-weight-disk-dir {shlex.quote(shared_dir)} "
+                f"--update-weight-local-checkpoint-dir {shlex.quote(local_dir)} "
+                "--update-weight-delta-encoding xor "
+                "--update-weight-delta-checksum xxh3-128 "
+            )
+
+        train_args = (
+            checkpoint_args
+            + rollout_args
+            + parallel_args
+            + grpo_args
+            + optimizer_args
+            + vllm_args
+            + model_args
+            + runtime_args
+            + disk_args
+        )
+        U.execute_train(
+            train_args=train_args,
+            num_gpus_per_node=8,
+            megatron_model_type="qwen3-4B",
+            extra_env_vars={},
+        )
+
+        if update_mode == "delta":
+            versions = sorted(Path(shared_dir).glob("weight_v*"))
+            assert len(versions) >= 2, f"Expected two delta updates under {shared_dir}, got {versions}"
+            assert all((version / "model.safetensors.index.json").exists() for version in versions)
+            assert any("delta_encoding" in (version / "model.safetensors.index.json").read_text() for version in versions)
+            assert (Path(local_dir) / ".weight_sync" / "state.json").exists()
 
 
 def main():

--- a/tests/unit/backends/vllm_utils/conftest.py
+++ b/tests/unit/backends/vllm_utils/conftest.py
@@ -23,6 +23,9 @@ def vllm_args() -> SimpleNamespace:
         use_critic=False,
         critic_num_gpus_per_node=0,
         critic_num_nodes=0,
+        update_weight_disk_dir="/shared/weights",
+        update_weight_local_checkpoint_dir="/local/weights",
+        custom_update_weight_pre_read_path=None,
     )
 
 

--- a/tests/unit/backends/vllm_utils/test_vllm_engine.py
+++ b/tests/unit/backends/vllm_utils/test_vllm_engine.py
@@ -354,6 +354,60 @@ def test_update_weights_from_distributed_posts_update_weights_without_checkpoint
 
 
 @pytest.mark.unit
+def test_pull_weights_posts_collective_rpc_and_records_version(vllm_engine, monkeypatch):
+    calls = []
+
+    def fake_post(url, *, json=None, timeout=None):
+        calls.append((url, json, timeout))
+        return _MockResponse(json_data={"success": True})
+
+    monkeypatch.setattr(mod.requests, "post", fake_post)
+
+    assert vllm_engine.pull_weights(8) == {"success": True}
+    assert calls == [
+        (
+            "http://127.0.0.1:8765/collective_rpc",
+            {
+                "method": "pull_weights",
+                "kwargs": {
+                    "local_checkpoint_dir": "/local/weights",
+                    "source_dir": "/shared/weights",
+                    "target_version": 8,
+                    "pre_read_hook": None,
+                },
+            },
+            600,
+        )
+    ]
+    assert vllm_engine._weight_version == "8"
+
+
+@pytest.mark.unit
+def test_pull_weights_failure_does_not_advance_version(vllm_engine, monkeypatch):
+    vllm_engine._weight_version = "old"
+
+    def fake_post(url, *, json=None, timeout=None):
+        del url, json, timeout
+        return _MockResponse(status_code=500, text="failed")
+
+    monkeypatch.setattr(mod.requests, "post", fake_post)
+    with pytest.raises(requests.exceptions.HTTPError):
+        vllm_engine.pull_weights(8)
+    assert vllm_engine._weight_version == "old"
+
+
+@pytest.mark.unit
+def test_disk_reload_records_version_only_after_success(vllm_engine, monkeypatch):
+    def fake_post(url, *, json=None, timeout=None):
+        del url, json, timeout
+        return _MockResponse(json_data={"reloaded": True})
+
+    monkeypatch.setattr(mod.requests, "post", fake_post)
+    assert vllm_engine.update_weights_from_disk("/local/weights", weight_version="9") == {"reloaded": True}
+    assert vllm_engine._weight_version == "9"
+
+
+@pytest.mark.unit
 def test_post_vllm_update_weights_http_wraps_update_info(vllm_engine, monkeypatch):
     seen: list[tuple] = []
 
@@ -680,5 +734,7 @@ def test_control_plane_methods_noop_on_headless_worker(vllm_engine, monkeypatch)
     assert vllm_engine.finish_weight_update() is None
     assert vllm_engine.init_weights_update_group("addr", 1, 0, 4, "g", "nccl") is None
     assert vllm_engine.update_weights_from_distributed(["w"], [torch.float32], [[1]], "g") is None
+    assert vllm_engine.pull_weights(1) is None
+    assert vllm_engine.update_weights_from_disk("/local/weights", weight_version="1") is None
     assert vllm_engine.release_memory_occupation() is None
     assert vllm_engine.resume_memory_occupation() is None

--- a/tests/unit/utils/test_disk_delta.py
+++ b/tests/unit/utils/test_disk_delta.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import numpy as np
+import safetensors.numpy
+
+from vime.utils.disk_delta import checksum, make_tensor_reader, overwrite_encode
+
+
+def test_overwrite_encode_contains_changed_positions_and_values():
+    old = np.array([1, 2, 3, 4], dtype=np.uint8)
+    new = np.array([1, 9, 3, 8], dtype=np.uint8)
+
+    encoded = overwrite_encode(new, new != old)
+
+    count = int.from_bytes(encoded[:4].tobytes(), "little")
+    positions = np.frombuffer(encoded[4 : 4 + count * 4].tobytes(), dtype="<u4")
+    assert count == 2
+    np.testing.assert_array_equal(positions, [1, 3])
+    np.testing.assert_array_equal(encoded[4 + count * 4 :], [9, 8])
+
+
+def test_checksum_algorithms_are_deterministic():
+    payload = np.arange(32, dtype=np.uint8)
+    for algorithm in ("adler32", "blake3", "xxh3-128"):
+        assert checksum(algorithm, payload) == checksum(algorithm, payload)
+
+
+def test_tensor_reader_reads_safetensor_bytes(tmp_path):
+    weight = np.arange(12, dtype=np.float32).reshape(3, 4)
+    safetensors.numpy.save_file({"weight": weight}, tmp_path / "model.safetensors")
+
+    actual = make_tensor_reader(str(tmp_path))("weight")
+
+    np.testing.assert_array_equal(actual, weight.view(np.uint8).reshape(-1))

--- a/tests/unit/utils/test_function_compat.py
+++ b/tests/unit/utils/test_function_compat.py
@@ -1,0 +1,28 @@
+import pytest
+
+from vime.utils.function_compat import call_with_optional_keyword
+
+
+@pytest.mark.parametrize("supports_keyword", [False, True])
+def test_call_with_optional_keyword(supports_keyword: bool) -> None:
+    calls = []
+
+    if supports_keyword:
+
+        def target(self, is_checkpoint_format: bool = True) -> None:
+            calls.append((self, is_checkpoint_format))
+
+    else:
+
+        def target(self) -> None:
+            calls.append((self, "without_keyword"))
+
+    receiver = object()
+    call_with_optional_keyword(
+        target,
+        receiver,
+        keyword="is_checkpoint_format",
+        value=False,
+    )
+
+    assert calls == [(receiver, False if supports_keyword else "without_keyword")]

--- a/vime/backends/megatron_utils/actor.py
+++ b/vime/backends/megatron_utils/actor.py
@@ -52,6 +52,7 @@ from .initialize import init, is_megatron_main_rank
 from .loss import compute_advantages_and_returns, get_log_probs_and_entropy, get_values
 from .model import forward_only, initialize_model_and_optimizer, save, train
 from .update_weight.common import named_params_and_buffers
+from .update_weight.update_weight_from_disk import UpdateWeightFromDisk
 from .update_weight.update_weight_from_disk_delta import UpdateWeightFromDiskDelta
 from .update_weight.update_weight_from_distributed import UpdateWeightFromDistributed
 from .update_weight.update_weight_from_tensor import UpdateWeightFromTensor
@@ -166,6 +167,8 @@ class MegatronTrainRayActor(TrainRayActor):
 
         if getattr(self.args, "update_weight_mode", "full") == "delta":
             update_weight_cls = UpdateWeightFromDiskDelta
+        elif self.args.update_weight_transport == "disk":
+            update_weight_cls = UpdateWeightFromDisk
         elif self.args.colocate:
             update_weight_cls = UpdateWeightFromTensor
         else:

--- a/vime/backends/megatron_utils/actor.py
+++ b/vime/backends/megatron_utils/actor.py
@@ -52,6 +52,7 @@ from .initialize import init, is_megatron_main_rank
 from .loss import compute_advantages_and_returns, get_log_probs_and_entropy, get_values
 from .model import forward_only, initialize_model_and_optimizer, save, train
 from .update_weight.common import named_params_and_buffers
+from .update_weight.update_weight_from_disk_delta import UpdateWeightFromDiskDelta
 from .update_weight.update_weight_from_distributed import UpdateWeightFromDistributed
 from .update_weight.update_weight_from_tensor import UpdateWeightFromTensor
 
@@ -163,7 +164,9 @@ class MegatronTrainRayActor(TrainRayActor):
             hf_vocab = getattr(self.hf_config, "vocab_size", None)
             self.args.vocab_size = hf_vocab if hf_vocab is not None else self.tokenizer.vocab_size
 
-        if self.args.colocate:
+        if getattr(self.args, "update_weight_mode", "full") == "delta":
+            update_weight_cls = UpdateWeightFromDiskDelta
+        elif self.args.colocate:
             update_weight_cls = UpdateWeightFromTensor
         else:
             update_weight_cls = UpdateWeightFromDistributed

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_disk.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_disk.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import time
+from argparse import Namespace
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+
+import ray
+import torch
+import torch.distributed as dist
+from ray.actor import ActorHandle
+from safetensors.torch import save_file
+
+from vime.utils.distributed_utils import get_gloo_group
+
+from .hf_weight_iterator_base import HfWeightIteratorBase
+
+logger = logging.getLogger(__name__)
+
+_HF_WEIGHT_FILE_NAMES = {
+    "model.safetensors.index.json",
+    "pytorch_model.bin.index.json",
+    "tf_model.h5",
+    "flax_model.msgpack",
+}
+_HF_WEIGHT_FILE_SUFFIXES = (".safetensors", ".bin", ".pt", ".pth", ".ckpt", ".msgpack")
+
+
+class UpdateWeightFromDisk:
+    """Publish a full HF checkpoint and reload non-colocated rollout engines from disk."""
+
+    def __init__(
+        self,
+        args: Namespace,
+        model: Sequence[torch.nn.Module],
+        weights_getter: Callable[[], Mapping[str, torch.Tensor]],
+        *,
+        model_name: str,
+        quantization_config: dict[str, int | str | list[str]] | None,
+    ) -> None:
+        self.args = args
+        self.weights_getter = weights_getter
+        self.weight_version = 0
+        self.update_weight_metrics: dict[str, float] = {}
+        self.rollout_engines: list[ActorHandle] = []
+        self._iterator = HfWeightIteratorBase.create(
+            args=args,
+            model=model,
+            model_name=model_name,
+            quantization_config=quantization_config,
+        )
+        self._post_write_hook: Callable | None = None
+        if args.custom_update_weight_post_write_path:
+            from vime.utils.misc import load_function
+
+            self._post_write_hook = load_function(args.custom_update_weight_post_write_path)
+
+    def connect_rollout_engines(
+        self,
+        rollout_engines: Sequence[ActorHandle],
+        rollout_engine_lock: ActorHandle,
+        engine_gpu_counts: Sequence[int] | None = None,
+        engine_gpu_offsets: Sequence[int] | None = None,
+    ) -> None:
+        del rollout_engine_lock, engine_gpu_counts, engine_gpu_offsets
+        self.rollout_engines = list(rollout_engines)
+
+    def disconnect_rollout_engines(self) -> None:
+        return
+
+    def pop_metrics(self) -> dict[str, float]:
+        metrics, self.update_weight_metrics = self.update_weight_metrics, {}
+        return metrics
+
+    @torch.no_grad()
+    def update_weights(self) -> None:
+        self.weight_version += 1
+        version_dir = Path(self.args.update_weight_disk_dir) / f"weight_v{self.weight_version:06d}"
+        started = time.perf_counter()
+
+        self._prepare_version_dir(version_dir)
+        write_started = time.perf_counter()
+        self._write_full_checkpoint(version_dir)
+        dist.barrier(group=get_gloo_group())
+        write_finished = time.perf_counter()
+
+        if self._post_write_hook is not None:
+            self._post_write_hook(self.args, str(version_dir), self.rollout_engines)
+        dist.barrier(group=get_gloo_group())
+
+        if dist.get_rank() == 0:
+            reload_started = time.perf_counter()
+            ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
+            paused = time.perf_counter()
+            try:
+                ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
+                flushed = time.perf_counter()
+                ray.get(
+                    [
+                        engine.update_weights_from_disk.remote(
+                            model_path=str(version_dir),
+                            weight_version=str(self.weight_version),
+                        )
+                        for engine in self.rollout_engines
+                    ]
+                )
+                reloaded = time.perf_counter()
+            finally:
+                ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
+            resumed = time.perf_counter()
+            self.update_weight_metrics.update(
+                {
+                    "perf/update_weights_full_disk_write_time": write_finished - write_started,
+                    "perf/update_weights_full_disk_pause_time": paused - reload_started,
+                    "perf/update_weights_full_disk_flush_time": flushed - paused,
+                    "perf/update_weights_full_disk_reload_time": reloaded - flushed,
+                    "perf/update_weights_full_disk_resume_time": resumed - reloaded,
+                    "perf/update_weights_full_disk_total_time": resumed - started,
+                }
+            )
+            logger.info("[disk full timings v=%s] %s", self.weight_version, self.update_weight_metrics)
+        dist.barrier(group=get_gloo_group())
+
+    def _prepare_version_dir(self, version_dir: Path) -> None:
+        if dist.get_rank() == 0:
+            shutil.rmtree(version_dir, ignore_errors=True)
+            version_dir.mkdir(parents=True, exist_ok=True)
+            source_dir = Path(self.args.hf_checkpoint)
+            for source in source_dir.iterdir():
+                if source.is_file() and not _is_hf_weight_file(source):
+                    shutil.copy2(source, version_dir / source.name)
+        dist.barrier(group=get_gloo_group())
+
+    def _write_full_checkpoint(self, version_dir: Path) -> None:
+        is_writer = dist.get_rank() == 0
+        weight_map: dict[str, str] = {}
+        total_size = 0
+        shard_files: list[str] = []
+
+        for chunk_index, chunk in enumerate(
+            self._iterator.get_hf_weight_chunks(
+                self.weights_getter(), progress_desc="Save full disk checkpoint"
+            ),
+            start=1,
+        ):
+            if not is_writer:
+                continue
+            state_dict: dict[str, torch.Tensor] = {}
+            for name, tensor in chunk:
+                if name in weight_map or name in state_dict:
+                    raise ValueError(f"Duplicate HF tensor while saving full disk checkpoint: {name}")
+                tensor = tensor.detach()
+                if not tensor.is_contiguous():
+                    tensor = tensor.contiguous()
+                if tensor.device.type != "cpu":
+                    tensor = tensor.cpu()
+                state_dict[name] = tensor
+                total_size += tensor.numel() * tensor.element_size()
+            if not state_dict:
+                continue
+            filename = f"model-{chunk_index:05d}.safetensors"
+            save_file(state_dict, version_dir / filename, metadata={"format": "pt"})
+            shard_files.append(filename)
+            weight_map.update({name: filename for name in state_dict})
+
+        if is_writer:
+            if not shard_files:
+                raise ValueError("No HF tensors were produced for full disk checkpoint")
+            rename_map: dict[str, str] = {}
+            total_files = len(shard_files)
+            for index, old_name in enumerate(shard_files, start=1):
+                new_name = f"model-{index:05d}-of-{total_files:05d}.safetensors"
+                os.replace(version_dir / old_name, version_dir / new_name)
+                rename_map[old_name] = new_name
+            index_data = {
+                "metadata": {"total_size": total_size},
+                "weight_map": {name: rename_map[filename] for name, filename in weight_map.items()},
+            }
+            index_path = version_dir / "model.safetensors.index.json"
+            temporary = index_path.with_suffix(index_path.suffix + ".tmp")
+            with temporary.open("w", encoding="utf-8") as output:
+                json.dump(index_data, output)
+                output.flush()
+                os.fsync(output.fileno())
+            os.replace(temporary, index_path)
+
+
+def _is_hf_weight_file(path: Path) -> bool:
+    return path.name in _HF_WEIGHT_FILE_NAMES or path.name.endswith(_HF_WEIGHT_FILE_SUFFIXES)

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_disk_delta.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_disk_delta.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import queue
+import shutil
+from argparse import Namespace
+from collections import deque
+from collections.abc import Callable, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import ray
+import safetensors.numpy
+import torch
+import torch.distributed as dist
+import zstandard
+from ray.actor import ActorHandle
+
+from vime.utils.disk_delta import NUM_WORKERS, checksum, make_tensor_reader, overwrite_encode
+from vime.utils.distributed_utils import get_gloo_group
+
+from .hf_weight_iterator_base import HfWeightIteratorBase
+
+logger = logging.getLogger(__name__)
+
+
+class UpdateWeightFromDiskDelta:
+    """Publish byte-level HF weight deltas and reload them through local checkpoints.
+
+    This is intentionally independent of ``UpdateWeightFromDistributed``: all
+    training ranks still participate in the Ascend PP/TP/EP conversion iterator,
+    while only global rank zero publishes the canonical result.  No HCCL group is
+    created for this transport.
+    """
+
+    def __init__(
+        self,
+        args: Namespace,
+        model: Sequence[torch.nn.Module],
+        weights_getter: Callable[[], Mapping[str, torch.Tensor]],
+        *,
+        model_name: str,
+        quantization_config: dict[str, int | str | list[str]] | None,
+    ) -> None:
+        self.args = args
+        self.weights_getter = weights_getter
+        self.weight_version = 0
+        self.update_weight_metrics: dict[str, float] = {}
+        self.rollout_engines: list[ActorHandle] = []
+        self.delta_dir = args.update_weight_disk_dir
+        self.delta_encoding = args.update_weight_delta_encoding
+        self.checksum_algorithm = args.update_weight_delta_checksum
+        self._iterator = HfWeightIteratorBase.create(
+            args=args,
+            model=model,
+            model_name=model_name,
+            quantization_config=quantization_config,
+        )
+        self._snapshot: dict[str, np.ndarray] = {}
+        self._baseline_captured = False
+        self._post_write_hook: Callable | None = None
+        if args.custom_update_weight_post_write_path:
+            from vime.utils.misc import load_function
+
+            self._post_write_hook = load_function(args.custom_update_weight_post_write_path)
+
+    def connect_rollout_engines(
+        self,
+        rollout_engines: Sequence[ActorHandle],
+        rollout_engine_lock: ActorHandle,
+        engine_gpu_counts: Sequence[int] | None = None,
+        engine_gpu_offsets: Sequence[int] | None = None,
+    ) -> None:
+        del rollout_engine_lock, engine_gpu_counts, engine_gpu_offsets
+        self.rollout_engines = list(rollout_engines)
+
+    def disconnect_rollout_engines(self) -> None:
+        return
+
+    def pop_metrics(self) -> dict[str, float]:
+        metrics, self.update_weight_metrics = self.update_weight_metrics, {}
+        return metrics
+
+    @torch.no_grad()
+    def update_weights(self) -> None:
+        if not self._baseline_captured:
+            self._capture_baseline()
+            self._baseline_captured = True
+            return
+
+        self.weight_version += 1
+        self._publish()
+        self._reload_engines()
+        self._record_metrics()
+
+    def _capture_baseline(self) -> None:
+        """Use the serving checkpoint as the byte-exact version-zero baseline."""
+        pulls = []
+        if dist.get_rank() == 0:
+            shutil.rmtree(self.delta_dir, ignore_errors=True)
+            os.makedirs(self.delta_dir, exist_ok=True)
+            if self._post_write_hook is not None:
+                self._post_write_hook(self.args, self.delta_dir, self.rollout_engines)
+            pulls = [engine.pull_weights.remote(target_version=0) for engine in self.rollout_engines]
+        dist.barrier(group=get_gloo_group())
+
+        read_hf = make_tensor_reader(self.args.hf_checkpoint)
+        for name, tensor in self._iter_hf_tensors(progress_desc="Capture disk delta baseline"):
+            try:
+                self._snapshot[name] = read_hf(name)
+            except KeyError:
+                self._snapshot[name] = _tensor_bytes(tensor)
+                logger.warning("delta baseline: %s absent from hf_checkpoint; using current converted weight", name)
+
+        if dist.get_rank() == 0:
+            ray.get(pulls)
+            logger.info("[disk delta] captured baseline for %d tensors", len(self._snapshot))
+
+    def _publish(self) -> None:
+        self._encode_delta()
+        dist.barrier(group=get_gloo_group())
+        if dist.get_rank() == 0:
+            self._write_delta_files()
+        dist.barrier(group=get_gloo_group())
+
+    def _iter_hf_tensors(self, *, progress_desc: str):
+        """All ranks execute conversion collectives; only rank zero publishes tensors."""
+        for chunk in self._iterator.get_hf_weight_chunks(self.weights_getter(), progress_desc=progress_desc):
+            if dist.get_rank() == 0:
+                yield from chunk
+
+    def _encode_delta(self) -> None:
+        self._version_dir = os.path.join(self.delta_dir, f"weight_v{self.weight_version:06d}")
+        self._delta: dict[str, np.ndarray] = {}
+        self._checksums: dict[str, str] = {}
+        self.changed_bytes = 0
+        self.total_bytes = 0
+        self.wire_bytes = 0
+
+        if dist.get_rank() != 0:
+            # Do not return: every rank must execute the conversion iterator's collectives.
+            for _name, _tensor in self._iter_hf_tensors(progress_desc="Encode disk delta"):
+                pass
+            return
+
+        os.makedirs(self._version_dir, exist_ok=True)
+        max_bytes = max((value.nbytes for value in self._snapshot.values()), default=0)
+        free_buffers: queue.Queue[torch.Tensor] = queue.Queue()
+        use_pinned = max_bytes > 0
+        if use_pinned:
+            try:
+                pool_size = max(2, min(2 * NUM_WORKERS, (8 << 30) // max(max_bytes, 1)))
+                for _ in range(pool_size):
+                    free_buffers.put(torch.empty(max_bytes, dtype=torch.uint8, pin_memory=True))
+            except RuntimeError as exc:
+                logger.warning("Pinned host buffers unavailable (%s); using pageable copies", exc)
+                use_pinned = False
+
+        def diff_and_compress(name: str, new: np.ndarray) -> tuple[str, np.ndarray, np.ndarray | None, str | None, int]:
+            old = self._snapshot[name]
+            if new.nbytes != old.nbytes:
+                raise ValueError(f"Delta tensor size changed for {name}: {old.nbytes} != {new.nbytes}")
+            if self.delta_encoding == "xor":
+                diff = new ^ old
+                changed = int(np.count_nonzero(diff))
+            else:
+                mask = new != old
+                changed = int(np.count_nonzero(mask))
+                diff = overwrite_encode(new, mask)
+            if not changed:
+                return name, new, None, None, 0
+            compressed = np.frombuffer(zstandard.ZstdCompressor(level=1).compress(diff), dtype=np.uint8)
+            return name, new, compressed, checksum(self.checksum_algorithm, new), changed
+
+        pool = ThreadPoolExecutor(max_workers=NUM_WORKERS)
+        inflight: deque = deque()
+        try:
+            for name, tensor in self._iter_hf_tensors(progress_desc="Encode disk delta"):
+                new = _tensor_bytes(tensor, free_buffers=free_buffers if use_pinned else None)
+                self.total_bytes += new.nbytes
+                inflight.append(pool.submit(diff_and_compress, name, new))
+                if len(inflight) >= 2 * NUM_WORKERS:
+                    self._collect_encoded(inflight.popleft())
+            while inflight:
+                self._collect_encoded(inflight.popleft())
+        finally:
+            pool.shutdown()
+
+    def _collect_encoded(self, future) -> None:
+        name, new, compressed, digest, changed = future.result()
+        self._snapshot[name] = new
+        if changed:
+            self.changed_bytes += changed
+            assert compressed is not None and digest is not None
+            self._delta[name] = compressed
+            self._checksums[name] = digest
+
+    def _write_delta_files(self) -> None:
+        if self._delta:
+            filename = "model-00000-of-00001.safetensors"
+            blob = safetensors.numpy.save(self._delta, metadata=self._checksums)
+            self.wire_bytes = len(blob)
+            _atomic_write(os.path.join(self._version_dir, filename), blob)
+        else:
+            filename = None
+        index = {
+            "metadata": {
+                "version": f"{self.weight_version:06d}",
+                "base_version": f"{self.weight_version - 1:06d}",
+                "delta_encoding": self.delta_encoding,
+                "compression_format": "zstd",
+                "checksum_format": self.checksum_algorithm,
+            },
+            "weight_map": {name: filename for name in self._delta},
+        }
+        _atomic_write(
+            os.path.join(self._version_dir, "model.safetensors.index.json"),
+            json.dumps(index).encode(),
+        )
+
+    def _reload_engines(self) -> None:
+        if self._post_write_hook is not None:
+            self._post_write_hook(self.args, self._version_dir, self.rollout_engines)
+        dist.barrier(group=get_gloo_group())
+        if dist.get_rank() == 0:
+            ray.get([engine.pull_weights.remote(self.weight_version) for engine in self.rollout_engines])
+            ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
+            try:
+                ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
+                ray.get(
+                    [
+                        engine.update_weights_from_disk.remote(
+                            self.args.update_weight_local_checkpoint_dir,
+                            weight_version=str(self.weight_version),
+                        )
+                        for engine in self.rollout_engines
+                    ]
+                )
+            finally:
+                ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
+        dist.barrier(group=get_gloo_group())
+
+    def _record_metrics(self) -> None:
+        device = _metric_device()
+        counts = torch.tensor(
+            [self.changed_bytes, self.total_bytes, self.wire_bytes], dtype=torch.int64, device=device
+        )
+        dist.all_reduce(counts)
+        changed, total, wire = counts.tolist()
+        self.update_weight_metrics["perf/update_weights_density"] = changed / max(total, 1)
+        self.update_weight_metrics["perf/update_weights_wire_bytes"] = wire
+        if dist.get_rank() == 0:
+            logger.info("[disk delta v=%s] density=%.2f%% wire=%.2f GB", self.weight_version, 100 * changed / max(total, 1), wire / 1e9)
+
+
+def _tensor_bytes(tensor: torch.Tensor, *, free_buffers: queue.Queue[torch.Tensor] | None = None) -> np.ndarray:
+    flat = tensor.detach().contiguous().view(torch.uint8).reshape(-1)
+    if flat.device.type == "cpu":
+        return flat.numpy().copy()
+    if free_buffers is None:
+        return flat.cpu().numpy().copy()
+
+    buffer = free_buffers.get()
+    try:
+        buffer[: flat.numel()].copy_(flat, non_blocking=True)
+        if flat.device.type == "npu":
+            torch.npu.current_stream().synchronize()
+        elif flat.device.type == "cuda":
+            torch.cuda.current_stream().synchronize()
+        return buffer[: flat.numel()].numpy().copy()
+    finally:
+        free_buffers.put(buffer)
+
+
+def _metric_device() -> torch.device:
+    if hasattr(torch, "npu") and torch.npu.is_available():
+        return torch.device("npu", torch.npu.current_device())
+    if torch.cuda.is_available():
+        return torch.device("cuda", torch.cuda.current_device())
+    return torch.device("cpu")
+
+
+def _atomic_write(path: str, data: bytes) -> None:
+    temporary = path + ".tmp"
+    with open(temporary, "wb") as output:
+        output.write(data)
+        output.flush()
+        os.fsync(output.fileno())
+    os.replace(temporary, path)

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_disk_delta.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_disk_delta.py
@@ -5,6 +5,7 @@ import logging
 import os
 import queue
 import shutil
+import time
 from argparse import Namespace
 from collections import deque
 from collections.abc import Callable, Mapping, Sequence
@@ -91,6 +92,7 @@ class UpdateWeightFromDiskDelta:
             return
 
         self.weight_version += 1
+        self._stage_metrics: dict[str, float] = {}
         self._publish()
         self._reload_engines()
         self._record_metrics()
@@ -119,11 +121,18 @@ class UpdateWeightFromDiskDelta:
             logger.info("[disk delta] captured baseline for %d tensors", len(self._snapshot))
 
     def _publish(self) -> None:
+        started = time.perf_counter()
         self._encode_delta()
+        encoded = time.perf_counter()
         dist.barrier(group=get_gloo_group())
         if dist.get_rank() == 0:
+            write_started = time.perf_counter()
             self._write_delta_files()
+            self._stage_metrics["perf/update_weights_delta_write_time"] = time.perf_counter() - write_started
         dist.barrier(group=get_gloo_group())
+        if dist.get_rank() == 0:
+            self._stage_metrics["perf/update_weights_delta_encode_time"] = encoded - started
+            self._stage_metrics["perf/update_weights_delta_publish_time"] = time.perf_counter() - started
 
     def _iter_hf_tensors(self, *, progress_desc: str):
         """All ranks execute conversion collectives; only rank zero publishes tensors."""
@@ -225,10 +234,14 @@ class UpdateWeightFromDiskDelta:
             self._post_write_hook(self.args, self._version_dir, self.rollout_engines)
         dist.barrier(group=get_gloo_group())
         if dist.get_rank() == 0:
+            started = time.perf_counter()
             ray.get([engine.pull_weights.remote(self.weight_version) for engine in self.rollout_engines])
+            pulled = time.perf_counter()
             ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
+            paused = time.perf_counter()
             try:
                 ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
+                flushed = time.perf_counter()
                 ray.get(
                     [
                         engine.update_weights_from_disk.remote(
@@ -238,8 +251,20 @@ class UpdateWeightFromDiskDelta:
                         for engine in self.rollout_engines
                     ]
                 )
+                reloaded = time.perf_counter()
             finally:
                 ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
+            resumed = time.perf_counter()
+            self._stage_metrics.update(
+                {
+                    "perf/update_weights_delta_materialize_time": pulled - started,
+                    "perf/update_weights_delta_pause_time": paused - pulled,
+                    "perf/update_weights_delta_flush_time": flushed - paused,
+                    "perf/update_weights_delta_reload_time": reloaded - flushed,
+                    "perf/update_weights_delta_resume_time": resumed - reloaded,
+                    "perf/update_weights_delta_rollout_time": resumed - started,
+                }
+            )
         dist.barrier(group=get_gloo_group())
 
     def _record_metrics(self) -> None:
@@ -252,6 +277,8 @@ class UpdateWeightFromDiskDelta:
         self.update_weight_metrics["perf/update_weights_density"] = changed / max(total, 1)
         self.update_weight_metrics["perf/update_weights_wire_bytes"] = wire
         if dist.get_rank() == 0:
+            self.update_weight_metrics.update(self._stage_metrics)
+            logger.info("[disk delta timings v=%s] %s", self.weight_version, self._stage_metrics)
             logger.info("[disk delta v=%s] density=%.2f%% wire=%.2f GB", self.weight_version, 100 * changed / max(total, 1), wire / 1e9)
 
 

--- a/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/vime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -16,6 +16,7 @@ from megatron.core import mpu
 from ray.actor import ActorHandle
 
 from vime.utils.common import is_npu
+from vime.utils.function_compat import call_with_optional_keyword
 from vime.utils.distributed_utils import get_gloo_group
 
 from .hf_weight_iterator_base import HfWeightIteratorBase
@@ -349,7 +350,12 @@ class _VLLMHijack:
             self, is_checkpoint_format: bool = True, _orig=_orig_start_weight_update
         ) -> None:
             _VLLMHijack.patch_moe_weight_loader(self.model_runner.model)
-            _orig(self, is_checkpoint_format=is_checkpoint_format)
+            call_with_optional_keyword(
+                _orig,
+                self,
+                keyword="is_checkpoint_format",
+                value=is_checkpoint_format,
+            )
             _VLLMHijack._invalidate_moe_alltoall_expert_ids()
 
         def _patched_wake_up(self, tags=None, _orig=_orig_wake_up) -> None:

--- a/vime/backends/vllm_utils/vllm_engine.py
+++ b/vime/backends/vllm_utils/vllm_engine.py
@@ -951,7 +951,33 @@ class VLLMEngine(RayActor):
         }
         return self._post_vllm_update_weights_http(update_info)
 
-    def update_weights_from_disk(self, model_path: str, load_format: str | None = None):
+    def pull_weights(self, target_version: int):
+        """Materialize a published disk version on every host of this engine."""
+        if self.node_rank != 0:
+            return None
+        response = requests.post(
+            f"{self._http_base()}/collective_rpc",
+            json={
+                "method": "pull_weights",
+                "kwargs": {
+                    "local_checkpoint_dir": self.args.update_weight_local_checkpoint_dir,
+                    "source_dir": self.args.update_weight_disk_dir,
+                    "target_version": target_version,
+                    "pre_read_hook": self.args.custom_update_weight_pre_read_path,
+                },
+            },
+            timeout=600,
+        )
+        result = _response_json(response)
+        self._weight_version = str(target_version)
+        return result
+
+    def update_weights_from_disk(
+        self,
+        model_path: str,
+        load_format: str | None = None,
+        weight_version: str | None = None,
+    ):
         """``POST /collective_rpc`` with ``reload_weights`` and ``weights_path``."""
         if self.node_rank != 0:
             return
@@ -964,7 +990,10 @@ class VLLMEngine(RayActor):
             },
             timeout=600,
         )
-        return _response_json(response)
+        result = _response_json(response)
+        if weight_version is not None:
+            self._weight_version = str(weight_version)
+        return result
 
     def pause_generation(self):
         """``POST /pause`` with mode="keep"; returns the ``requests.Response``."""

--- a/vime/utils/arguments.py
+++ b/vime/utils/arguments.py
@@ -132,6 +132,68 @@ def get_vime_extra_args_provider(add_custom_arguments=None):
                 default=1024**3,
                 help="Add margin for train memory allocation. By default we will reserve 1GB as margin.",
             )
+            parser.add_argument(
+                "--update-weight-mode",
+                choices=["full", "delta"],
+                default="full",
+                help=(
+                    "Weight sync strategy. 'full' keeps the existing accelerator-native "
+                    "HCCL/NPU-IPC path. 'delta' publishes only changed weight bytes "
+                    "through a shared filesystem."
+                ),
+            )
+            parser.add_argument(
+                "--update-weight-transport",
+                choices=["nccl", "disk"],
+                default="nccl",
+                help=(
+                    "Weight sync transport. 'nccl' is retained for CLI compatibility and "
+                    "selects the existing accelerator-native HCCL/NPU-IPC path on Ascend; "
+                    "'disk' is supported only with --update-weight-mode=delta."
+                ),
+            )
+            parser.add_argument(
+                "--update-weight-disk-dir",
+                type=str,
+                default=None,
+                help="Shared filesystem directory where delta weight versions are published.",
+            )
+            parser.add_argument(
+                "--update-weight-local-checkpoint-dir",
+                type=str,
+                default=None,
+                help="Host-local HF checkpoint directory patched in place by rollout workers.",
+            )
+            parser.add_argument(
+                "--update-weight-delta-encoding",
+                choices=["xor", "overwrite"],
+                default="xor",
+                help="Delta encoding: xor (compact) or overwrite (idempotent).",
+            )
+            parser.add_argument(
+                "--update-weight-delta-checksum",
+                choices=["xxh3-128", "blake3", "adler32"],
+                default="xxh3-128",
+                help="Per-tensor checksum algorithm for delta application.",
+            )
+            parser.add_argument(
+                "--custom-update-weight-post-write-path",
+                type=str,
+                default=None,
+                help=(
+                    "Optional trainer-side hook after a delta version is written. Signature: "
+                    "hook(args, version_dir: str, rollout_engines) -> None."
+                ),
+            )
+            parser.add_argument(
+                "--custom-update-weight-pre-read-path",
+                type=str,
+                default=None,
+                help=(
+                    "Optional rollout-host hook before a published version is read. Signature: "
+                    "hook(source_dir: str, target_version: int) -> None."
+                ),
+            )
             try:
                 default_megatron_to_hf_mode = "bridge" if is_npu() else "raw"
             except RuntimeError:
@@ -1687,6 +1749,24 @@ def vime_validate_args(args):
 
     if args.save_interval is not None:
         assert args.save is not None, "'--save' is required when save_interval is set."
+
+    if args.update_weight_mode == "delta":
+        if args.update_weight_transport != "disk":
+            raise ValueError("--update-weight-mode=delta requires --update-weight-transport=disk.")
+        if args.colocate:
+            raise ValueError(
+                "--update-weight-mode=delta is not supported with --colocate; "
+                "colocated NPU IPC already avoids full-model copies."
+            )
+        if not args.update_weight_disk_dir:
+            raise ValueError("--update-weight-mode=delta requires --update-weight-disk-dir.")
+        if not args.update_weight_local_checkpoint_dir:
+            raise ValueError("--update-weight-mode=delta requires --update-weight-local-checkpoint-dir.")
+    elif args.update_weight_transport == "disk":
+        raise ValueError(
+            "--update-weight-transport=disk is currently supported only with "
+            "--update-weight-mode=delta on Ascend."
+        )
 
     assert not (args.kl_coef != 0 and args.kl_loss_coef != 0), "Only one of kl_coef and kl_loss_coef can be set"
 

--- a/vime/utils/arguments.py
+++ b/vime/utils/arguments.py
@@ -149,20 +149,23 @@ def get_vime_extra_args_provider(add_custom_arguments=None):
                 help=(
                     "Weight sync transport. 'nccl' is retained for CLI compatibility and "
                     "selects the existing accelerator-native HCCL/NPU-IPC path on Ascend; "
-                    "'disk' is supported only with --update-weight-mode=delta."
+                    "'disk' publishes either full checkpoints or byte deltas through a shared filesystem."
                 ),
             )
             parser.add_argument(
                 "--update-weight-disk-dir",
                 type=str,
                 default=None,
-                help="Shared filesystem directory where delta weight versions are published.",
+                help="Shared filesystem directory where full or delta weight versions are published.",
             )
             parser.add_argument(
                 "--update-weight-local-checkpoint-dir",
                 type=str,
                 default=None,
-                help="Host-local HF checkpoint directory patched in place by rollout workers.",
+                help=(
+                    "Host-local HF checkpoint directory patched in place by rollout workers. "
+                    "Required for delta disk sync and unused by full disk sync."
+                ),
             )
             parser.add_argument(
                 "--update-weight-delta-encoding",
@@ -1763,10 +1766,10 @@ def vime_validate_args(args):
         if not args.update_weight_local_checkpoint_dir:
             raise ValueError("--update-weight-mode=delta requires --update-weight-local-checkpoint-dir.")
     elif args.update_weight_transport == "disk":
-        raise ValueError(
-            "--update-weight-transport=disk is currently supported only with "
-            "--update-weight-mode=delta on Ascend."
-        )
+        if args.colocate:
+            raise ValueError("--update-weight-mode=full --update-weight-transport=disk is not supported with --colocate.")
+        if not args.update_weight_disk_dir:
+            raise ValueError("full disk weight sync requires --update-weight-disk-dir.")
 
     assert not (args.kl_coef != 0 and args.kl_loss_coef != 0), "Only one of kl_coef and kl_loss_coef can be set"
 

--- a/vime/utils/disk_delta.py
+++ b/vime/utils/disk_delta.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import glob
+import json
+import os
+import struct
+import zlib
+
+import numpy as np
+
+
+NUM_WORKERS = min(32, os.cpu_count() or 8)
+
+
+def overwrite_encode(new: np.ndarray, changed_mask: np.ndarray) -> np.ndarray:
+    """Encode changed byte positions and their replacement values."""
+    positions = np.flatnonzero(changed_mask).astype("<u4")
+    return np.concatenate(
+        [np.array([positions.size], "<u4").view(np.uint8), positions.view(np.uint8), new[changed_mask]]
+    )
+
+
+class _Adler32:
+    def __init__(self) -> None:
+        self._value = 1
+
+    def update(self, data) -> None:
+        self._value = zlib.adler32(data, self._value)
+
+    def hexdigest(self) -> str:
+        return f"{self._value:08x}"
+
+
+def _new_hasher(algorithm: str):
+    if algorithm == "xxh3-128":
+        import xxhash
+
+        return xxhash.xxh3_128()
+    if algorithm == "blake3":
+        import blake3
+
+        return blake3.blake3()
+    if algorithm == "adler32":
+        return _Adler32()
+    raise KeyError(f"Unknown checksum algorithm {algorithm!r}")
+
+
+def checksum(algorithm: str, buffer) -> str:
+    hasher = _new_hasher(algorithm)
+    hasher.update(buffer)
+    return hasher.hexdigest()
+
+
+def _tensor_locations(checkpoint_dir: str) -> dict[str, tuple[str, int, int]]:
+    locations: dict[str, tuple[str, int, int]] = {}
+    for path in glob.glob(os.path.join(checkpoint_dir, "*.safetensors")):
+        with open(path, "rb") as tensor_file:
+            (header_len,) = struct.unpack("<Q", tensor_file.read(8))
+            header = json.loads(tensor_file.read(header_len))
+        for name, info in header.items():
+            if name == "__metadata__":
+                continue
+            begin, end = info["data_offsets"]
+            locations[name] = (path, 8 + header_len + begin, end - begin)
+    return locations
+
+
+def make_tensor_reader(checkpoint_dir: str):
+    """Return a direct byte reader for tensors in a safetensors checkpoint."""
+    locations = _tensor_locations(checkpoint_dir)
+
+    def read(name: str) -> np.ndarray:
+        path, offset, nbytes = locations[name]
+        with open(path, "rb") as tensor_file:
+            tensor_file.seek(offset)
+            return np.frombuffer(tensor_file.read(nbytes), dtype=np.uint8)
+
+    return read

--- a/vime/utils/function_compat.py
+++ b/vime/utils/function_compat.py
@@ -1,0 +1,12 @@
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+
+def call_with_optional_keyword(
+    func: Callable[..., Any], *args: Any, keyword: str, value: Any
+) -> Any:
+    """Call ``func`` with a keyword only when its installed version supports it."""
+    if keyword in inspect.signature(func).parameters:
+        return func(*args, **{keyword: value})
+    return func(*args)


### PR DESCRIPTION
## Summary

- add `full + disk` weight synchronization for non-colocated rollout engines
- publish versioned HF Safetensors checkpoints to shared storage
- reload vLLM engines through the existing collective `reload_weights` RPC
- add 4B and 30B reproducible disk full/delta benchmark coverage

## Validation

- argument validation covers `--update-weight-mode full --update-weight-transport disk`
- Qwen3-4B benchmark: full disk steady mean 5.4s
- Qwen3-30B-A3B benchmark: full disk steady mean 56.6s

## Notes

This PR is based on `validated-delta`, so it currently includes those prerequisite commits in the diff.