### PR TITLE
[CI] Allow testing candidate Vime images

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -17,9 +17,9 @@ The four test steps depend on the pre-commit gate. Each suite runs its files
 sequentially inside one step because these queues boot a fresh EC2 instance
 per job — a per-file matrix would be mostly boot + pip-install time.
 Most always-on CPU steps use the standard `python:3.11` image and install their
-lightweight dependencies at runtime. `upstream-sync-cpu` uses
-`vllm/vime:latest` because the synchronized GLM and checkpoint tests import the
-image-pinned Megatron stack even though they do not allocate a GPU.
+lightweight dependencies at runtime. `upstream-sync-cpu` uses `VIME_CI_IMAGE`
+(defaulting to `vllm/vime:latest`) because the synchronized GLM and checkpoint
+tests import the image-pinned Megatron stack even though they do not allocate a GPU.
 
 ## Creating the pipeline (one-time, Buildkite UI)
 
@@ -70,8 +70,8 @@ startup, so a warm HF cache is all they need. `WANDB_API_KEY` is not wired up
 yet; runs report without wandb until it's added (e.g. as a k8s secret in the
 pod spec).
 
-GPU jobs use `vllm/vime:latest`. Rebuild and publish that image before validating
-Dockerfile or vLLM patch changes.
+Set `VIME_CI_IMAGE` to an immutable candidate digest for image-backed jobs;
+otherwise they use `vllm/vime:latest`. Do not update `latest` before merge.
 
 ## Keeping it in sync
 

--- a/.buildkite/gpu_suites.py
+++ b/.buildkite/gpu_suites.py
@@ -23,7 +23,7 @@ import os
 import subprocess
 
 GPU_QUEUE = "mithril-h100-pool"
-CI_IMAGE = "vllm/vime:latest"
+CI_IMAGE = os.environ.get("VIME_CI_IMAGE", "vllm/vime:latest")
 HF_CACHE_HOST_PATH = "/mnt/hf-cache"
 HF_HOME = "/root/.cache/huggingface"
 NODE_INSTANCE_TYPE = "gpu-h100-sxm"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -140,7 +140,7 @@ steps:
         -e GIT_CONFIG_PARAMETERS="'safe.directory=/workspace'" \
         -e GLOO_SOCKET_IFNAME=lo -e TP_SOCKET_IFNAME=lo \
         -v "$$PWD:/workspace" -w /workspace \
-        vllm/vime:latest bash -lc '
+        "$${VIME_CI_IMAGE:-vllm/vime:latest}" bash -lc '
           set -euo pipefail
           pip install -q -e . --no-deps --break-system-packages
           for test_file in \

--- a/docs/en/developer_guide/ci.md
+++ b/docs/en/developer_guide/ci.md
@@ -31,8 +31,9 @@ After the CPU steps pass, the Buildkite build exposes a block step named
 - `ckpt`
 
 `.buildkite/gpu_suites.py` expands each selected suite into one Buildkite job
-per test. GPU tests use `vllm/vime:latest`; rebuild and publish that image
-before validating a Dockerfile or vLLM patch change.
+per test. Set `VIME_CI_IMAGE` to an immutable candidate digest when validating
+Dockerfile or vLLM patch changes. Jobs otherwise use `vllm/vime:latest`, which
+must not be updated before the change merges.
 
 ## Registering tests
 

--- a/docs/zh/developer_guide/ci.md
+++ b/docs/zh/developer_guide/ci.md
@@ -30,8 +30,8 @@ block step。可以选择一个或多个套件：
 - `ckpt`
 
 `.buildkite/gpu_suites.py` 会把所选套件展开为每个测试一个 Buildkite
-job。GPU 测试使用 `vllm/vime:latest`；验证 Dockerfile 或 vLLM patch 修改前，
-需要先重建并发布该镜像。
+job。验证 Dockerfile 或 vLLM patch 修改时，通过 `VIME_CI_IMAGE` 指定不可变的
+候选镜像 digest；未设置时使用 `vllm/vime:latest`，且 PR 合入前不得更新该标签。
 
 ## 注册测试
 


### PR DESCRIPTION
## Motivation

Image-changing PRs must be tested without publishing unmerged code to `vllm/vime:latest`.

## Changes

- Add one `VIME_CI_IMAGE` override shared by the static image-backed CPU job and generated GPU jobs.
- Preserve `vllm/vime:latest` as the default.
- Document candidate-tag/digest usage in the Buildkite guides.

## Validation

- Targeted pre-commit: passed.
- Default image resolution: `vllm/vime:latest`.
- Explicit immutable candidate digest resolution: passed.

This is a Vime-native CI change split out of #410; it does not change Slime-synchronized runtime behavior.